### PR TITLE
C++: Suggestions to #15343

### DIFF
--- a/cpp/ql/src/Critical/DoubleFree.ql
+++ b/cpp/ql/src/Critical/DoubleFree.ql
@@ -13,7 +13,6 @@
 
 import cpp
 import semmle.code.cpp.dataflow.new.DataFlow
-import semmle.code.cpp.ir.IR
 import FlowAfterFree
 import DoubleFree::PathGraph
 
@@ -42,28 +41,21 @@ predicate isExcludeFreePair(DeallocationExpr dealloc1, Expr e) {
   )
 }
 
-module DoubleFree = FlowFromFree<isFree/2, isExcludeFreePair/2>;
+module DoubleFreeParam implements FlowFromFreeParamSig {
+  predicate isSink = isFree/2;
 
-/*
- * In order to reduce false positives, the set of sinks is restricted to only those
- * that satisfy at least one of the following two criteria:
- * 1. The source dominates the sink, or
- * 2. The sink post-dominates the source.
- */
+  predicate isExcluded = isExcludeFreePair/2;
 
-from
-  DoubleFree::PathNode source, DoubleFree::PathNode sink, DeallocationExpr dealloc, Expr e2,
-  DataFlow::Node srcNode, DataFlow::Node sinkNode
+  predicate sourceSinkIsRelated = defaultSourceSinkIsRelated/2;
+}
+
+module DoubleFree = FlowFromFree<DoubleFreeParam>;
+
+from DoubleFree::PathNode source, DoubleFree::PathNode sink, DeallocationExpr dealloc, Expr e2
 where
   DoubleFree::flowPath(source, sink) and
-  source.getNode() = srcNode and
-  sink.getNode() = sinkNode and
-  isFree(srcNode, _, _, dealloc) and
-  isFree(sinkNode, e2) and
-  (
-    sinkStrictlyPostDominatesSource(srcNode, sinkNode) or
-    sourceStrictlyDominatesSink(srcNode, sinkNode)
-  )
-select sinkNode, source, sink,
+  isFree(source.getNode(), _, _, dealloc) and
+  isFree(sink.getNode(), e2)
+select sink.getNode(), source, sink,
   "Memory pointed to by '" + e2.toString() + "' may already have been freed by $@.", dealloc,
   dealloc.toString()

--- a/cpp/ql/src/Critical/FlowAfterFree.qll
+++ b/cpp/ql/src/Critical/FlowAfterFree.qll
@@ -3,20 +3,6 @@ import semmle.code.cpp.dataflow.new.DataFlow
 private import semmle.code.cpp.ir.IR
 
 /**
- * Signature for a predicate that holds if `n.asExpr() = e` and `n` is a sink in
- * the `FlowFromFreeConfig` module.
- */
-private signature predicate isSinkSig(DataFlow::Node n, Expr e);
-
-/**
- * Holds if `dealloc` is a deallocation expression and `e` is an expression such
- * that `isFree(_, e)` holds for some `isFree` predicate satisfying `isSinkSig`,
- * and this source-sink pair should be excluded from the analysis.
- */
-bindingset[dealloc, e]
-private signature predicate isExcludedSig(DeallocationExpr dealloc, Expr e);
-
-/**
  * Holds if `(b1, i1)` strictly post-dominates `(b2, i2)`
  */
 bindingset[i1, i2]
@@ -38,27 +24,32 @@ predicate strictlyDominates(IRBlock b1, int i1, IRBlock b2, int i2) {
   b1.strictlyDominates(b2)
 }
 
