### PR TITLE
DFS CPP + Java Compile Error patch

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/DataFlowStack.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/DataFlowStack.qll
@@ -1,9 +1,10 @@
 
+import csharp
 private import codeql.dataflow.DataFlow
 private import semmle.code.csharp.dataflow.internal.DataFlowImplSpecific
 
 private import codeql.dataflowstack.DataFlowStack as DFS
-private import DFS::DataFlowStackMake<CsharpDataFlow> as DataFlowStackFactory
+private import DFS::DataFlowStackMake<Location, CsharpDataFlow> as DataFlowStackFactory
 
 module DataFlowStackMake<DataFlowStackFactory::DataFlow::GlobalFlowSig Flow>{
     import DataFlowStackFactory::FlowStack<Flow>

--- a/java/ql/lib/semmle/code/java/dataflow/DataFlowStack.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/DataFlowStack.qll
@@ -1,8 +1,9 @@
+import java
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.internal.DataFlowImplSpecific
 
 private import codeql.dataflowstack.DataFlowStack as DFS
-private import DFS::DataFlowStackMake<JavaDataFlow> as DataFlowStackFactory
+private import DFS::DataFlowStackMake<Location, JavaDataFlow> as DataFlowStackFactory
 
 module DataFlowStackMake<DataFlowStackFactory::DataFlow::GlobalFlowSig Flow>{
     import DataFlowStackFactory::FlowStack<Flow>

--- a/shared/dataflowstack/codeql/dataflowstack/DataFlowStack.qll
+++ b/shared/dataflowstack/codeql/dataflowstack/DataFlowStack.qll
@@ -1,9 +1,10 @@
 
 private import codeql.dataflow.DataFlow as DF
+private import codeql.util.Location
 
-module DataFlowStackMake<DF::InputSig Lang>{
+module DataFlowStackMake<LocationSig Location, DF::InputSig<Location> Lang>{
 
-    import DF::DataFlowMake<Lang> as DataFlow
+    import DF::DataFlowMake<Location,Lang> as DataFlow
 
     module BiStackAnalysis<DataFlow::GlobalFlowSig FlowA, DataFlow::GlobalFlowSig FlowB>{
 

--- a/shared/dataflowstack/qlpack.yml
+++ b/shared/dataflowstack/qlpack.yml
@@ -4,4 +4,5 @@ groups: shared
 library: true
 dependencies:
   codeql/dataflow: ${workspace}
+  codeql/util: ${workspace}
 warnOnImplicitThis: true


### PR DESCRIPTION
Fills in missing type parameter introduced into the common DataFlow library for DataFlowStack