### PR TITLE
Jb1/improper array index

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
@@ -68,7 +68,7 @@ predicate predictableInstruction(Instruction instr) {
 module ImproperArrayIndexValidationConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     isFlowSource(source, _) and
-    not source.asExpr().getFile().getRelativePath().regexpMatch("/tests?/")
+    not source.getLocation().getFile().getRelativePath().regexpMatch("(.*/)?tests?/.*")
   }
 
   predicate isBarrier(DataFlow::Node node) {

--- a/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
@@ -116,10 +116,15 @@ module ImproperArrayIndexValidationConfig implements DataFlow::ConfigSig {
 
 module ImproperArrayIndexValidation = TaintTracking::Global<ImproperArrayIndexValidationConfig>;
 
+predicate isInTestFile(ImproperArrayIndexValidation::PathNode node){
+  node.getNode().asExpr().getFile().getRelativePath().regexpMatch("/tests?/")
+}
+
 from
   ImproperArrayIndexValidation::PathNode source, ImproperArrayIndexValidation::PathNode sink,
   string sourceType
 where
+  not isInTestFile(source) and
   ImproperArrayIndexValidation::flowPath(source, sink) and
   isFlowSource(source.getNode(), sourceType)
 select sink.getNode(), source, sink,

--- a/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
@@ -66,7 +66,10 @@ predicate predictableInstruction(Instruction instr) {
 }
 
 module ImproperArrayIndexValidationConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { isFlowSource(source, _) }
+  predicate isSource(DataFlow::Node source) {
+    isFlowSource(source, _) and
+    not source.asExpr().getFile().getRelativePath().regexpMatch("/tests?/")
+  }
 
   predicate isBarrier(DataFlow::Node node) {
     hasUpperBound(node.asExpr())
@@ -116,15 +119,11 @@ module ImproperArrayIndexValidationConfig implements DataFlow::ConfigSig {
 
 module ImproperArrayIndexValidation = TaintTracking::Global<ImproperArrayIndexValidationConfig>;
 
-predicate isInTestFile(ImproperArrayIndexValidation::PathNode node){
-  node.getNode().asExpr().getFile().getRelativePath().regexpMatch("/tests?/")
-}
-
 from
-  ImproperArrayIndexValidation::PathNode source, ImproperArrayIndexValidation::PathNode sink,
+  ImproperArrayIndexValidation::PathNode source,
+  ImproperArrayIndexValidation::PathNode sink,
   string sourceType
 where
-  not isInTestFile(source) and
   ImproperArrayIndexValidation::flowPath(source, sink) and
   isFlowSource(source.getNode(), sourceType)
 select sink.getNode(), source, sink,


### PR DESCRIPTION
**Query**
cpp/unclear-array-index-validation

**Description**
Filter out DataFlow nodes which occur in `~/\/tests?\//` directories.