-predicate sinkStrictlyPostDominatesSource(DataFlow::Node source, DataFlow::Node sink) {
-  exists(IRBlock b1, int i1, IRBlock b2, int i2 |
-    source.hasIndexInBlock(b1, i1) and
-    sink.hasIndexInBlock(b2, i2) and
-    strictlyPostDominates(b2, i2, b1, i1)
-  )
-}
+signature module FlowFromFreeParamSig {
+  /**
+   * Signature for a predicate that holds if `n.asExpr() = e` and `n` is a sink in
+   * the `FlowFromFreeConfig` module.
+   */
+  predicate isSink(DataFlow::Node n, Expr e);
 
-predicate sourceStrictlyDominatesSink(DataFlow::Node source, DataFlow::Node sink) {
-  exists(IRBlock b1, int i1, IRBlock b2, int i2 |
-    source.hasIndexInBlock(b1, i1) and
-    sink.hasIndexInBlock(b2, i2) and
-    strictlyDominates(b1, i1, b2, i2)
-  )
+  /**
+   * Holds if `dealloc` is a deallocation expression and `e` is an expression such
+   * that `isFree(_, e)` holds for some `isFree` predicate satisfying `isSinkSig`,
+   * and this source-sink pair should be excluded from the analysis.
+   */
+  bindingset[dealloc, e]
+  predicate isExcluded(DeallocationExpr dealloc, Expr e);
 }
 
 /**
  * Constructs a `FlowFromFreeConfig` module that can be used to find flow between
  * a pointer being freed by some deallocation function, and a user-specified sink.
+ *
+ * In order to reduce false positives, the set of sinks is restricted to only those
+ * that satisfy at least one of the following two criteria:
+ * 1. The source dominates the sink, or
+ * 2. The sink post-dominates the source.
  */
-module FlowFromFree<isSinkSig/2 isASink, isExcludedSig/2 isExcluded> {
+module FlowFromFree<FlowFromFreeParamSig P> {
   module FlowFromFreeConfig implements DataFlow::StateConfigSig {
     class FlowState instanceof Expr {
       FlowState() { isFree(_, _, this, _) }
@@ -70,11 +61,20 @@ module FlowFromFree<isSinkSig/2 isASink, isExcludedSig/2 isExcluded> {
 
     pragma[inline]
     predicate isSink(DataFlow::Node sink, FlowState state) {
-      exists(Expr e, DeallocationExpr dealloc |
-        isASink(sink, e) and
-        isFree(_, _, state, dealloc) and
+      exists(
+        Expr e, DataFlow::Node source, DeallocationExpr dealloc, IRBlock b1, int i1, IRBlock b2,
+        int i2
+      |
+        P::isSink(sink, e) and
+        isFree(source, _, state, dealloc) and
         e != state and
-        not isExcluded(dealloc, e)
+        not P::isExcluded(dealloc, e) and
+        source.hasIndexInBlock(b1, i1) and
+        sink.hasIndexInBlock(b2, i2)
+      |
+        strictlyDominates(b1, i1, b2, i2)
+        or
+        strictlyPostDominates(b2, i2, b1, i1)
       )
     }
 

--- a/cpp/ql/src/Critical/UseAfterFree.ql
+++ b/cpp/ql/src/Critical/UseAfterFree.ql
@@ -173,26 +173,19 @@ predicate isExcludeFreeUsePair(DeallocationExpr dealloc1, Expr e) {
   isExFreePoolCall(_, e)
 }
 
-module UseAfterFree = FlowFromFree<isUse/2, isExcludeFreeUsePair/2>;
+module UseAfterFreeParam implements FlowFromFreeParamSig {
+  predicate isSink = isUse/2;
 
-/*
- * In order to reduce false positives, the set of sinks is restricted to only those
- * that satisfy at least one of the following two criteria:
- * 1. The source dominates the sink, or
- * 2. The sink post-dominates the source.
- */
+  predicate isExcluded = isExcludeFreeUsePair/2;
 
-from
-  UseAfterFree::PathNode source, UseAfterFree::PathNode sink, DeallocationExpr dealloc,
-  DataFlow::Node srcNode, DataFlow::Node sinkNode
+  predicate sourceSinkIsRelated = defaultSourceSinkIsRelated/2;
+}
+
+module UseAfterFree = FlowFromFree<UseAfterFreeParam>;
+
+from UseAfterFree::PathNode source, UseAfterFree::PathNode sink, DeallocationExpr dealloc
 where
   UseAfterFree::flowPath(source, sink) and
-  source.getNode() = srcNode and
-  sink.getNode() = sinkNode and
-  isFree(srcNode, _, _, dealloc) and
-  (
-    sinkStrictlyPostDominatesSource(srcNode, sinkNode) or
-    sourceStrictlyDominatesSink(srcNode, sinkNode)
-  )
-select sinkNode, source, sink, "Memory may have been previously freed by $@.", dealloc,
+  isFree(source.getNode(), _, _, dealloc)
+select sink.getNode(), source, sink, "Memory may have been previously freed by $@.", dealloc,
   dealloc.toString()

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/DoubleFree.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/DoubleFree.expected
@@ -2,7 +2,6 @@ edges
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:14:10:14:10 | a |
 | test_free.cpp:30:10:30:10 | pointer to free output argument | test_free.cpp:31:27:31:27 | a |
 | test_free.cpp:35:10:35:10 | pointer to free output argument | test_free.cpp:37:27:37:27 | a |
-| test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:44:27:44:27 | a |
 | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:46:10:46:10 | a |
 | test_free.cpp:44:27:44:27 | pointer to free output argument | test_free.cpp:46:10:46:10 | a |
 | test_free.cpp:50:27:50:27 | pointer to free output argument | test_free.cpp:51:10:51:10 | a |
@@ -20,7 +19,6 @@ nodes
 | test_free.cpp:35:10:35:10 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:37:27:37:27 | a | semmle.label | a |
 | test_free.cpp:42:27:42:27 | pointer to free output argument | semmle.label | pointer to free output argument |
-| test_free.cpp:44:27:44:27 | a | semmle.label | a |
 | test_free.cpp:44:27:44:27 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:46:10:46:10 | a | semmle.label | a |
 | test_free.cpp:46:10:46:10 | a | semmle.label | a |

--- a/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
+++ b/cpp/ql/test/query-tests/Critical/MemoryFreed/UseAfterFree.expected
@@ -1,7 +1,6 @@
 edges
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:12:5:12:5 | a |
 | test_free.cpp:11:10:11:10 | pointer to free output argument | test_free.cpp:13:5:13:6 | * ... |
-| test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:43:22:43:22 | a |
 | test_free.cpp:42:27:42:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a |
 | test_free.cpp:44:27:44:27 | pointer to free output argument | test_free.cpp:45:5:45:5 | a |
 | test_free.cpp:69:10:69:10 | pointer to free output argument | test_free.cpp:71:9:71:9 | a |
@@ -28,7 +27,6 @@ nodes
 | test_free.cpp:12:5:12:5 | a | semmle.label | a |
 | test_free.cpp:13:5:13:6 | * ... | semmle.label | * ... |
 | test_free.cpp:42:27:42:27 | pointer to free output argument | semmle.label | pointer to free output argument |
-| test_free.cpp:43:22:43:22 | a | semmle.label | a |
 | test_free.cpp:44:27:44:27 | pointer to free output argument | semmle.label | pointer to free output argument |
 | test_free.cpp:45:5:45:5 | a | semmle.label | a |
 | test_free.cpp:45:5:45:5 | a | semmle.label | a |


### PR DESCRIPTION
@bdrodes these are my suggestions to https://github.com/github/codeql/pull/15343.

Commit-by-commit review recommended - especially if you're not yet comfortable with parameterized modules!

- The first commit does a straightforward refactoring of the interface of `FlowFromFree`: instead of passing two predicates as parameters to the module I wrap the "input predicates" into a module signature and change the `FlowFromFree` module to take such an "input module" as a parameter.
- The next commit is really the meat of my suggestion: it adds a new predicate to the "input module" that represents additional requirements on the relationship between the source and the sink. In particular, for the github/codeql queries this can be the dominance/post-domination relationship, and for microsoft/codeql this defaults to `any()` meaning that no additional relationship is required.
- The next commit makes `cpp/use-after-free` and `cpp/double-free` conform to this new interface.
- The final commit accepts the test changes. This basically undoes the changes you saw in https://github.com/github/codeql/pull/15343.

The change I'm proposing here _should_ mean that there are no performance changes compared to what's running currently in Code Scanning 🤞. But obviously we need to run DCA on this to confirm