### PR TITLE
Update to insecure sql connection to check for version

### DIFF
--- a/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
+++ b/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
@@ -10,68 +10,64 @@
  *       external/cwe/cwe-327
  */
 
- import csharp
- import InsecureSqlConnection::PathGraph
- 
- class Source extends DataFlow::Node{
-   string sourcestring;
-   Source(){
-     sourcestring = this.asExpr().(StringLiteral).getValue().toLowerCase() and 
-     (
-       not sourcestring.matches("%encrypt=%") or 
-       sourcestring.matches("%encrypt=false%")
-     )
-   }
-   predicate setsEncryptFalse(){
-     sourcestring.matches("%encrypt=false%")
-   } 
- }
- 
- class Sink extends DataFlow::Node {
-   Version version; 
-   Sink(){
-     exists(ObjectCreation oc |
-       oc.getRuntimeArgument(0) = this.asExpr() and
-       (
-         oc.getType().getName() = "SqlConnectionStringBuilder"
-         or
-         oc.getType().getName() = "SqlConnection"
-       ) and 
-       version = oc.getType().getALocation().(Assembly).getVersion()
-     )
-   }
-   predicate isEncryptedByDefault(){
-     version.compareTo("4.0") >= 0
-   }
- }
- 
- predicate isEncryptTrue(Source source, Sink sink){
-   sink.isEncryptedByDefault() and 
-   not source.setsEncryptFalse()
- }
- 
- /**
-  * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
-  */
- module InsecureSqlConnectionConfig implements DataFlow::ConfigSig {
-   predicate isSource(DataFlow::Node source) {
-     source instanceof Source
-   }
- 
-   predicate isSink(DataFlow::Node sink) {
-     sink instanceof Sink
-   }
- }
- 
- /**
-  * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
-  */
- module InsecureSqlConnection = DataFlow::Global<InsecureSqlConnectionConfig>;
- 
- from InsecureSqlConnection::PathNode source, InsecureSqlConnection::PathNode sink
- where InsecureSqlConnection::flowPath(source, sink) and 
- not isEncryptTrue(source.getNode().(Source), sink.getNode().(Sink))
- select sink.getNode(), source, sink,
-   "$@ flows to this SQL connection and does not specify `Encrypt=True`.", source.getNode(),
-   "Connection string"
- 
+import csharp
+import InsecureSqlConnection::PathGraph
+
+class Source extends DataFlow::Node {
+  string sourcestring;
+
+  Source() {
+    sourcestring = this.asExpr().(StringLiteral).getValue().toLowerCase() and
+    (
+      not sourcestring.matches("%encrypt=%") or
+      sourcestring.matches("%encrypt=false%")
+    )
+  }
+
+  predicate setsEncryptFalse() { sourcestring.matches("%encrypt=false%") }
+}
+
+class Sink extends DataFlow::Node {
+  Version version;
+
+  Sink() {
+    exists(ObjectCreation oc |
+      oc.getRuntimeArgument(0) = this.asExpr() and
+      (
+        oc.getType().getName() = "SqlConnectionStringBuilder"
+        or
+        oc.getType().getName() = "SqlConnection"
+      ) and
+      version = oc.getType().getALocation().(Assembly).getVersion()
+    )
+  }
+
+  predicate isEncryptedByDefault() { version.compareTo("4.0") >= 0 }
+}
+
+predicate isEncryptTrue(Source source, Sink sink) {
+  sink.isEncryptedByDefault() and
+  not source.setsEncryptFalse()
+}
+
+/**
+ * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
+ */
+module InsecureSqlConnectionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+}
+
+/**
+ * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
+ */
+module InsecureSqlConnection = DataFlow::Global<InsecureSqlConnectionConfig>;
+
+from InsecureSqlConnection::PathNode source, InsecureSqlConnection::PathNode sink
+where
+  InsecureSqlConnection::flowPath(source, sink) and
+  not isEncryptTrue(source.getNode().(Source), sink.getNode().(Sink))
+select sink.getNode(), source, sink,
+  "$@ flows to this SQL connection and does not specify `Encrypt=True`.", source.getNode(),
+  "Connection string"

--- a/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
+++ b/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
@@ -10,45 +10,71 @@
  *       external/cwe/cwe-327
  */
 
