### PR TITLE
MethodCallInsecureFileCreation isSource

### DIFF
--- a/java/ql/lib/semmle/code/java/security/TempDirLocalInformationDisclosureQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TempDirLocalInformationDisclosureQuery.qll
@@ -212,6 +212,9 @@ abstract class MethodCallInsecureFileCreation extends MethodCall {
    * Gets the dataflow node representing the file system entity created.
    */
   DataFlow::Node getNode() { result.asExpr() = this }
+
+  /** Holds if this node is a source. */
+  predicate isSource() { any() }
 }
 
 /** DEPRECATED: Alias for `MethodCallInsecureFileCreation`. */


### PR DESCRIPTION
Adds isSource to the PathNode class in MethodCallInsecureFileCreation which is a single-step PathNode.