-import csharp
-import InsecureSqlConnection::PathGraph
-
-/**
- * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
- */
-module InsecureSqlConnectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) {
-    exists(string s | s = source.asExpr().(StringLiteral).getValue().toLowerCase() |
-      s.matches("%encrypt=false%")
-      or
-      not s.matches("%encrypt=%")
-    )
-  }
-
-  predicate isSink(DataFlow::Node sink) {
-    exists(ObjectCreation oc |
-      oc.getRuntimeArgument(0) = sink.asExpr() and
-      (
-        oc.getType().getName() = "SqlConnectionStringBuilder"
-        or
-        oc.getType().getName() = "SqlConnection"
-      ) and
-      not exists(MemberInitializer mi |
-        mi = oc.getInitializer().(ObjectInitializer).getAMemberInitializer() and
-        mi.getLValue().(PropertyAccess).getTarget().getName() = "Encrypt" and
-        mi.getRValue().(BoolLiteral).getValue() = "true"
-      )
-    )
-  }
-}
-
-/**
- * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
- */
-module InsecureSqlConnection = DataFlow::Global<InsecureSqlConnectionConfig>;
-
-from InsecureSqlConnection::PathNode source, InsecureSqlConnection::PathNode sink
-where InsecureSqlConnection::flowPath(source, sink)
-select sink.getNode(), source, sink,
-  "$@ flows to this SQL connection and does not specify `Encrypt=True`.", source.getNode(),
-  "Connection string"
+ import csharp
+ import InsecureSqlConnection::PathGraph
+ 
+ class Source extends DataFlow::Node{
+   string sourcestring;
+   Source(){
+     sourcestring = this.asExpr().(StringLiteral).getValue().toLowerCase() and 
+     (
+       not sourcestring.matches("%encrypt=%") or 
+       sourcestring.matches("%encrypt=false%")
+     )
+   }
+   predicate setsEncryptFalse(){
+     sourcestring.matches("%encrypt=false%")
+   } 
+ }
+ 
+ class Sink extends DataFlow::Node {
+   Version version; 
+   Sink(){
+     exists(ObjectCreation oc |
+       oc.getRuntimeArgument(0) = this.asExpr() and
+       (
+         oc.getType().getName() = "SqlConnectionStringBuilder"
+         or
+         oc.getType().getName() = "SqlConnection"
+       ) and 
+       version = oc.getType().getALocation().(Assembly).getVersion()
+     )
+   }
+   predicate isEncryptedByDefault(){
+     version.compareTo("4.0") >= 0
+   }
+   Version getVersion(){
+     result = version
+   }
+ }
+ 
+ predicate isEncryptTrue(Source source, Sink sink){
+   sink.isEncryptedByDefault() and 
+   not source.setsEncryptFalse()
+ }
+ 
+ /**
+  * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
+  */
+ module InsecureSqlConnectionConfig implements DataFlow::ConfigSig {
+   predicate isSource(DataFlow::Node source) {
+     source instanceof Source
+   }
+ 
+   predicate isSink(DataFlow::Node sink) {
+     sink instanceof Sink
+   }
+ }
+ 
+ /**
+  * A data flow configuration for tracking strings passed to `SqlConnection[StringBuilder]` instances.
+  */
+ module InsecureSqlConnection = DataFlow::Global<InsecureSqlConnectionConfig>;
+ 
+ from InsecureSqlConnection::PathNode source, InsecureSqlConnection::PathNode sink
+ where InsecureSqlConnection::flowPath(source, sink) and 
+ not isEncryptTrue(source.getNode().(Source), sink.getNode().(Sink))
+ select sink.getNode(), source, sink,
+   "$@ flows to this SQL connection and does not specify `Encrypt=True`.", source.getNode(),
+   "Connection string"
+ 

--- a/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
+++ b/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
@@ -43,9 +43,6 @@
    predicate isEncryptedByDefault(){
      version.compareTo("4.0") >= 0
    }
-   Version getVersion(){
-     result = version
-   }
  }
  
  predicate isEncryptTrue(Source source, Sink sink){


### PR DESCRIPTION
Encrypt is true by default in versions 4.0+ , so if the class is from that version or later, doesn't need to explicitly specify encrypt as true.

https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnectionstringbuilder.encrypt?view=sqlclient-dotnet-standard-5.2