### PR TITLE
PS: Open source the powershell extractor

### DIFF
--- a/powershell/README.md
+++ b/powershell/README.md
@@ -1,0 +1,12 @@
+# Powershell Extractor
+
+## Directories:
+- `extractor`
+  - Powershell extractor source code
+- `ql`
+  - QL libraries and queries for Powershell (to be written)
+- `tools`
+  - Directory containing files that must be copied to powershell/tools in the directory containing the CodeQL CLI. This will be done automatically by `build.ps1` (see below).
+
+## How to build the Powershell:
+- Run `build.ps1 path-to-codeql-cli-folder` where `path-to-codeql-cli-folder` is the path to the folder containing the CodeQL CLI (i.e., `codeql.exe`).

--- a/powershell/build.ps1
+++ b/powershell/build.ps1
@@ -1,0 +1,17 @@
+param (
+    [Parameter(Mandatory=$true)][string]$cliFolder
+)
+
+$toolsWin64Folder = Join-Path (Join-Path (Join-Path $cliFolder "powershell") "tools") "win64"
+dotnet publish (Join-Path "extractor" "powershell.sln") -o $toolsWin64Folder
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Build failed"
+    exit 1
+}
+
+$powershellFolder = Join-Path -Path $cliFolder -ChildPath "powershell"
+Copy-Item -Path codeql-extractor.yml -Destination $powershellFolder -Force
+$qlLibFolder = Join-Path -Path "ql" -ChildPath "lib"
+Copy-Item -Path (Join-Path $qlLibFolder "semmlecode.powershell.dbscheme") -Destination $powershellFolder -Force
+Copy-Item -Path (Join-Path $qlLibFolder "semmlecode.powershell.dbscheme.stats") -Destination $powershellFolder -Force
+Copy-Item -Path "tools" -Destination $powershellFolder -Recurse -Force

--- a/powershell/codeql-extractor.yml
+++ b/powershell/codeql-extractor.yml
@@ -1,0 +1,10 @@
+name: "powershell"
+display_name: "powershell"
+version: 0.0.1
+column_kind: "utf16"
+legacy_qltest_extraction: true
+file_types:
+  - name: powershell
+    display_name: powershellscripts
+    extensions:
+      - .ps1

--- a/powershell/extractor/Microsoft.Extractor.Tests/Microsoft.Extractor.Tests.csproj
+++ b/powershell/extractor/Microsoft.Extractor.Tests/Microsoft.Extractor.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Semmle.Extraction.PowerShell.Standalone\Semmle.Extraction.PowerShell.Standalone.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/powershell/extractor/Microsoft.Extractor.Tests/TrapSanitizer.cs
+++ b/powershell/extractor/Microsoft.Extractor.Tests/TrapSanitizer.cs
@@ -1,0 +1,88 @@
+﻿using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Extraction.Tests;
+
+/// <summary>
+/// This class provides a method for sanitizing a trap files in tests so they can be validated. 
+///     The resulting trap file will not be valid for making a codeqldb due to missing file metadata,
+///     which is removed to ensure the test case can match the expected trap.
+/// </summary>
+internal class TrapSanitizer
+{
+    // Regex to match the IDs in the file (# followed by digits)
+    private static readonly Regex CaptureId = new Regex($"#([0-9]+)");
+
+    /// <summary>
+    /// Sanitize a Trap file to check equality by removing run specific things like file names and squashing ids
+    ///     to a consistent range
+    /// </summary>
+    /// <param name="TrapContents">The lines of the trap file to sanitize</param>
+    /// <returns>A string containing the sanitized contents</returns>
+    public static string SanitizeTrap(string[] TrapContents)
+    {
+        StringBuilder sb = new();
+        int largestId = 0;
+        int startingLineActual = -1;
+        for (int i = 0; i < TrapContents.Length; i++)
+        {
+            // The first line with actual extracted contents will be after the numlines line
+            if (TrapContents[i].StartsWith("numlines"))
+            {
+                startingLineActual = i + 1;
+                break;
+            }
+            // If a line before numlines has an ID it is a candidate for largest id found
+            if (CaptureId.IsMatch(TrapContents[i]))
+            {
+                largestId = int.Max(largestId, int.Parse(CaptureId.Matches(TrapContents[i])[0].Groups[1].Captures[0].Value));
+            }
+        }
+
+        // Starting from the line after numlines declaration
+        for (int i = startingLineActual; i < TrapContents.Length; i++)
+        {
+            // Replace IDs in each line based on the largest previous ID found
+            // Reserve #1 for the File
+            sb.Append(SanitizeLine(TrapContents[i], largestId - 1));
+            sb.Append(Environment.NewLine);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Sanitize a single line of trap content given the largest previously used id number to ignore,
+    ///     subtracting the offset from those IDs.
+    /// </summary>
+    /// <param name="trapContent">A single line of trap content</param>
+    /// <param name="offset">The offset to apply</param>
+    /// <returns>A sanitized line</returns>
+    private static string SanitizeLine(string trapContent, int offset)
+    {
+        var matches = CaptureId.Matches(trapContent);
+        if (!matches.Any())
+        {
+            return trapContent;
+        }
+        var sb = new StringBuilder();
+        int lastIndex = 0;
+        foreach (Match match in matches)
+        {
+            var capture = match.Groups[1].Captures[0];
+            sb.Append(trapContent[lastIndex..capture.Index]);
+            lastIndex = capture.Index + capture.Length;
+            int newInt = int.Parse(capture.Value);
+            if (newInt > 1)
+            {
+                sb.Append(newInt - offset);
+            }
+            else
+            {
+                sb.Append(newInt);
+            }
+        }
+        sb.Append(trapContent[lastIndex..]);
+        return sb.ToString();
+    }
+}

--- a/powershell/extractor/Microsoft.Extractor.Tests/Traps.cs
+++ b/powershell/extractor/Microsoft.Extractor.Tests/Traps.cs
@@ -1,0 +1,212 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.Extraction.Tests;
+using Semmle.Extraction;
+using Semmle.Extraction.PowerShell.Standalone;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using Semmle.Extraction.PowerShell;
+
+namespace Microsoft.Extractor.Tests;
+
+internal static class PathHolder
+{
+    internal static string powershellSource = Path.Join("..", "..", "..", "..", "..", "samples", "code");
+    internal static string expectedTraps = Path.Join("..", "..", "..", "..", "..", "samples", "traps");
+    internal static string schemaPath = Path.Join("..", "..", "..", "..", "..", "config", "semmlecode.powershell.dbscheme");
+    internal static string generatedTraps = Path.Join(".", Path.GetFullPath(powershellSource).Replace(":", "_"));
+}
+public class TrapTestFixture : IDisposable
+{
+    public TrapTestFixture()
+    {
+        // Setup here
+    }
+
+    public void Dispose()
+    {
+        // Delete the generated traps
+        Directory.Delete(PathHolder.generatedTraps, true);
+    }
+}
+
+public class Traps : IClassFixture<TrapTestFixture>
+{
+    private readonly ITestOutputHelper _output;
+    public Traps(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static Regex schemaDeclStart = new("([a-zA-Z_]+)\\(");
+    private static Regex schemaEnd = new("^\\)");
+    private static Regex commentEnd = new("\\*/");
+
+    /// <summary>
+    /// Naiively parse the schema and try to determine how many parameters each table expects
+    /// </summary>
+    /// <param name="schemaContents"></param>
+    /// <returns>Dictionary mapping table name to number of parameters</returns>
+    private static Dictionary<string, int> ParseSchema(string[] schemaContents)
+    {
+        bool isParsingTable = false;
+        int expectedNumEntries = 0;
+        string targetName = string.Empty;
+        Dictionary<string, int> output = new();
+        for (int index = 0; index < schemaContents.Length; index++)
+        {
+            if (!isParsingTable)
+            {
+                if (schemaDeclStart.IsMatch(schemaContents[index]))
+                {
+                    targetName = schemaDeclStart.Matches(schemaContents[index])[0].Groups[1].Captures[0].Value;
+                    isParsingTable = true;
+                    expectedNumEntries = 0;
+                }
+            }
+            else
+            {
+                if (commentEnd.IsMatch(schemaContents[index]))
+                {
+                    isParsingTable = false;
+                    expectedNumEntries = 0;
+                }
+                if (schemaEnd.IsMatch(schemaContents[index]))
+                {
+                    output.Add(targetName, expectedNumEntries);
+                    isParsingTable = false;
+                    expectedNumEntries++;
+                }
+                else
+                {
+                    expectedNumEntries++;
+                }
+            }
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Check that the Schema entries match the implemented methods in Tuples.cs
+    /// </summary>
+    [Fact]
+    public void Schema_Matches_Tuples()
+    {
+        string[] schemaContents = File.ReadLines(PathHolder.schemaPath).ToArray();
+        Dictionary<string, int> expected = ParseSchema(schemaContents);
+        // Get all the nonpublic static methods from the Tuples classes
+        var methods = typeof(Semmle.Extraction.PowerShell.Tuples)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .Union(typeof(Semmle.Extraction.Tuples).GetMethods(BindingFlags.Static | BindingFlags.NonPublic))
+            // Select a tuple of the method, its parameters
+            .Select(method => (method, method.GetParameters(),
+                // the expected number of parameters - one fewer than actual if the first is a TextWriter, and the name of the method
+                method.GetParameters()[0].ParameterType.Name.Equals("TextWriter") ? method.GetParameters().Length - 1 : method.GetParameters().Length , method.Name));
+        List<string> errors = new();
+        List<string> warnings = new();
+        // If a tuple method exists and doesn't have a matching schema entry that is an error, as the produce traps won't be match
+        foreach (var method in methods)
+        {
+            if (expected.Any(entry => method.Name == entry.Key && (method.Item3) == entry.Value))
+            {
+                continue;
+            }
+            errors.Add($"Tuple {method.Name} does not match any schema entry, expected {method.Item3} parameters.");
+        }
+        // If the schema has a superfluous entity that is a warning, as the extractor simply cannot product those things
+        foreach (var entry in expected)
+        {
+            if (methods.Any(method => method.Name == entry.Key && (method.Item3) == entry.Value))
+            {
+                continue;
+            }
+            warnings.Add($"Schema entry {entry.Key} does not match any implemented Tuple, expected {entry.Value} parameters.");
+        }
+
+        foreach (var warning in warnings)
+        {
+            _output.WriteLine($"Warning: {warning}");
+        }
+        foreach (var error in errors)
+        {
+            _output.WriteLine($"Error: {error}");
+        }
+        Assert.Empty(errors);
+    }
+    
+    [Fact]
+    public void Verify_Sample_Traps()
+    {
+        string[] expectedTrapsFiles = Directory.GetFiles(PathHolder.expectedTraps);
+        int numFailures = 0;
+        foreach (string expected in expectedTrapsFiles)
+        {
+            if (File.ReadAllText(expected).Contains("extractor_messages"))
+            {
+                numFailures++;
+                _output.WriteLine($"Expected sample trap {expected} has extractor error messages.");
+            }
+        }
+
+        if (numFailures > 0)
+        {
+            _output.WriteLine($"{numFailures} errors were detected.");
+        }
+        Assert.Equal(0, numFailures);
+    }
+
+
+    [Fact]
+    public void Compare_Generated_Traps()
+    {
+        string[] args = new string[] { PathHolder.powershellSource };
+        int exitcode = Program.Main(args);
+        Assert.Equal(0, exitcode);
+        string[] generatedTrapsFiles = Directory.GetFiles(PathHolder.generatedTraps);
+        string[] expectedTrapsFiles = Directory.GetFiles(PathHolder.expectedTraps);
+
+        Assert.NotEmpty(generatedTrapsFiles);
+        int numFailures = 0;
+        var generatedFileNames = generatedTrapsFiles.Select(x => (Path.GetFileName(x), x)).ToList();
+        var expectedFileNames = expectedTrapsFiles.Select(x => (Path.GetFileName(x), x)).ToList();
+        foreach (var expectedTrapFile in expectedFileNames)
+        {
+            if (generatedFileNames.Any(x => x.Item1 == expectedTrapFile.Item1)) continue;
+            numFailures++;
+            _output.WriteLine($"{expectedTrapFile} has no matching filename in generated.");
+        }
+        foreach (var generated in generatedFileNames)
+        {
+            var expected = expectedFileNames.FirstOrDefault(filePath => filePath.Item1.Equals(generated.Item1));
+            if (expected.Item1 is null || expected.x is null)
+            {
+                numFailures++;
+                _output.WriteLine($"{generated.Item1} has no matching filename in expected.");
+            }
+            else
+            {
+                if (File.ReadAllText(generated.x).Contains("extractor_messages"))
+                {
+                    _output.WriteLine($"Test generated trap {generated} has extractor error messages.");
+                    numFailures++;
+                    continue;
+                }
+                string generatedFileSanitized = TrapSanitizer.SanitizeTrap(File.ReadAllLines(generated.x));
+                string expectedFileSanitized = TrapSanitizer.SanitizeTrap(File.ReadAllLines(expected.x));
+                if (!generatedFileSanitized.Equals(expectedFileSanitized))
+                {
+                    numFailures++;
+                    _output.WriteLine($"{generated} does not match {expected}");
+                }
+            }
+        }
+
+        if (numFailures > 0)
+        {
+            _output.WriteLine($"{numFailures} errors were detected.");
+        }
+        Assert.Equal(expectedTrapsFiles.Length, generatedTrapsFiles.Length);
+        Assert.Equal(0, numFailures);
+    }
+}

--- a/powershell/extractor/Microsoft.Extractor.Tests/Usings.cs
+++ b/powershell/extractor/Microsoft.Extractor.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
@@ -1,0 +1,133 @@
+using Semmle.Util.Logging;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Semmle.Util;
+
+namespace Semmle.Extraction.PowerShell.Standalone
+{
+    /// <summary>
+    /// The options controlling standalone extraction.
+    /// </summary>
+    public sealed class Options : CommonOptions
+    {
+        public override bool HandleFlag(string key, bool value)
+        {
+            switch (key)
+            {
+                case "silent":
+                    Verbosity = value ? Verbosity.Off : Verbosity.Info;
+                    return true;
+                case "help":
+                    Help = true;
+                    return true;
+                case "dry-run":
+                    SkipExtraction = value;
+                    return true;
+                default:
+                    return base.HandleFlag(key, value);
+            }
+        }
+
+        public override bool HandleOption(string key, string value)
+        {
+            switch (key)
+            {
+                case "exclude":
+                    Excludes.Add(value);
+                    return true;
+                default:
+                    return base.HandleOption(key, value);
+            }
+        }
+
+        public override bool HandleArgument(string arg)
+        {
+            SrcDir = arg;
+            if (!new FileInfo(SrcDir).Exists)
+            {
+                var di = new DirectoryInfo(SrcDir);
+                if (!di.Exists)
+                {
+                    System.Console.WriteLine("Error: The file or directory {0} does not exist", di.FullName);
+                    Errors = true;
+                }
+            }
+            return true;
+        }
+
+        public override void InvalidArgument(string argument)
+        {
+            System.Console.WriteLine($"Error: Invalid argument {argument}");
+            Errors = true;
+        }
+
+        /// <summary>
+        /// List of extensions to include.
+        /// </summary>
+        public IList<string> Extensions { get; } = new List<string>() { ".ps1" };
+
+        /// <summary>
+        /// Files/patterns to exclude.
+        /// </summary>
+        public IList<string> Excludes { get; } = new List<string>() { "node_modules", "bower_components" };
+
+        /// <summary>
+        /// The directory or file containing the source code;
+        /// </summary>
+        public string SrcDir { get; set; } = Directory.GetCurrentDirectory();
+
+        /// <summary>
+        /// Whether the extraction phase should be skipped (dry-run).
+        /// </summary>
+        public bool SkipExtraction { get; private set; } = false;
+
+        /// <summary>
+        /// Whether errors were encountered parsing the arguments.
+        /// </summary>
+        public bool Errors { get; private set; } = false;
+
+        /// <summary>
+        /// Whether to show help.
+        /// </summary>
+        public bool Help { get; private set; } = false;
+
+        public string OutDir { get; set; } = Directory.GetCurrentDirectory();
+
+        /// <summary>
+        /// Determine whether the given path should be excluded.
+        /// </summary>
+        /// <param name="path">The path to query.</param>
+        /// <returns>True iff the path matches an exclusion.</returns>
+        public bool ExcludesFile(string path)
+        {
+            return Excludes.Any(ex => path.Contains(ex));
+        }
+
+        /// <summary>
+        /// Outputs the command line options to the console.
+        /// </summary>
+        public static void ShowHelp(System.IO.TextWriter output)
+        {
+            output.WriteLine("PowerShell# standalone extractor\n\nExtracts PowerShell scripts in the current directory.\n");
+            output.WriteLine("Additional options:\n");
+            output.WriteLine("    <path>           Use the provided path instead.");
+            output.WriteLine("    --exclude:xxx    Exclude a file or directory (can be specified multiple times)");
+            output.WriteLine("    --dry-run        Stop before extraction");
+            output.WriteLine("    --threads:nnn    Specify number of threads (default=CPU cores)");
+            output.WriteLine("    --verbose        Produce more output");
+
+        }
+
+        private Options()
+        {
+        }
+
+        public static Options Create(string[] args)
+        {
+            var options = new Options();
+            options.ParseArguments(args);
+            return options;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Program.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Program.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using Semmle.Util.Logging;
+using System.IO;
+using System.Linq;
+using Semmle.Extraction.PowerShell;
+
+namespace Semmle.Extraction.PowerShell.Standalone
+{
+
+    /// <summary>
+    ///     One independent run of the extractor.
+    /// </summary>
+    internal class Extraction
+    {
+        public Extraction(string directory)
+        {
+            Directory = directory;
+        }
+
+        public string Directory { get; }
+        public List<string> Sources { get; } = new List<string>();
+    };
+
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            PowerShell.Extractor.Extractor.SetInvariantCulture();
+
+            var options = Options.Create(args);
+            using var output = new ConsoleLogger(options.Verbosity);
+
+            if (options.Help)
+            {
+                Options.ShowHelp(System.Console.Out);
+                return 0;
+            }
+
+            if (options.Errors)
+                // Something went wrong
+                // https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/exit-codes
+                return 2;
+
+            var start = DateTime.Now;
+
+            output.Log(Severity.Info, "Running PowerShell standalone extractor");
+            var di = new DirectoryInfo(options.SrcDir);
+            var sourceFiles = di.GetFiles("*.*", SearchOption.AllDirectories)
+                .Where(d => options.Extensions.Contains(d.Extension,StringComparer.InvariantCultureIgnoreCase))
+                .Select(d => d.FullName)
+                .Where(d => !options.ExcludesFile(d))
+                .ToArray();
+
+            var sourceFileCount = sourceFiles.Length;
+
+            if (sourceFileCount == 0)
+            {
+                output.Log(Severity.Error, "No source files found");
+                // No source files found
+                // https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/exit-codes
+                return 32;
+            }
+
+            if (!options.SkipExtraction)
+            {
+                using var fileLogger = new FileLogger(options.Verbosity, PowerShell.Extractor.Extractor.GetPowerShellLogPath());
+
+                output.Log(Severity.Info, "");
+                output.Log(Severity.Info, "Extracting...");
+                options.TrapCompression = TrapWriter.CompressionMode.None;
+                PowerShell.Extractor.Extractor.ExtractStandalone(
+                    sourceFiles,
+                    new ExtractionProgress(output),
+                    fileLogger,
+                    options);
+                output.Log(Severity.Info, $"Extraction completed in {DateTime.Now - start}");
+            }
+
+            return 0;
+        }
+
+        private class ExtractionProgress : IProgressMonitor
+        {
+            public ExtractionProgress(ILogger output)
+            {
+                logger = output;
+            }
+
+            private readonly ILogger logger;
+
+            public void Analysed(int item, int total, string source, string output, TimeSpan time, AnalysisAction action)
+            {
+                logger.Log(Severity.Info, "[{0}/{1}] {2} ({3})", item, total, source,
+                    action == AnalysisAction.Extracted
+                        ? time.ToString()
+                        : action == AnalysisAction.Excluded
+                            ? "excluded"
+                            : "up to date");
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/ProgressMonitor.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/ProgressMonitor.cs
@@ -1,0 +1,40 @@
+﻿using Semmle.Util.Logging;
+using System;
+
+namespace Semmle.BuildAnalyser.PowerShell
+{
+    /// <summary>
+    /// Callback for various events that may happen during the build analysis.
+    /// </summary>
+    internal interface IProgressMonitor
+    {
+        void FindingFiles(string dir);
+        void Log(Severity severity, string message);
+        void CommandFailed(string exe, string arguments, int exitCode);
+    }
+
+    internal class ProgressMonitor : IProgressMonitor
+    {
+        private readonly ILogger logger;
+
+        public ProgressMonitor(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public void FindingFiles(string dir)
+        {
+            logger.Log(Severity.Info, "Finding files in {0}...", dir);
+        }
+
+        public void Log(Severity severity, string message)
+        {
+            logger.Log(severity, message);
+        }
+
+        public void CommandFailed(string exe, string arguments, int exitCode)
+        {
+            logger.Log(Severity.Error, $"Command {exe} {arguments} failed with exit code {exitCode}");
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Properties/launchSettings.json
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Semmle.Extraction.PowerShell.Standalone": {
+      "commandName": "Project",
+      "commandLineArgs": "C:\\codeql-home\\Microsoft\\codeql-queries\\src\\extractors\\powershell\\samples\\code",
+      "workingDirectory": "C:\\codeql-home\\Microsoft\\codeql-queries\\src\\extractors\\powershell\\extractor\\Semmle.Extraction.PowerShell.Standalone\\bin\\Debug\\net7.0"
+    }
+  }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Semmle.Extraction.PowerShell.Standalone.csproj
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Semmle.Extraction.PowerShell.Standalone.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+	<AssemblyName>Semmle.Extraction.PowerShell.Standalone</AssemblyName>
+	<RootNamespace>Semmle.Extraction.PowerShell.Standalone</RootNamespace>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+	<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+	<Nullable>enable</Nullable>
+	<LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Semmle.Extraction.PowerShell\Semmle.Extraction.PowerShell.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/powershell/extractor/Semmle.Extraction.PowerShell/CachedEntityFactory.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/CachedEntityFactory.cs
@@ -1,0 +1,19 @@
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// A factory for creating cached entities.
+    /// </summary>
+    internal abstract class CachedEntityFactory<TInit, TEntity>
+        : Extraction.CachedEntityFactory<TInit, TEntity> where TEntity : CachedEntity
+    {
+        /// <summary>
+        /// Initializes the entity, but does not generate any trap code.
+        /// </summary>
+        public sealed override TEntity Create(Context cx, TInit init)
+        {
+            return Create((PowerShellContext)cx, init);
+        }
+
+        public abstract TEntity Create(PowerShellContext cx, TInit init);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/CachedFunction.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/CachedFunction.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// A factory and a cache for mapping source entities to target entities.
+    /// Could be considered as a memoizer.
+    /// </summary>
+    /// <typeparam name="TSrc">The type of the source.</typeparam>
+    /// <typeparam name="TTarget">The type of the generated object.</typeparam>
+    public class CachedFunction<TSrc, TTarget> where TSrc : notnull
+    {
+        private readonly Func<TSrc, TTarget> generator;
+        private readonly Dictionary<TSrc, TTarget> cache;
+
+        /// <summary>
+        /// Initializes the factory with a given mapping.
+        /// </summary>
+        /// <param name="g">The mapping.</param>
+        public CachedFunction(Func<TSrc, TTarget> g)
+        {
+            generator = g;
+            cache = new Dictionary<TSrc, TTarget>();
+        }
+
+        /// <summary>
+        /// Gets the target for a given source.
+        /// Create it if it does not exist.
+        /// </summary>
+        /// <param name="src">The source object.</param>
+        /// <returns>The created object.</returns>
+        public TTarget this[TSrc src]
+        {
+            get
+            {
+                if (!cache.TryGetValue(src, out var result))
+                {
+                    result = generator(src);
+                    cache[src] = result;
+                }
+                return result;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A factory for mapping a pair of source entities to a target entity.
+    /// </summary>
+    /// <typeparam name="TSrcEntity1">Source entity type 1.</typeparam>
+    /// <typeparam name="TSrcEntity2">Source entity type 2.</typeparam>
+    /// <typeparam name="TTarget">The target type.</typeparam>
+    public class CachedFunction<TSrcEntity1, TSrcEntity2, TTarget>
+    {
+        private readonly CachedFunction<(TSrcEntity1, TSrcEntity2), TTarget> factory;
+
+        /// <summary>
+        /// Initializes the factory with a given mapping.
+        /// </summary>
+        /// <param name="g">The mapping.</param>
+        public CachedFunction(Func<TSrcEntity1, TSrcEntity2, TTarget> g)
+        {
+            factory = new CachedFunction<(TSrcEntity1, TSrcEntity2), TTarget>(p => g(p.Item1, p.Item2));
+        }
+
+        public TTarget this[TSrcEntity1 s1, TSrcEntity2 s2] => factory[(s1, s2)];
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/CompiledScript.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/CompiledScript.cs
@@ -1,0 +1,31 @@
+﻿using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// Represents a parsed PowerShell Script
+    /// </summary>
+    public class CompiledScript
+    {
+        public CompiledScript(string path, ScriptBlockAst compilation, Token[] tokens, ParseError[] errors)
+        {
+            Location = path;
+            ParseResult = compilation;
+            Tokens = tokens;
+            ParseErrors = errors;
+        }
+
+        public ParseError[] ParseErrors { get; set; }
+
+        public Token[] Tokens { get; set; }
+
+        /// <summary>
+        /// The AST of this script
+        /// </summary>
+        public ScriptBlockAst ParseResult { get; }
+        /// <summary>
+        /// Where this script came from.
+        /// </summary>
+        public string Location { get; }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayExpressionEntity.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+using System.Reflection;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ArrayExpressionEntity : CachedEntity<(ArrayExpressionAst, ArrayExpressionAst)>
+    {
+        private ArrayExpressionEntity(PowerShellContext cx, ArrayExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ArrayExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var subExpression = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.SubExpression);
+            trapFile.array_expression(this, subExpression);
+            trapFile.array_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";array_expression");
+        }
+
+        internal static ArrayExpressionEntity Create(PowerShellContext cx, ArrayExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ArrayExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ArrayExpressionEntityFactory : CachedEntityFactory<(ArrayExpressionAst, ArrayExpressionAst), ArrayExpressionEntity>
+        {
+            public static ArrayExpressionEntityFactory Instance { get; } = new ArrayExpressionEntityFactory();
+
+            public override ArrayExpressionEntity Create(PowerShellContext cx, (ArrayExpressionAst, ArrayExpressionAst) init) =>
+                new ArrayExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayLiteralEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayLiteralEntity.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ArrayLiteralEntity : CachedEntity<(ArrayLiteralAst, ArrayLiteralAst)>
+    {
+        private ArrayLiteralEntity(PowerShellContext cx, ArrayLiteralAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ArrayLiteralAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.array_literal(this);
+            trapFile.array_literal_location(this, TrapSuitableLocation);
+
+            for (int index = 0; index < Fragment.Elements.Count; index++)
+            {
+                var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Elements[index]);
+                trapFile.array_literal_element(this, index, entity);
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";array_literal");
+        }
+
+        internal static ArrayLiteralEntity Create(PowerShellContext cx, ArrayLiteralAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ArrayLiteralEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ArrayLiteralEntityFactory : CachedEntityFactory<(ArrayLiteralAst, ArrayLiteralAst), ArrayLiteralEntity>
+        {
+            public static ArrayLiteralEntityFactory Instance { get; } = new ArrayLiteralEntityFactory();
+
+            public override ArrayLiteralEntity Create(PowerShellContext cx, (ArrayLiteralAst, ArrayLiteralAst) init) =>
+                new ArrayLiteralEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AssignmentStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AssignmentStatementEntity.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class AssignmentStatementEntity : CachedEntity<(AssignmentStatementAst, AssignmentStatementAst)>
+    {
+        private AssignmentStatementEntity(PowerShellContext cx, AssignmentStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public AssignmentStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var left = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Left);
+            var right = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Right);
+            trapFile.assignment_statement(this, Fragment.Operator, left, right);
+            trapFile.assignment_statement_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";assignment_statement");
+        }
+
+        internal static AssignmentStatementEntity Create(PowerShellContext cx, AssignmentStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return AssignmentStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class AssignmentStatementEntityFactory : CachedEntityFactory<(AssignmentStatementAst, AssignmentStatementAst), AssignmentStatementEntity>
+        {
+            public static AssignmentStatementEntityFactory Instance { get; } = new AssignmentStatementEntityFactory();
+
+            public override AssignmentStatementEntity Create(PowerShellContext cx, (AssignmentStatementAst, AssignmentStatementAst) init) =>
+                new AssignmentStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributeEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributeEntity.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class AttributeEntity : CachedEntity<(AttributeAst, AttributeAst)>
+    {
+        private AttributeEntity(PowerShellContext cx, AttributeAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public AttributeAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.attribute(this, Fragment.TypeName.Name, Fragment.NamedArguments.Count, Fragment.PositionalArguments.Count);
+            trapFile.attribute_location(this, TrapSuitableLocation);
+            for (int i = 0; i < Fragment.NamedArguments.Count; i++)
+            {
+                trapFile.attribute_named_argument(this, i,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.NamedArguments[i]));
+            }
+            for (int i = 0; i < Fragment.PositionalArguments.Count; i++)
+            {
+                trapFile.attribute_positional_argument(this, i,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.PositionalArguments[i]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";attribute");
+        }
+
+        internal static AttributeEntity Create(PowerShellContext cx, AttributeAst fragment)
+        {
+            var init = (fragment, fragment);
+            return AttributeEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class AttributeEntityFactory : CachedEntityFactory<(AttributeAst, AttributeAst), AttributeEntity>
+        {
+            public static AttributeEntityFactory Instance { get; } = new AttributeEntityFactory();
+
+            public override AttributeEntity Create(PowerShellContext cx, (AttributeAst, AttributeAst) init) =>
+                new AttributeEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributedExpression.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributedExpression.cs
@@ -1,0 +1,47 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class AttributedExpressionEntity : CachedEntity<(AttributedExpressionAst, AttributedExpressionAst)>
+    {
+        private AttributedExpressionEntity(PowerShellContext cx, AttributedExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public AttributedExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.attributed_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attribute), 
+                EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Child));
+            trapFile.attributed_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";attributed_expression");
+        }
+
+        internal static AttributedExpressionEntity Create(PowerShellContext cx, AttributedExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return AttributedExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class AttributedExpressionEntityFactory : CachedEntityFactory<(AttributedExpressionAst, AttributedExpressionAst), AttributedExpressionEntity>
+        {
+            public static AttributedExpressionEntityFactory Instance { get; } = new AttributedExpressionEntityFactory();
+
+            public override AttributedExpressionEntity Create(PowerShellContext cx, (AttributedExpressionAst, AttributedExpressionAst) init) =>
+                new AttributedExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/CachedEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/CachedEntity.cs
@@ -1,0 +1,20 @@
+using System.Management.Automation.Language;
+using Semmle.Extraction.Entities;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal abstract class CachedEntity<T> : Extraction.CachedEntity<T> where T : notnull
+    {
+        public PowerShellContext PowerShellContext => (PowerShellContext)base.Context;
+
+        /// <summary>
+        /// Call PowerShellContext.CreateLocation on the ReportingLocation and return result
+        /// </summary>
+        internal Location TrapSuitableLocation => PowerShellContext.CreateLocation(ReportingLocation);
+        
+        protected CachedEntity(PowerShellContext powerShellContext, T symbol)
+            : base(powerShellContext, symbol)
+        {
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/File.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/File.cs
@@ -1,0 +1,63 @@
+using Semmle.Util;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class File : Extraction.Entities.File
+    {
+        public PowerShellContext PowerShellContext => (PowerShellContext)base.Context;
+
+        protected File(PowerShellContext cx, string path)
+            : base(cx, path)
+        {
+        }
+
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.files(this, TransformedPath.Value);
+
+            if (TransformedPath.ParentDirectory is PathTransformer.ITransformedPath dir)
+            {
+                trapFile.containerparent(Extraction.Entities.Folder.Create(PowerShellContext, dir), this);
+            }
+
+            try
+            {
+                System.Text.Encoding encoding;
+                var lineCount = 0;
+                using (var sr = new StreamReader(originalPath, detectEncodingFromByteOrderMarks: true))
+                {
+                    while (sr.ReadLine() is not null)
+                    {
+                        lineCount++;
+                    }
+                    encoding = sr.CurrentEncoding;
+                }
+
+                trapFile.numlines(this, lineCount, 0, 0);
+                PowerShellContext.TrapWriter.Archive(originalPath, TransformedPath, encoding ?? System.Text.Encoding.Default);
+            }
+            catch (Exception exc)
+            {
+                PowerShellContext.ExtractionError($"Couldn't read file: {originalPath}. {exc.Message}", null, null, exc.StackTrace);
+            }
+        }
+
+        private bool IsPossiblyTextFile()
+        {
+            var extension = TransformedPath.Extension.ToLowerInvariant();
+            return !extension.Equals("dll") && !extension.Equals("exe");
+        }
+
+        public static File Create(PowerShellContext cx, string path) => FileFactory.Instance.CreateEntity(cx, (typeof(File), path), path);
+
+        private class FileFactory : CachedEntityFactory<string, File>
+        {
+            public static FileFactory Instance { get; } = new FileFactory();
+
+            public override File Create(PowerShellContext cx, string init) => new File(cx, init);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/Folder.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/Folder.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal sealed class Folder : LabelledEntity, IFileOrFolder
+    {
+        private readonly PathTransformer.ITransformedPath transformedPath;
+
+        public Folder(PowerShellContext cx, PathTransformer.ITransformedPath path) : base(cx)
+        {
+            this.transformedPath = path;
+        }
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.Write(transformedPath.DatabaseId);
+            trapFile.Write(";folder");
+        }
+
+        public override IEnumerable<IExtractionProduct> Contents
+        {
+            get
+            {
+                if (transformedPath.ParentDirectory is PathTransformer.ITransformedPath parent)
+                {
+                    var parentFolder = PowerShellContext.CreateFolder(parent);
+                    yield return parentFolder;
+                    yield return Tuples.containerparent(parentFolder, this);
+                }
+                yield return Tuples.folders(this, transformedPath.Value);
+            }
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is Folder folder && transformedPath == folder.transformedPath;
+        }
+
+        public override int GetHashCode() => transformedPath.GetHashCode();
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/IExtractedEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/IExtractedEntity.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    /// <summary>
+    /// An entity which has been extracted.
+    /// </summary>
+    internal interface IExtractedEntity : IExtractionProduct, IEntity
+    {
+        /// <summary>
+        /// The contents of the entity.
+        /// </summary>
+
+        IEnumerable<IExtractionProduct> Contents { get; }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/IExtractionProduct.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/IExtractionProduct.cs
@@ -1,0 +1,24 @@
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    /// <summary>
+    /// Something that is extracted from an entity.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// The extraction algorithm proceeds as follows:
+    /// - Construct entity
+    /// - Call Extract()
+    /// - IExtractedEntity check if already extracted
+    /// - Enumerate Contents to produce more extraction products
+    /// - Extract these until there is nothing left to extract
+    /// </remarks>
+    internal interface IExtractionProduct
+    {
+        /// <summary>
+        /// Perform further extraction/population of this item as necessary.
+        /// </summary>
+        ///
+        /// <param name="cx">The extraction context.</param>
+        void Extract(PowerShellContext cx);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/IFileOrFolder.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/IFileOrFolder.cs
@@ -1,0 +1,6 @@
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal interface IFileOrFolder : IEntity
+    {
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/LabelledEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/LabelledEntity.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    /// <summary>
+    /// An entity that needs to be populated during extraction.
+    /// This assigns a key and optionally extracts its contents.
+    /// </summary>
+    internal abstract class LabelledEntity : Extraction.LabelledEntity, IExtractedEntity
+    {
+        public PowerShellContext PowerShellContext => (PowerShellContext)base.Context;
+
+        protected LabelledEntity(PowerShellContext cx) : base(cx)
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => throw new NotImplementedException();
+
+        public void Extract(PowerShellContext cx2)
+        {
+            cx2.Populate(this);
+        }
+
+        public override string ToString()
+        {
+            using var writer = new EscapingTextWriter();
+            WriteQuotedId(writer);
+            return writer.ToString();
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
+
+        public abstract IEnumerable<IExtractionProduct> Contents { get; }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/PerformanceMetrics.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/PerformanceMetrics.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    /// <summary>
+    /// The various performance metrics to log.
+    /// </summary>
+    public struct PerformanceMetrics
+    {
+        public Timings Frontend { get; set; }
+        public Timings Extractor { get; set; }
+        public Timings Total { get; set; }
+        public long PeakWorkingSet { get; set; }
+
+        /// <summary>
+        /// These are in database order (0 indexed)
+        /// </summary>
+        public IEnumerable<float> Metrics
+        {
+            get
+            {
+                yield return (float)Frontend.Cpu.TotalSeconds;
+                yield return (float)Frontend.Elapsed.TotalSeconds;
+                yield return (float)Extractor.Cpu.TotalSeconds;
+                yield return (float)Extractor.Elapsed.TotalSeconds;
+                yield return (float)Frontend.User.TotalSeconds;
+                yield return (float)Extractor.User.TotalSeconds;
+                yield return PeakWorkingSet / 1024.0f / 1024.0f;
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/SourceCodeLocation.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/SourceCodeLocation.cs
@@ -1,0 +1,59 @@
+using Microsoft.CodeAnalysis;
+using System.IO;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class SourceCodeLocation : Extraction.Entities.SourceLocation
+    {
+        public PowerShellContext powershellContext => (PowerShellContext)base.Context;
+
+        protected SourceCodeLocation(PowerShellContext cx, Location init)
+            : base(cx, init)
+        {
+            Position = init.GetLineSpan();
+            FileEntity = File.Create(powershellContext, Position.Path);
+        }
+
+        public override bool NeedsPopulation { get; } = true;
+
+        public static SourceCodeLocation Create(PowerShellContext cx, Location loc) => SourceLocationFactory.Instance.CreateEntity(cx, loc, loc);
+
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.locations_default(this, FileEntity,
+                Position.Span.Start.Line, Position.Span.Start.Character,
+                Position.Span.End.Line, Position.Span.End.Character);
+        }
+
+        public FileLinePositionSpan Position
+        {
+            get;
+        }
+
+        public File FileEntity
+        {
+            get;
+        }
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.Write("loc,");
+            trapFile.WriteSubId(FileEntity);
+            trapFile.Write(',');
+            trapFile.Write(Position.Span.Start.Line);
+            trapFile.Write(',');
+            trapFile.Write(Position.Span.Start.Character);
+            trapFile.Write(',');
+            trapFile.Write(Position.Span.End.Line);
+            trapFile.Write(',');
+            trapFile.Write(Position.Span.End.Character);
+        }
+
+        private class SourceLocationFactory : CachedEntityFactory<Location, SourceCodeLocation>
+        {
+            public static SourceLocationFactory Instance { get; } = new SourceLocationFactory();
+
+            public override SourceCodeLocation Create(PowerShellContext cx, Location init) => new SourceCodeLocation(cx, init);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/StringLiteralEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/StringLiteralEntity.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace Semmle.Extraction.PowerShell.Entities;
+
+using Semmle.Extraction.Entities;
+using System.IO;
+
+internal class StringLiteralEntity : CachedEntity<(Microsoft.CodeAnalysis.Location, string)>
+{
+    private StringLiteralEntity(PowerShellContext cx, Microsoft.CodeAnalysis.Location loc, string text)
+        : base(cx, (loc, text))
+    {
+    }
+
+    private Location? location;
+
+    public override Microsoft.CodeAnalysis.Location ReportingLocation => Symbol.Item1;
+    public string Text => Symbol.Item2;
+    public override void Populate(TextWriter trapFile)
+    {
+        location = PowerShellContext.CreateLocation(ReportingLocation);
+        trapFile.string_literal(this);
+        trapFile.string_literal_location(this, TrapSuitableLocation);
+        string[] splits = Text.Split(new[] { '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (int index = 0; index < splits.Length; index++)
+        {
+            trapFile.string_literal_line(this, index, splits[index]);
+        }
+    }
+
+    public override bool NeedsPopulation => true;
+
+    public override void WriteId(EscapingTextWriter trapFile)
+    {
+        trapFile.WriteSubId(TrapSuitableLocation);
+        trapFile.Write(";string_literal");
+    }
+
+    internal static StringLiteralEntity Create(PowerShellContext cx, Microsoft.CodeAnalysis.Location loc, string text)
+    {
+        var init = (loc, text);
+        return StringLiteralFactory.Instance.CreateEntity(cx, init, init);
+    }
+
+    private class StringLiteralFactory : CachedEntityFactory<(Microsoft.CodeAnalysis.Location, string), StringLiteralEntity>
+    {
+        public static StringLiteralFactory Instance { get; } = new StringLiteralFactory();
+
+        public override StringLiteralEntity Create(PowerShellContext cx, (Microsoft.CodeAnalysis.Location, string) init) =>
+            new StringLiteralEntity(cx, init.Item1, init.Item2);
+    }
+
+    public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/Timings.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/Timings.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    public struct Timings
+    {
+        public TimeSpan Elapsed { get; set; }
+        public TimeSpan Cpu { get; set; }
+        public TimeSpan User { get; set; }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/Tuple.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/Tuple.cs
@@ -1,0 +1,24 @@
+using Semmle.Extraction.PowerShell.Entities;
+
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// A tuple that is an extraction product.
+    /// </summary>
+    internal class Tuple : IExtractionProduct
+    {
+        private readonly Extraction.Tuple tuple;
+
+        public Tuple(string name, params object[] args)
+        {
+            tuple = new Extraction.Tuple(name, args);
+        }
+
+        public void Extract(PowerShellContext cx)
+        {
+            cx.TrapWriter.Emit(tuple);
+        }
+
+        public override string ToString() => tuple.ToString();
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/UnlabelledEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/UnlabelledEntity.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    /// <summary>
+    /// An entity that has contents to extract. There is no need to populate
+    /// a key as it's done in the contructor.
+    /// </summary>
+    internal abstract class UnlabelledEntity : Extraction.UnlabelledEntity, IExtractedEntity
+    {
+        public PowerShellContext PowerShellContext => (PowerShellContext)base.Context;
+
+        protected UnlabelledEntity(PowerShellContext cx) : base(cx)
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => throw new NotImplementedException();
+
+        public void Extract(PowerShellContext cx2)
+        {
+            cx2.Extract(this);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
+
+        public abstract IEnumerable<IExtractionProduct> Contents { get; }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BinaryExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BinaryExpressionEntity.cs
@@ -1,0 +1,48 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class BinaryExpressionEntity : CachedEntity<(BinaryExpressionAst, BinaryExpressionAst)>
+    {
+        private BinaryExpressionEntity(PowerShellContext cx, BinaryExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public BinaryExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var left = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Left);
+            var right = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Right);
+            trapFile.binary_expression(this, Fragment.Operator, left, right);
+            trapFile.binary_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";binary_expression");
+        }
+
+        internal static BinaryExpressionEntity Create(PowerShellContext cx, BinaryExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return BinaryExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class BinaryExpressionEntityFactory : CachedEntityFactory<(BinaryExpressionAst, BinaryExpressionAst), BinaryExpressionEntity>
+        {
+            public static BinaryExpressionEntityFactory Instance { get; } = new BinaryExpressionEntityFactory();
+
+            public override BinaryExpressionEntity Create(PowerShellContext cx, (BinaryExpressionAst, BinaryExpressionAst) init) =>
+                new BinaryExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BlockStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BlockStatementEntity.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class BlockStatementEntity : CachedEntity<(BlockStatementAst, BlockStatementAst)>
+    {
+        private BlockStatementEntity(PowerShellContext cx, BlockStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public BlockStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.block_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), TokenEntity.Create(PowerShellContext, Fragment.Kind));
+            trapFile.block_statement_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";block_statement");
+        }
+
+        internal static BlockStatementEntity Create(PowerShellContext cx, BlockStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return BlockStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class BlockStatementEntityFactory : CachedEntityFactory<(BlockStatementAst, BlockStatementAst), BlockStatementEntity>
+        {
+            public static BlockStatementEntityFactory Instance { get; } = new BlockStatementEntityFactory();
+
+            public override BlockStatementEntity Create(PowerShellContext cx, (BlockStatementAst, BlockStatementAst) init) =>
+                new BlockStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BreakStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BreakStatementEntity.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class BreakStatementEntity : CachedEntity<(BreakStatementAst, BreakStatementAst)>
+    {
+        private BreakStatementEntity(PowerShellContext cx, BreakStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public BreakStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.break_statement(this);
+            if (Fragment.Label is not null)
+            {
+                trapFile.statement_label(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Label));
+            }
+
+            trapFile.break_statement_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";break_statement");
+        }
+
+        internal static BreakStatementEntity Create(PowerShellContext cx, BreakStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return BreakStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class BreakStatementEntityFactory : CachedEntityFactory<(BreakStatementAst, BreakStatementAst), BreakStatementEntity>
+        {
+            public static BreakStatementEntityFactory Instance { get; } = new BreakStatementEntityFactory();
+
+            public override BreakStatementEntity Create(PowerShellContext cx, (BreakStatementAst, BreakStatementAst) init) =>
+                new BreakStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CatchClauseEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CatchClauseEntity.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class CatchClauseEntity : CachedEntity<(CatchClauseAst, CatchClauseAst)>
+    {
+        private CatchClauseEntity(PowerShellContext cx, CatchClauseAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public CatchClauseAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.catch_clause(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), Fragment.IsCatchAll);
+            for(int index = 0; index < Fragment.CatchTypes.Count; index++)
+            {
+                trapFile.catch_clause_catch_type(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CatchTypes[index]));
+            }
+            trapFile.catch_clause_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";catch_clause");
+        }
+
+        internal static CatchClauseEntity Create(PowerShellContext cx, CatchClauseAst fragment)
+        {
+            var init = (fragment, fragment);
+            return CatchClauseEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class CatchClauseEntityFactory : CachedEntityFactory<(CatchClauseAst, CatchClauseAst), CatchClauseEntity>
+        {
+            public static CatchClauseEntityFactory Instance { get; } = new CatchClauseEntityFactory();
+
+            public override CatchClauseEntity Create(PowerShellContext cx, (CatchClauseAst, CatchClauseAst) init) =>
+                new CatchClauseEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandEntity.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class CommandEntity : CachedEntity<(CommandAst, CommandAst)>
+    {
+        private CommandEntity(PowerShellContext cx, CommandAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public CommandAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.command(this, Fragment.GetCommandName() ?? string.Empty, Fragment.InvocationOperator, Fragment.CommandElements.Count, Fragment.Redirections.Count);
+            trapFile.command_location(this, TrapSuitableLocation);
+            // TODO: Need a sample where this isn't null
+            if (Fragment.DefiningKeyword is { } dynamicKeyword)
+            {
+            }
+            for (int index = 0; index < Fragment.CommandElements.Count; index++)
+            {
+                var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CommandElements[index]);
+                trapFile.command_command_element(this, index, entity);
+            }
+            for(int index = 0; index < Fragment.Redirections.Count; index++)
+            {
+                var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Redirections[index]);
+                trapFile.command_redirection(this, index, entity);
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";command");
+        }
+
+        internal static CommandEntity Create(PowerShellContext cx, CommandAst fragment)
+        {
+            var init = (fragment, fragment);
+            return CommandEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class CommandEntityFactory : CachedEntityFactory<(CommandAst, CommandAst), CommandEntity>
+        {
+            public static CommandEntityFactory Instance { get; } = new CommandEntityFactory();
+
+            public override CommandEntity Create(PowerShellContext cx, (CommandAst, CommandAst) init) =>
+                new CommandEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandExpressionEntity.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class CommandExpressionEntity : CachedEntity<(CommandExpressionAst, CommandExpressionAst)>
+    {
+        private CommandExpressionEntity(PowerShellContext cx, CommandExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public CommandExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var wrappedEntity =
+                EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Expression);
+            trapFile.command_expression(this, wrappedEntity, Fragment.Redirections.Count);
+            trapFile.command_expression_location(this, TrapSuitableLocation);
+            for (var index = 0; index < Fragment.Redirections.Count; index++)
+            {
+                trapFile.command_expression_redirection(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Redirections[index]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";command_expression");
+        }
+
+        internal static CommandExpressionEntity Create(PowerShellContext cx, CommandExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return CommandExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class CommandExpressionEntityFactory : CachedEntityFactory<(CommandExpressionAst, CommandExpressionAst), CommandExpressionEntity>
+        {
+            public static CommandExpressionEntityFactory Instance { get; } = new CommandExpressionEntityFactory();
+
+            public override CommandExpressionEntity Create(PowerShellContext cx, (CommandExpressionAst, CommandExpressionAst) init) =>
+                new CommandExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandParameterEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandParameterEntity.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class CommandParameterEntity : CachedEntity<(CommandParameterAst, CommandParameterAst)>
+    {
+        private CommandParameterEntity(PowerShellContext cx, CommandParameterAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public CommandParameterAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.command_parameter(this, Fragment.ParameterName);
+            trapFile.command_parameter_location(this, TrapSuitableLocation);
+            if (Fragment.Argument is not null)
+            {
+                trapFile.command_parameter_argument(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext,Fragment.Argument));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";command_parameter");
+        }
+
+        internal static CommandParameterEntity Create(PowerShellContext cx, CommandParameterAst fragment)
+        {
+            var init = (fragment, fragment);
+            return CommandParameterEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class CommandParameterEntityFactory : CachedEntityFactory<(CommandParameterAst, CommandParameterAst), CommandParameterEntity>
+        {
+            public static CommandParameterEntityFactory Instance { get; } = new CommandParameterEntityFactory();
+
+            public override CommandParameterEntity Create(PowerShellContext cx, (CommandParameterAst, CommandParameterAst) init) =>
+                new CommandParameterEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommentEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommentEntity.cs
@@ -1,0 +1,57 @@
+using Semmle.Extraction.Entities;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal enum CommentType
+    {
+        SingleLine,
+        MultiLineContinuation
+    }
+    internal class CommentEntity : CachedEntity<(Token, Token)>
+    {
+        private CommentEntity(PowerShellContext cx, Token token)
+            : base(cx, (token, token))
+        {
+        }
+        private Location? location;
+
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.ExtentToAnalysisLocation(Fragment.Extent);
+        public Token Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            location = TrapSuitableLocation;
+
+            var literal = StringLiteralEntity.Create(PowerShellContext, ReportingLocation, Fragment.Text);
+            trapFile.comment_entity(this, literal);
+            trapFile.comment_entity_location(this, location);
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";comment");
+        }
+
+        internal static CommentEntity Create(PowerShellContext cx, Token init)
+        {
+            var init2 = (init, init);
+            return CommentLineFactory.Instance.CreateEntity(cx, init2, init2);
+        }
+
+        private class CommentLineFactory : CachedEntityFactory<(Token, Token), CommentEntity>
+        {
+            public static CommentLineFactory Instance { get; } = new CommentLineFactory();
+
+            public override CommentEntity Create(PowerShellContext cx, (Token, Token) init) =>
+                new CommentEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConfigurationDefinitionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConfigurationDefinitionEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ConfigurationDefinitionEntity : CachedEntity<(ConfigurationDefinitionAst, ConfigurationDefinitionAst)>
+    {
+        private ConfigurationDefinitionEntity(PowerShellContext cx, ConfigurationDefinitionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ConfigurationDefinitionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.configuration_definition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), Fragment.ConfigurationType, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.InstanceName));
+            trapFile.configuration_definition_location(this, TrapSuitableLocation); 
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";configuration_definition");
+        }
+
+        internal static ConfigurationDefinitionEntity Create(PowerShellContext cx, ConfigurationDefinitionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ConfigurationDefinitionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ConfigurationDefinitionEntityFactory : CachedEntityFactory<(ConfigurationDefinitionAst, ConfigurationDefinitionAst), ConfigurationDefinitionEntity>
+        {
+            public static ConfigurationDefinitionEntityFactory Instance { get; } = new ConfigurationDefinitionEntityFactory();
+
+            public override ConfigurationDefinitionEntity Create(PowerShellContext cx, (ConfigurationDefinitionAst, ConfigurationDefinitionAst) init) =>
+                new ConfigurationDefinitionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConstantExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConstantExpressionEntity.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+using System.Reflection.Metadata;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ConstantExpressionEntity : CachedEntity<(ConstantExpressionAst, ConstantExpressionAst)>
+    {
+        private ConstantExpressionEntity(PowerShellContext cx, ConstantExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ConstantExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.constant_expression(this, Fragment.StaticType.Name);
+            if (Fragment.Value is not null && Fragment.Value.ToString() is {} strVal)
+            {
+                trapFile.constant_expression_value(this,
+                    StringLiteralEntity.Create(PowerShellContext, ReportingLocation, strVal));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.constant_expression_location(this, TrapSuitableLocation);
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";constant_expression");
+        }
+
+        internal static ConstantExpressionEntity Create(PowerShellContext cx, ConstantExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ConstantExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ConstantExpressionEntityFactory : CachedEntityFactory<(ConstantExpressionAst, ConstantExpressionAst), ConstantExpressionEntity>
+        {
+            public static ConstantExpressionEntityFactory Instance { get; } = new ConstantExpressionEntityFactory();
+
+            public override ConstantExpressionEntity Create(PowerShellContext cx, (ConstantExpressionAst, ConstantExpressionAst) init) =>
+                new ConstantExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+
+        /// <summary>
+        /// Gets a string representation of a constant value.
+        /// </summary>
+        /// <param name="obj">The value.</param>
+        /// <returns>The string representation.</returns>
+        /// From https://github.com/github/codeql/blob/main/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
+        public static string ValueAsString(object? value)
+        {
+            return value is null
+                ? "null"
+                : value.ToString()!;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ContinueStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ContinueStatementEntity.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ContinueStatementEntity : CachedEntity<(ContinueStatementAst, ContinueStatementAst)>
+    {
+        private ContinueStatementEntity(PowerShellContext cx, ContinueStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ContinueStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.continue_statement(this);
+            if (Fragment.Label is not null)
+            {
+                trapFile.statement_label(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Label));
+            }
+
+            trapFile.continue_statement_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";continue_statement");
+        }
+
+        internal static ContinueStatementEntity Create(PowerShellContext cx, ContinueStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ContinueStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ContinueStatementEntityFactory : CachedEntityFactory<(ContinueStatementAst, ContinueStatementAst), ContinueStatementEntity>
+        {
+            public static ContinueStatementEntityFactory Instance { get; } = new ContinueStatementEntityFactory();
+
+            public override ContinueStatementEntity Create(PowerShellContext cx, (ContinueStatementAst, ContinueStatementAst) init) =>
+                new ContinueStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConvertExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConvertExpressionEntity.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+using System.Reflection;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ConvertExpressionEntity : CachedEntity<(ConvertExpressionAst, ConvertExpressionAst)>
+    {
+        private ConvertExpressionEntity(PowerShellContext cx, ConvertExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ConvertExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var attribute = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attribute);
+            var child = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Child);
+            var type = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Type);
+            trapFile.convert_expression(this, attribute, child, type, Fragment.StaticType.Name);
+            trapFile.convert_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";convert_expression");
+        }
+
+        internal static ConvertExpressionEntity Create(PowerShellContext cx, ConvertExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ConvertExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ConvertExpressionEntityFactory : CachedEntityFactory<(ConvertExpressionAst, ConvertExpressionAst), ConvertExpressionEntity>
+        {
+            public static ConvertExpressionEntityFactory Instance { get; } = new ConvertExpressionEntityFactory();
+
+            public override ConvertExpressionEntity Create(PowerShellContext cx, (ConvertExpressionAst, ConvertExpressionAst) init) =>
+                new ConvertExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DataStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DataStatementEntity.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class DataStatementEntity : CachedEntity<(DataStatementAst, DataStatementAst)>
+    {
+        private DataStatementEntity(PowerShellContext cx, DataStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public DataStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.data_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body));
+            trapFile.data_statement_location(this, TrapSuitableLocation);
+            if (Fragment.Variable != null)
+            {
+                trapFile.data_statement_variable(this, Fragment.Variable);
+            }
+            for(int i = 0; i < Fragment.CommandsAllowed.Count; i++)
+            {
+                trapFile.data_statement_commands_allowed(this, i, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CommandsAllowed[i]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";data_statement");
+        }
+
+        internal static DataStatementEntity Create(PowerShellContext cx, DataStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return DataStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class DataStatementEntityFactory : CachedEntityFactory<(DataStatementAst, DataStatementAst), DataStatementEntity>
+        {
+            public static DataStatementEntityFactory Instance { get; } = new DataStatementEntityFactory();
+
+            public override DataStatementEntity Create(PowerShellContext cx, (DataStatementAst, DataStatementAst) init) =>
+                new DataStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoUntilStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoUntilStatementEntity.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class DoUntilStatementEntity : CachedEntity<(DoUntilStatementAst, DoUntilStatementAst)>
+    {
+        private DoUntilStatementEntity(PowerShellContext cx, DoUntilStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public DoUntilStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            // Condition can be null only if this is a For statement so For Statement must be parsed first
+            trapFile.do_until_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body));
+            trapFile.do_until_statement_location(this, TrapSuitableLocation);
+            if (Fragment.Label is not null)
+            {
+                trapFile.label(this, Fragment.Label);
+            }
+
+            if (Fragment.Condition is not null)
+            {
+                trapFile.do_until_statement_condition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";do_until_statement");
+        }
+
+        internal static DoUntilStatementEntity Create(PowerShellContext cx, DoUntilStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return DoUntilStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class DoUntilStatementEntityFactory : CachedEntityFactory<(DoUntilStatementAst, DoUntilStatementAst), DoUntilStatementEntity>
+        {
+            public static DoUntilStatementEntityFactory Instance { get; } = new DoUntilStatementEntityFactory();
+
+            public override DoUntilStatementEntity Create(PowerShellContext cx, (DoUntilStatementAst, DoUntilStatementAst) init) =>
+                new DoUntilStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoWhileStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoWhileStatementEntity.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class DoWhileStatementEntity : CachedEntity<(DoWhileStatementAst, DoWhileStatementAst)>
+    {
+        private DoWhileStatementEntity(PowerShellContext cx, DoWhileStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public DoWhileStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            // Condition can be null only if this is a For statement so For Statement must be parsed first
+            trapFile.do_while_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body));
+            trapFile.do_while_statement_location(this, TrapSuitableLocation);
+            if (Fragment.Label is not null)
+            {
+                trapFile.label(this, Fragment.Label);
+            }
+
+            if (Fragment.Condition is not null)
+            {
+                trapFile.do_while_statement_condition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";do_while_statement");
+        }
+
+        internal static DoWhileStatementEntity Create(PowerShellContext cx, DoWhileStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return DoWhileStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class DoWhileStatementEntityFactory : CachedEntityFactory<(DoWhileStatementAst, DoWhileStatementAst), DoWhileStatementEntity>
+        {
+            public static DoWhileStatementEntityFactory Instance { get; } = new DoWhileStatementEntityFactory();
+
+            public override DoWhileStatementEntity Create(PowerShellContext cx, (DoWhileStatementAst, DoWhileStatementAst) init) =>
+                new DoWhileStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DynamicKeywordStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DynamicKeywordStatementEntity.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class DynamicKeywordStatementEntity : CachedEntity<(DynamicKeywordStatementAst, DynamicKeywordStatementAst)>
+    {
+        private DynamicKeywordStatementEntity(PowerShellContext cx, DynamicKeywordStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public DynamicKeywordStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.dynamic_keyword_statement(this);
+            trapFile.dynamic_keyword_statement_location(this, TrapSuitableLocation);
+            for(int index = 0; index < Fragment.CommandElements.Count; index++)
+            {
+                trapFile.dynamic_keyword_statement_command_elements(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CommandElements[index]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";dynamic_keyword_statement");
+        }
+
+        internal static DynamicKeywordStatementEntity Create(PowerShellContext cx, DynamicKeywordStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return DynamicKeywordStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class DynamicKeywordStatementEntityFactory : CachedEntityFactory<(DynamicKeywordStatementAst, DynamicKeywordStatementAst), DynamicKeywordStatementEntity>
+        {
+            public static DynamicKeywordStatementEntityFactory Instance { get; } = new DynamicKeywordStatementEntityFactory();
+
+            public override DynamicKeywordStatementEntity Create(PowerShellContext cx, (DynamicKeywordStatementAst, DynamicKeywordStatementAst) init) =>
+                new DynamicKeywordStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorExpressionEntity.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ErrorExpressionEntity : CachedEntity<(ErrorExpressionAst, ErrorExpressionAst)>
+    {
+        private ErrorExpressionEntity(PowerShellContext cx, ErrorExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ErrorExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.error_expression(this);
+            trapFile.error_expression_location(this, TrapSuitableLocation);
+            if (Fragment.NestedAst is not null)
+            {
+                for(int index = 0; index < Fragment.NestedAst.Count; index++)
+                {
+                    trapFile.error_expression_nested_ast(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.NestedAst[index]));
+                }
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";error_expression");
+        }
+
+        internal static ErrorExpressionEntity Create(PowerShellContext cx, ErrorExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ErrorExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ErrorExpressionEntityFactory : CachedEntityFactory<(ErrorExpressionAst, ErrorExpressionAst), ErrorExpressionEntity>
+        {
+            public static ErrorExpressionEntityFactory Instance { get; } = new ErrorExpressionEntityFactory();
+
+            public override ErrorExpressionEntity Create(PowerShellContext cx, (ErrorExpressionAst, ErrorExpressionAst) init) =>
+                new ErrorExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorStatementEntity.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ErrorStatementEntity : CachedEntity<(ErrorStatementAst, ErrorStatementAst)>
+    {
+        private ErrorStatementEntity(PowerShellContext cx, ErrorStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ErrorStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.error_statement(this, TokenEntity.Create(PowerShellContext, Fragment.Kind));
+            if (Fragment.Flags is not null)
+            {
+                int index = 0;
+                foreach (var flag in Fragment.Flags)
+                {
+                    trapFile.error_statement_flag(this, index++, flag.Key, TokenEntity.Create(PowerShellContext,flag.Value.Item1), EntityConstructor.ConstructAppropriateEntity(PowerShellContext, flag.Value.Item2));
+                }
+            }
+            if (Fragment.NestedAst is not null)
+            {
+                for(int index = 0; index < Fragment.NestedAst.Count; index++)
+                {
+                    trapFile.error_statement_nested_ast(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.NestedAst[index]));
+                }
+            }
+            for(int index = 0; index < Fragment.Conditions.Count; index++)
+            {
+                trapFile.error_statement_conditions(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Conditions[index]));
+            }
+            for(int index = 0; index < Fragment.Bodies.Count; index++)
+            {
+                trapFile.error_statement_bodies(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Bodies[index]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.error_statement_location(this, TrapSuitableLocation);
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";error_statement");
+        }
+
+        internal static ErrorStatementEntity Create(PowerShellContext cx, ErrorStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ErrorStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ErrorStatementEntityFactory : CachedEntityFactory<(ErrorStatementAst, ErrorStatementAst), ErrorStatementEntity>
+        {
+            public static ErrorStatementEntityFactory Instance { get; } = new ErrorStatementEntityFactory();
+
+            public override ErrorStatementEntity Create(PowerShellContext cx, (ErrorStatementAst, ErrorStatementAst) init) =>
+                new ErrorStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExitStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExitStatementEntity.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ExitStatementEntity : CachedEntity<(ExitStatementAst, ExitStatementAst)>
+    {
+        private ExitStatementEntity(PowerShellContext cx, ExitStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ExitStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            if(Fragment.Pipeline is not null)
+            {
+                trapFile.exit_statement_pipeline(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
+            }    
+            trapFile.exit_statement(this);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.exit_statement_location(this, TrapSuitableLocation);
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";exit_statement");
+        }
+
+        internal static ExitStatementEntity Create(PowerShellContext cx, ExitStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ExitStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ExitStatementEntityFactory : CachedEntityFactory<(ExitStatementAst, ExitStatementAst), ExitStatementEntity>
+        {
+            public static ExitStatementEntityFactory Instance { get; } = new ExitStatementEntityFactory();
+
+            public override ExitStatementEntity Create(PowerShellContext cx, (ExitStatementAst, ExitStatementAst) init) =>
+                new ExitStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExpandableStringExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExpandableStringExpressionEntity.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ExpandableStringExpressionEntity : CachedEntity<(ExpandableStringExpressionAst, ExpandableStringExpressionAst)>
+    {
+        private ExpandableStringExpressionEntity(PowerShellContext cx, ExpandableStringExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ExpandableStringExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            // todo: for expandable_string_expression, string_constant_expression, and constant_expression
+            // implement support for when the value contains `n, since this is causing the line in .trap to be split
+            
+            trapFile.expandable_string_expression(this, StringLiteralEntity.Create(PowerShellContext, ReportingLocation, Fragment.Value), Fragment.StringConstantType, Fragment.NestedExpressions.Count);
+            trapFile.expandable_string_expression_location(this, TrapSuitableLocation);
+            for (int index = 0; index < Fragment.NestedExpressions.Count; index++)
+            {
+                trapFile.expandable_string_expression_nested_expression(this, index,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.NestedExpressions[index]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";expandable_string_expression");
+        }
+
+        internal static ExpandableStringExpressionEntity Create(PowerShellContext cx, ExpandableStringExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ExpandableStringExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ExpandableStringExpressionEntityFactory : CachedEntityFactory<(ExpandableStringExpressionAst, ExpandableStringExpressionAst), ExpandableStringExpressionEntity>
+        {
+            public static ExpandableStringExpressionEntityFactory Instance { get; } = new ExpandableStringExpressionEntityFactory();
+
+            public override ExpandableStringExpressionEntity Create(PowerShellContext cx, (ExpandableStringExpressionAst, ExpandableStringExpressionAst) init) =>
+                new ExpandableStringExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FileRedirectionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FileRedirectionEntity.cs
@@ -1,0 +1,47 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class FileRedirectionEntity : CachedEntity<(FileRedirectionAst, FileRedirectionAst)>
+    {
+        private FileRedirectionEntity(PowerShellContext cx, FileRedirectionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public FileRedirectionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.file_redirection(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Location),
+                Fragment.Append, Fragment.FromStream);
+            trapFile.file_redirection_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";file_redirection");
+        }
+
+        internal static FileRedirectionEntity Create(PowerShellContext cx, FileRedirectionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return FileRedirectionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class FileRedirectionEntityFactory : CachedEntityFactory<(FileRedirectionAst, FileRedirectionAst), FileRedirectionEntity>
+        {
+            public static FileRedirectionEntityFactory Instance { get; } = new FileRedirectionEntityFactory();
+
+            public override FileRedirectionEntity Create(PowerShellContext cx, (FileRedirectionAst, FileRedirectionAst) init) =>
+                new FileRedirectionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForEachStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForEachStatementEntity.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ForEachStatementEntity : CachedEntity<(ForEachStatementAst, ForEachStatementAst)>
+    {
+        private ForEachStatementEntity(PowerShellContext cx, ForEachStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ForEachStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            // Condition can be null only if this is a For statement so For Statement must be parsed first
+            trapFile.foreach_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Variable), 
+                EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition), 
+                EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), Fragment.Flags);
+            trapFile.foreach_statement_location(this, TrapSuitableLocation);
+            if (Fragment.Label is not null)
+            {
+                trapFile.label(this, Fragment.Label);
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";foreach_statement");
+        }
+
+        internal static ForEachStatementEntity Create(PowerShellContext cx, ForEachStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ForEachStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ForEachStatementEntityFactory : CachedEntityFactory<(ForEachStatementAst, ForEachStatementAst), ForEachStatementEntity>
+        {
+            public static ForEachStatementEntityFactory Instance { get; } = new ForEachStatementEntityFactory();
+
+            public override ForEachStatementEntity Create(PowerShellContext cx, (ForEachStatementAst, ForEachStatementAst) init) =>
+                new ForEachStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForStatementEntity.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ForStatementEntity : CachedEntity<(ForStatementAst, ForStatementAst)>
+    {
+        private ForStatementEntity(PowerShellContext cx, ForStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ForStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            // Condition can be null only if this is a For statement so For Statement must be parsed first
+            trapFile.for_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body));
+            trapFile.for_statement_location(this, TrapSuitableLocation);
+            if (Fragment.Label is not null)
+            {
+                trapFile.label(this, Fragment.Label);
+            }
+
+            if (Fragment.Initializer is not null)
+            {
+                trapFile.for_statement_initializer(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Initializer));
+            }
+
+            if (Fragment.Condition is not null)
+            {
+                trapFile.for_statement_condition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition));
+            }
+
+            if (Fragment.Iterator is not null)
+            {
+                trapFile.for_statement_iterator(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Iterator));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";for_statement");
+        }
+
+        internal static ForStatementEntity Create(PowerShellContext cx, ForStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ForStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ForStatementEntityFactory : CachedEntityFactory<(ForStatementAst, ForStatementAst), ForStatementEntity>
+        {
+            public static ForStatementEntityFactory Instance { get; } = new ForStatementEntityFactory();
+
+            public override ForStatementEntity Create(PowerShellContext cx, (ForStatementAst, ForStatementAst) init) =>
+                new ForStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionDefinitionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionDefinitionEntity.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class FunctionDefinitionEntity : CachedEntity<(FunctionDefinitionAst, FunctionDefinitionAst)>
+    {
+        private FunctionDefinitionEntity(PowerShellContext cx, FunctionDefinitionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public FunctionDefinitionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.function_definition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), Fragment.Name, Fragment.IsFilter, Fragment.IsWorkflow);
+            trapFile.function_definition_location(this, TrapSuitableLocation);
+            for (int i = 0; i < Fragment.Parameters?.Count; i++)
+            {
+                trapFile.function_definition_parameter(this, i, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parameters[i]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";function_definition");
+        }
+
+        internal static FunctionDefinitionEntity Create(PowerShellContext cx, FunctionDefinitionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return FunctionDefinitionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class FunctionDefinitionEntityFactory : CachedEntityFactory<(FunctionDefinitionAst, FunctionDefinitionAst), FunctionDefinitionEntity>
+        {
+            public static FunctionDefinitionEntityFactory Instance { get; } = new FunctionDefinitionEntityFactory();
+
+            public override FunctionDefinitionEntity Create(PowerShellContext cx, (FunctionDefinitionAst, FunctionDefinitionAst) init) =>
+                new FunctionDefinitionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionMemberEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionMemberEntity.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class FunctionMemberEntity : CachedEntity<(FunctionMemberAst, FunctionMemberAst)>
+    {
+        private FunctionMemberEntity(PowerShellContext cx, FunctionMemberAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public FunctionMemberAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.function_member(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), Fragment.IsConstructor, Fragment.IsHidden, Fragment.IsPrivate, Fragment.IsPublic, Fragment.IsStatic, Fragment.Name, Fragment.MethodAttributes);
+            trapFile.function_member_location(this, TrapSuitableLocation);
+            for(int index = 0; index < Fragment.Parameters.Count; index++)
+            {
+                trapFile.function_member_parameter(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parameters[index]));
+            }
+            for(int index = 0; index < Fragment.Attributes.Count; index++)
+            {
+                trapFile.function_member_attribute(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attributes[index]));
+            }
+            if (Fragment.ReturnType is not null)
+            {
+                trapFile.function_member_return_type(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.ReturnType));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";function_member");
+        }
+
+        internal static FunctionMemberEntity Create(PowerShellContext cx, FunctionMemberAst fragment)
+        {
+            var init = (fragment, fragment);
+            return FunctionMemberEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class FunctionMemberEntityFactory : CachedEntityFactory<(FunctionMemberAst, FunctionMemberAst), FunctionMemberEntity>
+        {
+            public static FunctionMemberEntityFactory Instance { get; } = new FunctionMemberEntityFactory();
+
+            public override FunctionMemberEntity Create(PowerShellContext cx, (FunctionMemberAst, FunctionMemberAst) init) =>
+                new FunctionMemberEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/HashTableEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/HashTableEntity.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class HashtableEntity : CachedEntity<(HashtableAst, HashtableAst)>
+    {
+        private HashtableEntity(PowerShellContext cx, HashtableAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public HashtableAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.hash_table(this);
+            trapFile.hash_table_location(this, TrapSuitableLocation);
+            int index = 0;
+            foreach(var pair in Fragment.KeyValuePairs)
+            {
+                trapFile.hash_table_key_value_pairs(this, index++, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, pair.Item1), EntityConstructor.ConstructAppropriateEntity(PowerShellContext, pair.Item2));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";hash_table");
+        }
+
+        internal static HashtableEntity Create(PowerShellContext cx, HashtableAst fragment)
+        {
+            var init = (fragment, fragment);
+            return HashtableEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class HashtableEntityFactory : CachedEntityFactory<(HashtableAst, HashtableAst), HashtableEntity>
+        {
+            public static HashtableEntityFactory Instance { get; } = new HashtableEntityFactory();
+
+            public override HashtableEntity Create(PowerShellContext cx, (HashtableAst, HashtableAst) init) =>
+                new HashtableEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IfStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IfStatementEntity.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class IfStatementEntity : CachedEntity<(IfStatementAst, IfStatementAst)>
+    {
+        private IfStatementEntity(PowerShellContext cx, IfStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public IfStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.if_statement(this);
+            trapFile.if_statement_location(this, TrapSuitableLocation);
+            for(int index = 0; index < Fragment.Clauses.Count; index++)
+            {
+                var item1 = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Clauses[index].Item1); 
+                var item2 = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Clauses[index].Item2); 
+                trapFile.if_statement_clause(this, index, item1, item2);
+                index++; 
+            }
+            if (Fragment.ElseClause is not null)
+            {
+                trapFile.if_statement_else(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.ElseClause));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";if_statement");
+        }
+
+        internal static IfStatementEntity Create(PowerShellContext cx, IfStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return IfStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class IfStatementEntityFactory : CachedEntityFactory<(IfStatementAst, IfStatementAst), IfStatementEntity>
+        {
+            public static IfStatementEntityFactory Instance { get; } = new IfStatementEntityFactory();
+
+            public override IfStatementEntity Create(PowerShellContext cx, (IfStatementAst, IfStatementAst) init) =>
+                new IfStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IndexExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IndexExpressionEntity.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class IndexExpressionEntity : CachedEntity<(IndexExpressionAst, IndexExpressionAst)>
+    {
+        private IndexExpressionEntity(PowerShellContext cx, IndexExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public IndexExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var index = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Index);
+            var target = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Target);
+            trapFile.index_expression(this, index, target, Fragment.NullConditional);
+            trapFile.index_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";index_expression");
+        }
+
+        internal static IndexExpressionEntity Create(PowerShellContext cx, IndexExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return IndexExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class IndexExpressionEntityFactory : CachedEntityFactory<(IndexExpressionAst, IndexExpressionAst), IndexExpressionEntity>
+        {
+            public static IndexExpressionEntityFactory Instance { get; } = new IndexExpressionEntityFactory();
+
+            public override IndexExpressionEntity Create(PowerShellContext cx, (IndexExpressionAst, IndexExpressionAst) init) =>
+                new IndexExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/InvokeMemberExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/InvokeMemberExpressionEntity.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class InvokeMemberExpressionEntity : CachedEntity<(InvokeMemberExpressionAst, InvokeMemberExpressionAst)>
+    {
+        private InvokeMemberExpressionEntity(PowerShellContext cx, InvokeMemberExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public InvokeMemberExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var expression = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Expression);
+            var member = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Member);
+            trapFile.invoke_member_expression(this, expression, member);
+            trapFile.invoke_member_expression_location(this, TrapSuitableLocation);
+            if (Fragment.Arguments is not null)
+            {
+                for (int index = 0; index < Fragment.Arguments.Count; index++)
+                {
+                    var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Arguments[index]);
+                    trapFile.invoke_member_expression_argument(this, index, entity);
+                }
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";invoke_member_expression");
+        }
+
+        internal static InvokeMemberExpressionEntity Create(PowerShellContext cx, InvokeMemberExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return InvokeMemberExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class InvokeMemberExpressionEntityFactory : CachedEntityFactory<(InvokeMemberExpressionAst, InvokeMemberExpressionAst), InvokeMemberExpressionEntity>
+        {
+            public static InvokeMemberExpressionEntityFactory Instance { get; } = new InvokeMemberExpressionEntityFactory();
+
+            public override InvokeMemberExpressionEntity Create(PowerShellContext cx, (InvokeMemberExpressionAst, InvokeMemberExpressionAst) init) =>
+                new InvokeMemberExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MemberExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MemberExpressionEntity.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+using System.Reflection;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class MemberExpressionEntity : CachedEntity<(MemberExpressionAst, MemberExpressionAst)>
+    {
+        private MemberExpressionEntity(PowerShellContext cx, MemberExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public MemberExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var expression = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Expression);
+            var member = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Member);
+            trapFile.member_expression(this, expression, member, Fragment.NullConditional, Fragment.Static);
+            trapFile.member_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";member_expression");
+        }
+
+        internal static MemberExpressionEntity Create(PowerShellContext cx, MemberExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return MemberExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class MemberExpressionEntityFactory : CachedEntityFactory<(MemberExpressionAst, MemberExpressionAst), MemberExpressionEntity>
+        {
+            public static MemberExpressionEntityFactory Instance { get; } = new MemberExpressionEntityFactory();
+
+            public override MemberExpressionEntity Create(PowerShellContext cx, (MemberExpressionAst, MemberExpressionAst) init) =>
+                new MemberExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MergingRedirectionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MergingRedirectionEntity.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class MergingRedirectionEntity : CachedEntity<(MergingRedirectionAst, MergingRedirectionAst)>
+    {
+        private MergingRedirectionEntity(PowerShellContext cx, MergingRedirectionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public MergingRedirectionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.merging_redirection(this, Fragment.FromStream, Fragment.ToStream);
+            trapFile.merging_redirection_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";merging_redirection");
+        }
+
+        internal static MergingRedirectionEntity Create(PowerShellContext cx, MergingRedirectionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return MergingRedirectionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class MergingRedirectionEntityFactory : CachedEntityFactory<(MergingRedirectionAst, MergingRedirectionAst), MergingRedirectionEntity>
+        {
+            public static MergingRedirectionEntityFactory Instance { get; } = new MergingRedirectionEntityFactory();
+
+            public override MergingRedirectionEntity Create(PowerShellContext cx, (MergingRedirectionAst, MergingRedirectionAst) init) =>
+                new MergingRedirectionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ModuleSpecificationEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ModuleSpecificationEntity.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+using Microsoft.PowerShell.Commands;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ModuleSpecificationEntity : CachedEntity<(ModuleSpecification, Microsoft.CodeAnalysis.Location)>
+    {
+        private ModuleSpecificationEntity(PowerShellContext cx, ModuleSpecification fragment, Microsoft.CodeAnalysis.Location location)
+            : base(cx, (fragment, location))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => Symbol.Item2;
+        public ModuleSpecification Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.module_specification(this, Fragment.Name, Fragment.Guid?.ToString() ?? string.Empty, Fragment.MaximumVersion ?? string.Empty, Fragment.RequiredVersion?.ToString() ?? string.Empty, Fragment.Version?.ToString() ?? string.Empty);
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";module_specification");
+        }
+
+        internal static ModuleSpecificationEntity Create(PowerShellContext cx, ModuleSpecification fragment, Microsoft.CodeAnalysis.Location location)
+        {
+            var init = (fragment, location);
+            return ModuleSpecificationEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ModuleSpecificationEntityFactory : CachedEntityFactory<(ModuleSpecification, Microsoft.CodeAnalysis.Location), ModuleSpecificationEntity>
+        {
+            public static ModuleSpecificationEntityFactory Instance { get; } = new ModuleSpecificationEntityFactory();
+
+            public override ModuleSpecificationEntity Create(PowerShellContext cx, (ModuleSpecification, Microsoft.CodeAnalysis.Location) init) =>
+                new ModuleSpecificationEntity(cx, init.Item1, init.Item2);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedAttributeArgumentEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedAttributeArgumentEntity.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class NamedAttributeArgumentEntity : CachedEntity<(NamedAttributeArgumentAst, NamedAttributeArgumentAst)>
+    {
+        private NamedAttributeArgumentEntity(PowerShellContext cx, NamedAttributeArgumentAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public NamedAttributeArgumentAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.named_attribute_argument(this, Fragment.ArgumentName,
+                EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Argument));
+            trapFile.named_attribute_argument_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";named_attribute_argument");
+        }
+
+        internal static NamedAttributeArgumentEntity Create(PowerShellContext cx, NamedAttributeArgumentAst fragment)
+        {
+            var init = (fragment, fragment);
+            return NamedAttributeArgumentEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class NamedAttributeArgumentEntityFactory : CachedEntityFactory<(NamedAttributeArgumentAst, NamedAttributeArgumentAst), NamedAttributeArgumentEntity>
+        {
+            public static NamedAttributeArgumentEntityFactory Instance { get; } = new NamedAttributeArgumentEntityFactory();
+
+            public override NamedAttributeArgumentEntity Create(PowerShellContext cx, (NamedAttributeArgumentAst, NamedAttributeArgumentAst) init) =>
+                new NamedAttributeArgumentEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedBlockEntity.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class NamedBlockEntity : CachedEntity<(NamedBlockAst, NamedBlockAst)>
+    {
+        private NamedBlockEntity(PowerShellContext cx, NamedBlockAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public NamedBlockAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.named_block(this, Fragment.Statements.Count, Fragment.Traps?.Count ?? 0);
+            trapFile.named_block_location(this, TrapSuitableLocation);
+            for(int index = 0; index < Fragment.Statements?.Count; index++)
+            {
+                trapFile.named_block_statement(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Statements[index]));
+            }
+            for(int index = 0; index < Fragment.Traps?.Count; index++)
+            {
+                trapFile.named_block_trap(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Traps[index]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";named_block");
+        }
+
+        internal static NamedBlockEntity Create(PowerShellContext cx, NamedBlockAst fragment)
+        {
+            var init = (fragment, fragment);
+            return NamedBlockEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class NamedBlockEntityFactory : CachedEntityFactory<(NamedBlockAst, NamedBlockAst), NamedBlockEntity>
+        {
+            public static NamedBlockEntityFactory Instance { get; } = new NamedBlockEntityFactory();
+
+            public override NamedBlockEntity Create(PowerShellContext cx, (NamedBlockAst, NamedBlockAst) init) =>
+                new NamedBlockEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NotImplementedEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NotImplementedEntity.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class NotImplementedEntity : CachedEntity<(Ast, Type)>
+    {
+        private NotImplementedEntity(PowerShellContext cx, Ast fragment, Type type)
+            : base(cx, (fragment, type))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public Ast Fragment => Symbol.Item1;
+        public Type type => Symbol.Item2;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.not_implemented(this, type.FullName ?? type.Name);
+            trapFile.not_implemented_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";not_implemented");
+        }
+
+        internal static NotImplementedEntity Create(PowerShellContext cx, Ast fragment, Type type)
+        {
+            var init = (fragment, type);
+            return NotImplementedEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class NotImplementedEntityFactory : CachedEntityFactory<(Ast, Type), NotImplementedEntity>
+        {
+            public static NotImplementedEntityFactory Instance { get; } = new NotImplementedEntityFactory();
+
+            public override NotImplementedEntity Create(PowerShellContext cx, (Ast, Type) init) =>
+                new NotImplementedEntity(cx, init.Item1, init.Item2);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParamBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParamBlockEntity.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ParamBlockEntity : CachedEntity<(ParamBlockAst, ParamBlockAst)>
+    {
+        private ParamBlockEntity(PowerShellContext cx, ParamBlockAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ParamBlockAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.param_block(this, Fragment.Attributes.Count, Fragment.Parameters.Count);
+            trapFile.param_block_location(this, TrapSuitableLocation);
+            for (int i = 0; i < Fragment.Attributes.Count; i++)
+            {
+                trapFile.param_block_attribute(this, i, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attributes[i]));
+            }
+
+            for (int i = 0; i < Fragment.Parameters.Count; i++)
+            {
+                trapFile.param_block_parameter(this, i,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parameters[i]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";param_block");
+        }
+
+        internal static ParamBlockEntity Create(PowerShellContext cx, ParamBlockAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ParamBlockEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ParamBlockEntityFactory : CachedEntityFactory<(ParamBlockAst, ParamBlockAst), ParamBlockEntity>
+        {
+            public static ParamBlockEntityFactory Instance { get; } = new ParamBlockEntityFactory();
+
+            public override ParamBlockEntity Create(PowerShellContext cx, (ParamBlockAst, ParamBlockAst) init) =>
+                new ParamBlockEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParameterEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParameterEntity.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+using System.Reflection.Metadata;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ParameterEntity : CachedEntity<(ParameterAst, ParameterAst)>
+    {
+        private ParameterEntity(PowerShellContext cx, ParameterAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ParameterAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.parameter(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Name), Fragment.StaticType.Name, Fragment.Attributes.Count);
+            trapFile.parameter_location(this, TrapSuitableLocation);
+            for (int i = 0; i < Fragment.Attributes.Count; i++)
+            {
+                trapFile.parameter_attribute(this, i,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attributes[i]));
+            }
+
+            if (Fragment.DefaultValue is not null)
+            {
+                var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.DefaultValue);
+                trapFile.parameter_default_value(this, entity);
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";parameter");
+        }
+
+        internal static ParameterEntity Create(PowerShellContext cx, ParameterAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ParameterEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ParameterEntityFactory : CachedEntityFactory<(ParameterAst, ParameterAst), ParameterEntity>
+        {
+            public static ParameterEntityFactory Instance { get; } = new ParameterEntityFactory();
+
+            public override ParameterEntity Create(PowerShellContext cx, (ParameterAst, ParameterAst) init) =>
+                new ParameterEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParenExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParenExpressionEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ParenExpressionEntity : CachedEntity<(ParenExpressionAst, ParenExpressionAst)>
+    {
+        private ParenExpressionEntity(PowerShellContext cx, ParenExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ParenExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.paren_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
+            trapFile.paren_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";paren_expression");
+        }
+
+        internal static ParenExpressionEntity Create(PowerShellContext cx, ParenExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ParenExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ParenExpressionEntityFactory : CachedEntityFactory<(ParenExpressionAst, ParenExpressionAst), ParenExpressionEntity>
+        {
+            public static ParenExpressionEntityFactory Instance { get; } = new ParenExpressionEntityFactory();
+
+            public override ParenExpressionEntity Create(PowerShellContext cx, (ParenExpressionAst, ParenExpressionAst) init) =>
+                new ParenExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineChainEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineChainEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class PipelineChainEntity : CachedEntity<(PipelineChainAst, PipelineChainAst)>
+    {
+        private PipelineChainEntity(PowerShellContext cx, PipelineChainAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public PipelineChainAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.pipeline_chain(this, Fragment.Background, Fragment.Operator, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.LhsPipelineChain), EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.RhsPipeline));
+            trapFile.pipeline_chain_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";pipeline_chain");
+        }
+
+        internal static PipelineChainEntity Create(PowerShellContext cx, PipelineChainAst fragment)
+        {
+            var init = (fragment, fragment);
+            return PipelineChainEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class PipelineChainEntityFactory : CachedEntityFactory<(PipelineChainAst, PipelineChainAst), PipelineChainEntity>
+        {
+            public static PipelineChainEntityFactory Instance { get; } = new PipelineChainEntityFactory();
+
+            public override PipelineChainEntity Create(PowerShellContext cx, (PipelineChainAst, PipelineChainAst) init) =>
+                new PipelineChainEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineEntity.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class PipelineEntity : CachedEntity<(PipelineAst, PipelineAst)>
+    {
+        private PipelineEntity(PowerShellContext cx, PipelineAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public PipelineAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.pipeline(this, Fragment.PipelineElements.Count);
+            trapFile.pipeline_location(this, TrapSuitableLocation);
+            for (var index = 0; index < Fragment.PipelineElements.Count; index++)
+            {
+                var subEntity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.PipelineElements[index]);
+                trapFile.pipeline_component(this, index, subEntity);
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";pipeline");
+        }
+
+        internal static PipelineEntity Create(PowerShellContext cx, PipelineAst fragment)
+        {
+            var init = (fragment, fragment);
+            return PipelineEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class PipelineEntityFactory : CachedEntityFactory<(PipelineAst, PipelineAst), PipelineEntity>
+        {
+            public static PipelineEntityFactory Instance { get; } = new PipelineEntityFactory();
+
+            public override PipelineEntity Create(PowerShellContext cx, (PipelineAst, PipelineAst) init) =>
+                new PipelineEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PropertyMemberEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PropertyMemberEntity.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class PropertyMemberEntity : CachedEntity<(PropertyMemberAst, PropertyMemberAst)>
+    {
+        private PropertyMemberEntity(PowerShellContext cx, PropertyMemberAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public PropertyMemberAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.property_member(this, Fragment.IsHidden, Fragment.IsPrivate, Fragment.IsPublic, Fragment.IsStatic, Fragment.Name, Fragment.PropertyAttributes);
+            trapFile.property_member_location(this, TrapSuitableLocation);
+            for(int index = 0; index < Fragment.Attributes.Count; index++)
+            {
+                trapFile.property_member_attribute(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attributes[index]));
+            }
+            if (Fragment.PropertyType is not null)
+            {
+                trapFile.property_member_property_type(this, TypeConstraintEntity.Create(PowerShellContext, Fragment.PropertyType));
+            }
+            if (Fragment.InitialValue is not null)
+            {
+                trapFile.property_member_initial_value(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.InitialValue));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";property_member");
+        }
+
+        internal static PropertyMemberEntity Create(PowerShellContext cx, PropertyMemberAst fragment)
+        {
+            var init = (fragment, fragment);
+            return PropertyMemberEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class PropertyMemberEntityFactory : CachedEntityFactory<(PropertyMemberAst, PropertyMemberAst), PropertyMemberEntity>
+        {
+            public static PropertyMemberEntityFactory Instance { get; } = new PropertyMemberEntityFactory();
+
+            public override PropertyMemberEntity Create(PowerShellContext cx, (PropertyMemberAst, PropertyMemberAst) init) =>
+                new PropertyMemberEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ReturnStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ReturnStatementEntity.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ReturnStatementEntity : CachedEntity<(ReturnStatementAst, ReturnStatementAst)>
+    {
+        private ReturnStatementEntity(PowerShellContext cx, ReturnStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ReturnStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.return_statement(this);
+            if (Fragment.Pipeline is not null)
+            {
+                trapFile.return_statement_pipeline(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
+            }
+            trapFile.return_statement_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";continue_statement");
+        }
+
+        internal static ReturnStatementEntity Create(PowerShellContext cx, ReturnStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ReturnStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ReturnStatementEntityFactory : CachedEntityFactory<(ReturnStatementAst, ReturnStatementAst), ReturnStatementEntity>
+        {
+            public static ReturnStatementEntityFactory Instance { get; } = new ReturnStatementEntityFactory();
+
+            public override ReturnStatementEntity Create(PowerShellContext cx, (ReturnStatementAst, ReturnStatementAst) init) =>
+                new ReturnStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockEntity.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ScriptBlockEntity : CachedEntity<(ScriptBlockAst, ScriptBlockAst)>
+    {
+        private ScriptBlockEntity(PowerShellContext cx, ScriptBlockAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ScriptBlockAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.script_block(this, Fragment.UsingStatements.Count, Fragment.ScriptRequirements?.RequiredModules.Count ?? 0, Fragment.ScriptRequirements?.RequiredAssemblies.Count ?? 0, Fragment.ScriptRequirements?.RequiredPSEditions.Count ?? 0, Fragment.ScriptRequirements?.RequiresPSSnapIns.Count ?? 0);
+            trapFile.script_block_location(this, TrapSuitableLocation);
+            if (Fragment.ScriptRequirements is not null){
+                trapFile.script_block_requires_elevation(this, Fragment.ScriptRequirements.IsElevationRequired);
+                if (Fragment.ScriptRequirements.RequiredApplicationId is not null)
+                {
+                    trapFile.script_block_required_application_id(this, Fragment.ScriptRequirements.RequiredApplicationId);
+                }
+                if (Fragment.ScriptRequirements.RequiredPSVersion is not null)
+                {
+                    trapFile.script_block_required_ps_version(this, Fragment.ScriptRequirements.RequiredPSVersion.ToString());
+                }
+                for(int i = 0; i < Fragment.ScriptRequirements.RequiredModules.Count; i++)
+                {
+                    var theModule = ModuleSpecificationEntity.Create(PowerShellContext, Fragment.ScriptRequirements.RequiredModules[i], ReportingLocation);
+                    trapFile.script_block_required_module(this, i, theModule);
+                }
+                for (int i = 0; i < Fragment.ScriptRequirements.RequiredAssemblies.Count; i++)
+                {
+                    trapFile.script_block_required_assembly(this, i, Fragment.ScriptRequirements.RequiredAssemblies[i]);
+                }
+                for (int i = 0; i < Fragment.ScriptRequirements.RequiredPSEditions.Count; i++)
+                {
+                    trapFile.script_block_required_ps_edition(this, i, Fragment.ScriptRequirements.RequiredPSEditions[i]);
+                }
+                for (int i = 0; i < Fragment.ScriptRequirements.RequiresPSSnapIns.Count; i++)
+                {
+                    trapFile.script_block_requires_ps_snapin(this, i, Fragment.ScriptRequirements.RequiresPSSnapIns[i].Name, Fragment.ScriptRequirements.RequiresPSSnapIns[i].Version.ToString());
+                }
+            }
+            if (Fragment.ParamBlock is not null)
+            {
+                trapFile.script_block_param_block(this,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.ParamBlock));
+            }
+
+            if (Fragment.BeginBlock is not null)
+            {
+                trapFile.script_block_begin_block(this,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.BeginBlock));
+            }
+
+            if (Fragment.CleanBlock is not null)
+            {
+                trapFile.script_block_clean_block(this,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CleanBlock));
+            }
+
+            if (Fragment.DynamicParamBlock is not null)
+            {
+                trapFile.script_block_dynamic_param_block(this,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.DynamicParamBlock));
+            }
+            
+            if (Fragment.EndBlock is not null)
+            {
+                trapFile.script_block_end_block(this,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.EndBlock));
+            }
+            
+            if (Fragment.ProcessBlock is not null)
+            {            
+                trapFile.script_block_process_block(this,
+                EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.ProcessBlock));
+            }
+
+            // TODO: Fragment.Requirements, need a non-null example
+            
+            for (int index = 0; index < Fragment.UsingStatements.Count; index++)
+            {
+                trapFile.script_block_using(this, index,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.UsingStatements[index]));
+            }
+
+            if (Fragment.Parent is not null)
+            {
+                trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            }
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";script_block");
+        }
+
+        internal static ScriptBlockEntity Create(PowerShellContext cx, ScriptBlockAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ScriptBlockEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ScriptBlockEntityFactory : CachedEntityFactory<(ScriptBlockAst, ScriptBlockAst), ScriptBlockEntity>
+        {
+            public static ScriptBlockEntityFactory Instance { get; } = new ScriptBlockEntityFactory();
+
+            public override ScriptBlockEntity Create(PowerShellContext cx, (ScriptBlockAst, ScriptBlockAst) init) =>
+                new ScriptBlockEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockExpressionEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ScriptBlockExpressionEntity : CachedEntity<(ScriptBlockExpressionAst, ScriptBlockExpressionAst)>
+    {
+        private ScriptBlockExpressionEntity(PowerShellContext cx, ScriptBlockExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ScriptBlockExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.script_block_expression(this, ScriptBlockEntity.Create(PowerShellContext, Fragment.ScriptBlock));
+            trapFile.script_block_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";script_block_expression");
+        }
+
+        internal static ScriptBlockExpressionEntity Create(PowerShellContext cx, ScriptBlockExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ScriptBlockExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ScriptBlockExpressionEntityFactory : CachedEntityFactory<(ScriptBlockExpressionAst, ScriptBlockExpressionAst), ScriptBlockExpressionEntity>
+        {
+            public static ScriptBlockExpressionEntityFactory Instance { get; } = new ScriptBlockExpressionEntityFactory();
+
+            public override ScriptBlockExpressionEntity Create(PowerShellContext cx, (ScriptBlockExpressionAst, ScriptBlockExpressionAst) init) =>
+                new ScriptBlockExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StatementBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StatementBlockEntity.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class StatementBlockEntity : CachedEntity<(StatementBlockAst, StatementBlockAst)>
+    {
+        private StatementBlockEntity(PowerShellContext cx, StatementBlockAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public StatementBlockAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.statement_block(this, Fragment.Statements.Count, Fragment.Traps?.Count ?? 0);
+            trapFile.statement_block_location(this, TrapSuitableLocation);
+            
+            for (int index = 0; index < Fragment.Statements.Count; index++)
+            {
+                trapFile.statement_block_statement(this, index,
+                    EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Statements[index]));
+            }
+
+            if (Fragment.Traps is not null)
+            {
+                for (int index = 0; index < Fragment.Traps.Count; index++)
+                {
+                    trapFile.statement_block_trap(this, index,
+                        EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Traps[index]));
+                }
+            }
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";statement_block");
+        }
+
+        internal static StatementBlockEntity Create(PowerShellContext cx, StatementBlockAst fragment)
+        {
+            var init = (fragment, fragment);
+            return StatementBlockEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class StatementBlockEntityFactory : CachedEntityFactory<(StatementBlockAst, StatementBlockAst), StatementBlockEntity>
+        {
+            public static StatementBlockEntityFactory Instance { get; } = new StatementBlockEntityFactory();
+
+            public override StatementBlockEntity Create(PowerShellContext cx, (StatementBlockAst, StatementBlockAst) init) =>
+                new StatementBlockEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StringConstantExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StringConstantExpressionEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class StringConstantExpressionEntity : CachedEntity<(StringConstantExpressionAst, StringConstantExpressionAst)>
+    {
+        private StringConstantExpressionEntity(PowerShellContext cx, StringConstantExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public StringConstantExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.string_constant_expression(this, StringLiteralEntity.Create(PowerShellContext, ReportingLocation, Fragment.Value));
+            trapFile.string_constant_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";string_constant_expression");
+        }
+
+        internal static StringConstantExpressionEntity Create(PowerShellContext cx, StringConstantExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return StringConstantExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class StringConstantExpressionEntityFactory : CachedEntityFactory<(StringConstantExpressionAst, StringConstantExpressionAst), StringConstantExpressionEntity>
+        {
+            public static StringConstantExpressionEntityFactory Instance { get; } = new StringConstantExpressionEntityFactory();
+
+            public override StringConstantExpressionEntity Create(PowerShellContext cx, (StringConstantExpressionAst, StringConstantExpressionAst) init) =>
+                new StringConstantExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SubExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SubExpressionEntity.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+using System.Reflection;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class SubExpressionEntity : CachedEntity<(SubExpressionAst, SubExpressionAst)>
+    {
+        private SubExpressionEntity(PowerShellContext cx, SubExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public SubExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var subExpression = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.SubExpression);
+            trapFile.sub_expression(this, subExpression);
+            trapFile.sub_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";sub_expression");
+        }
+
+        internal static SubExpressionEntity Create(PowerShellContext cx, SubExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return SubExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class SubExpressionEntityFactory : CachedEntityFactory<(SubExpressionAst, SubExpressionAst), SubExpressionEntity>
+        {
+            public static SubExpressionEntityFactory Instance { get; } = new SubExpressionEntityFactory();
+
+            public override SubExpressionEntity Create(PowerShellContext cx, (SubExpressionAst, SubExpressionAst) init) =>
+                new SubExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SwitchStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SwitchStatementEntity.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class SwitchStatementEntity : CachedEntity<(SwitchStatementAst, SwitchStatementAst)>
+    {
+        private SwitchStatementEntity(PowerShellContext cx, SwitchStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public SwitchStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.switch_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition), Fragment.Flags);
+            trapFile.switch_statement_location(this, TrapSuitableLocation);
+            for(int index = 0; index < Fragment.Clauses.Count; index++)
+            {
+                trapFile.switch_statement_clauses(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Clauses[index].Item1), EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Clauses[index].Item2));
+            }
+            if (Fragment.Default is not null)
+            {
+                trapFile.switch_statement_default(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Default));
+            }
+            if (Fragment.Label is not null)
+            {
+                trapFile.label(this, Fragment.Label);
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";switch_statement");
+        }
+
+        internal static SwitchStatementEntity Create(PowerShellContext cx, SwitchStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return SwitchStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class SwitchStatementEntityFactory : CachedEntityFactory<(SwitchStatementAst, SwitchStatementAst), SwitchStatementEntity>
+        {
+            public static SwitchStatementEntityFactory Instance { get; } = new SwitchStatementEntityFactory();
+
+            public override SwitchStatementEntity Create(PowerShellContext cx, (SwitchStatementAst, SwitchStatementAst) init) =>
+                new SwitchStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TernaryExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TernaryExpressionEntity.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class TernaryExpressionEntity : CachedEntity<(TernaryExpressionAst, TernaryExpressionAst)>
+    {
+        
+        private TernaryExpressionEntity(PowerShellContext cx, TernaryExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public TernaryExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            var condition = EntityConstructor.ConstructAppropriateEntity(PowerShellContext,Fragment.Condition);
+            var ifFalse = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.IfFalse);
+            var ifTrue = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.IfTrue);
+
+            trapFile.ternary_expression(this, condition, ifFalse, ifTrue);
+            trapFile.ternary_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";ternary_expression");
+        }
+
+        internal static TernaryExpressionEntity Create(PowerShellContext cx, TernaryExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return TernaryExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class TernaryExpressionEntityFactory : CachedEntityFactory<(TernaryExpressionAst, TernaryExpressionAst), TernaryExpressionEntity>
+        {
+            public static TernaryExpressionEntityFactory Instance { get; } = new TernaryExpressionEntityFactory();
+
+            public override TernaryExpressionEntity Create(PowerShellContext cx, (TernaryExpressionAst, TernaryExpressionAst) init) =>
+                new TernaryExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ThrowStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ThrowStatementEntity.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class ThrowStatementEntity : CachedEntity<(ThrowStatementAst, ThrowStatementAst)>
+    {
+        private ThrowStatementEntity(PowerShellContext cx, ThrowStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public ThrowStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.throw_statement(this, Fragment.IsRethrow);
+            trapFile.throw_statement_location(this, TrapSuitableLocation);
+            if (Fragment.Pipeline is not null)
+            {
+                trapFile.throw_statement_pipeline(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";throw_statement");
+        }
+
+        internal static ThrowStatementEntity Create(PowerShellContext cx, ThrowStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return ThrowStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class ThrowStatementEntityFactory : CachedEntityFactory<(ThrowStatementAst, ThrowStatementAst), ThrowStatementEntity>
+        {
+            public static ThrowStatementEntityFactory Instance { get; } = new ThrowStatementEntityFactory();
+
+            public override ThrowStatementEntity Create(PowerShellContext cx, (ThrowStatementAst, ThrowStatementAst) init) =>
+                new ThrowStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TokenEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TokenEntity.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class TokenEntity : CachedEntity<(Token, Token)>
+    {
+        private TokenEntity(PowerShellContext cx, Token fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.ExtentToAnalysisLocation(Fragment.Extent);
+        public Token Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.token(this, Fragment.HasError, Fragment.Kind, Fragment.Text, Fragment.TokenFlags);
+            trapFile.token_location(this, TrapSuitableLocation);
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";token");
+        }
+
+        internal static TokenEntity Create(PowerShellContext cx, Token fragment)
+        {
+            var init = (fragment, fragment);
+            return TokenEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class TokenEntityFactory : CachedEntityFactory<(Token, Token), TokenEntity>
+        {
+            public static TokenEntityFactory Instance { get; } = new TokenEntityFactory();
+
+            public override TokenEntity Create(PowerShellContext cx, (Token, Token) init) =>
+                new TokenEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TrapStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TrapStatementEntity.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class TrapStatementEntity : CachedEntity<(TrapStatementAst, TrapStatementAst)>
+    {
+        private TrapStatementEntity(PowerShellContext cx, TrapStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public TrapStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.trap_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body));
+
+            if (Fragment.TrapType is not null)
+            {
+                trapFile.trap_statement_type(this,
+                    (TypeConstraintEntity)EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.TrapType));
+            }
+
+            trapFile.trap_statement_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";trap_statement");
+        }
+
+        internal static TrapStatementEntity Create(PowerShellContext cx, TrapStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return TrapStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class TrapStatementEntityFactory : CachedEntityFactory<(TrapStatementAst, TrapStatementAst), TrapStatementEntity>
+        {
+            public static TrapStatementEntityFactory Instance { get; } = new TrapStatementEntityFactory();
+
+            public override TrapStatementEntity Create(PowerShellContext cx, (TrapStatementAst, TrapStatementAst) init) =>
+                new TrapStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TryStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TryStatementEntity.cs
@@ -1,0 +1,54 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class TryStatementEntity : CachedEntity<(TryStatementAst, TryStatementAst)>
+    {
+        private TryStatementEntity(PowerShellContext cx, TryStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public TryStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.try_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body));
+            for(int index = 0; index < Fragment.CatchClauses.Count; index++)
+            {
+                trapFile.try_statement_catch_clause(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CatchClauses[index]));
+            }
+            if (Fragment.Finally is not null)
+            {
+                trapFile.try_statement_finally(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Finally));
+            }
+            trapFile.try_statement_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";try_statement");
+        }
+
+        internal static TryStatementEntity Create(PowerShellContext cx, TryStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return TryStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class TryStatementEntityFactory : CachedEntityFactory<(TryStatementAst, TryStatementAst), TryStatementEntity>
+        {
+            public static TryStatementEntityFactory Instance { get; } = new TryStatementEntityFactory();
+
+            public override TryStatementEntity Create(PowerShellContext cx, (TryStatementAst, TryStatementAst) init) =>
+                new TryStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeConstraintEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeConstraintEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class TypeConstraintEntity : CachedEntity<(TypeConstraintAst, TypeConstraintAst)>
+    {
+        private TypeConstraintEntity(PowerShellContext cx, TypeConstraintAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public TypeConstraintAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.type_constraint(this, Fragment.TypeName.Name ?? string.Empty, Fragment.TypeName.FullName ?? string.Empty);
+            trapFile.type_constraint_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";type_constraint");
+        }
+
+        internal static TypeConstraintEntity Create(PowerShellContext cx, TypeConstraintAst fragment)
+        {
+            var init = (fragment, fragment);
+            return TypeConstraintEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class TypeConstraintEntityFactory : CachedEntityFactory<(TypeConstraintAst, TypeConstraintAst), TypeConstraintEntity>
+        {
+            public static TypeConstraintEntityFactory Instance { get; } = new TypeConstraintEntityFactory();
+
+            public override TypeConstraintEntity Create(PowerShellContext cx, (TypeConstraintAst, TypeConstraintAst) init) =>
+                new TypeConstraintEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeDefinitionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeDefinitionEntity.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class TypeDefinitionEntity : CachedEntity<(TypeDefinitionAst, TypeDefinitionAst)>
+    {
+        
+        private TypeDefinitionEntity(PowerShellContext cx, TypeDefinitionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public TypeDefinitionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.type_definition(this, Fragment.Name, Fragment.TypeAttributes, Fragment.IsClass, Fragment.IsEnum, Fragment.IsInterface);
+            trapFile.type_definition_location(this, TrapSuitableLocation);
+            for(int index = 0; index < Fragment.Members.Count; index++)
+            {
+                trapFile.type_definition_members(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Members[index]));
+            }
+            for(int index = 0; index < Fragment.Attributes.Count; index++)
+            {
+                trapFile.type_definition_attributes(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attributes[index]));
+            }
+            for(int index = 0; index < Fragment.BaseTypes.Count; index++)
+            {
+                trapFile.type_definition_base_type(this, index, TypeConstraintEntity.Create(PowerShellContext, Fragment.BaseTypes[index]));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";type_definition");
+        }
+
+        internal static TypeDefinitionEntity Create(PowerShellContext cx, TypeDefinitionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return TypeDefinitionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class TypeDefinitionEntityFactory : CachedEntityFactory<(TypeDefinitionAst, TypeDefinitionAst), TypeDefinitionEntity>
+        {
+            public static TypeDefinitionEntityFactory Instance { get; } = new TypeDefinitionEntityFactory();
+
+            public override TypeDefinitionEntity Create(PowerShellContext cx, (TypeDefinitionAst, TypeDefinitionAst) init) =>
+                new TypeDefinitionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeExpressionEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class TypeExpressionEntity : CachedEntity<(TypeExpressionAst, TypeExpressionAst)>
+    {
+        private TypeExpressionEntity(PowerShellContext cx, TypeExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public TypeExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.type_expression(this, Fragment.TypeName.Name, Fragment.TypeName.FullName);
+            trapFile.type_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";type_expression");
+        }
+
+        internal static TypeExpressionEntity Create(PowerShellContext cx, TypeExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return TypeExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class TypeExpressionEntityFactory : CachedEntityFactory<(TypeExpressionAst, TypeExpressionAst), TypeExpressionEntity>
+        {
+            public static TypeExpressionEntityFactory Instance { get; } = new TypeExpressionEntityFactory();
+
+            public override TypeExpressionEntity Create(PowerShellContext cx, (TypeExpressionAst, TypeExpressionAst) init) =>
+                new TypeExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UnaryExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UnaryExpressionEntity.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class UnaryExpressionEntity : CachedEntity<(UnaryExpressionAst, UnaryExpressionAst)>
+    {
+        private UnaryExpressionEntity(PowerShellContext cx, UnaryExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public UnaryExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.unary_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Child), Fragment.TokenKind, Fragment.StaticType.Name);
+            trapFile.unary_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";unary_expression");
+        }
+
+        internal static UnaryExpressionEntity Create(PowerShellContext cx, UnaryExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return UnaryExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class UnaryExpressionEntityFactory : CachedEntityFactory<(UnaryExpressionAst, UnaryExpressionAst), UnaryExpressionEntity>
+        {
+            public static UnaryExpressionEntityFactory Instance { get; } = new UnaryExpressionEntityFactory();
+
+            public override UnaryExpressionEntity Create(PowerShellContext cx, (UnaryExpressionAst, UnaryExpressionAst) init) =>
+                new UnaryExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingExpressionEntity.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class UsingExpressionEntity : CachedEntity<(UsingExpressionAst, UsingExpressionAst)>
+    {
+        private UsingExpressionEntity(PowerShellContext cx, UsingExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public UsingExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.using_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.SubExpression));
+            trapFile.using_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";using_expression");
+        }
+
+        internal static UsingExpressionEntity Create(PowerShellContext cx, UsingExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return UsingExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class UsingExpressionEntityFactory : CachedEntityFactory<(UsingExpressionAst, UsingExpressionAst), UsingExpressionEntity>
+        {
+            public static UsingExpressionEntityFactory Instance { get; } = new UsingExpressionEntityFactory();
+
+            public override UsingExpressionEntity Create(PowerShellContext cx, (UsingExpressionAst, UsingExpressionAst) init) =>
+                new UsingExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingStatementEntity.cs
@@ -1,0 +1,58 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class UsingStatementEntity : CachedEntity<(UsingStatementAst, UsingStatementAst)>
+    {
+        private UsingStatementEntity(PowerShellContext cx, UsingStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public UsingStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.using_statement(this, Fragment.UsingStatementKind);
+            trapFile.using_statement_location(this, TrapSuitableLocation);
+            if(Fragment.Alias is not null)
+            {
+                trapFile.using_statement_alias(this, StringConstantExpressionEntity.Create(PowerShellContext, Fragment.Alias));
+            }
+            if (Fragment.Name is not null)
+            {
+                trapFile.using_statement_name(this, StringConstantExpressionEntity.Create(PowerShellContext, Fragment.Name));
+            }
+            if (Fragment.ModuleSpecification is not null)
+            {
+                trapFile.using_statement_module_specification(this, HashtableEntity.Create(PowerShellContext, Fragment.ModuleSpecification));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";using_statement");
+        }
+
+        internal static UsingStatementEntity Create(PowerShellContext cx, UsingStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return UsingStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class UsingStatementEntityFactory : CachedEntityFactory<(UsingStatementAst, UsingStatementAst), UsingStatementEntity>
+        {
+            public static UsingStatementEntityFactory Instance { get; } = new UsingStatementEntityFactory();
+
+            public override UsingStatementEntity Create(PowerShellContext cx, (UsingStatementAst, UsingStatementAst) init) =>
+                new UsingStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/VariableExpressionAst.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/VariableExpressionAst.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class VariableExpressionEntity : CachedEntity<(VariableExpressionAst, VariableExpressionAst)>
+    {
+        private VariableExpressionEntity(PowerShellContext cx, VariableExpressionAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public VariableExpressionAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.variable_expression(this, Fragment.VariablePath.UserPath, Fragment.VariablePath.DriveName ?? string.Empty, Fragment.IsConstantVariable(),
+                Fragment.VariablePath.IsGlobal, Fragment.VariablePath.IsLocal, Fragment.VariablePath.IsPrivate,
+                Fragment.VariablePath.IsScript, Fragment.VariablePath.IsUnqualified,
+                Fragment.VariablePath.IsUnscopedVariable, Fragment.VariablePath.IsVariable,
+                Fragment.VariablePath.IsDriveQualified);
+            trapFile.variable_expression_location(this, TrapSuitableLocation);
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";variable_expression");
+        }
+
+        internal static VariableExpressionEntity Create(PowerShellContext cx, VariableExpressionAst fragment)
+        {
+            var init = (fragment, fragment);
+            return VariableExpressionEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class VariableExpressionEntityFactory : CachedEntityFactory<(VariableExpressionAst, VariableExpressionAst), VariableExpressionEntity>
+        {
+            public static VariableExpressionEntityFactory Instance { get; } = new VariableExpressionEntityFactory();
+
+            public override VariableExpressionEntity Create(PowerShellContext cx, (VariableExpressionAst, VariableExpressionAst) init) =>
+                new VariableExpressionEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/WhileStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/WhileStatementEntity.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Entities
+{
+    internal class WhileStatementEntity : CachedEntity<(WhileStatementAst, WhileStatementAst)>
+    {
+        private WhileStatementEntity(PowerShellContext cx, WhileStatementAst fragment)
+            : base(cx, (fragment, fragment))
+        {
+        }
+
+        public override Microsoft.CodeAnalysis.Location ReportingLocation => PowerShellContext.CreateAnalysisLocation(Fragment);
+        public WhileStatementAst Fragment => Symbol.Item1;
+        public override void Populate(TextWriter trapFile)
+        {
+            // Condition can be null only if this is a For statement so For Statement must be parsed first
+            trapFile.while_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body));
+            trapFile.while_statement_location(this, TrapSuitableLocation);
+            if (Fragment.Label is not null)
+            {
+                trapFile.label(this, Fragment.Label);
+            }
+
+            if (Fragment.Condition is not null)
+            {
+                trapFile.while_statement_condition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition));
+            }
+            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(TrapSuitableLocation);
+            trapFile.Write(";while_statement");
+        }
+
+        internal static WhileStatementEntity Create(PowerShellContext cx, WhileStatementAst fragment)
+        {
+            var init = (fragment, fragment);
+            return WhileStatementEntityFactory.Instance.CreateEntity(cx, init, init);
+        }
+
+        private class WhileStatementEntityFactory : CachedEntityFactory<(WhileStatementAst, WhileStatementAst), WhileStatementEntity>
+        {
+            public static WhileStatementEntityFactory Instance { get; } = new WhileStatementEntityFactory();
+
+            public override WhileStatementEntity Create(PowerShellContext cx, (WhileStatementAst, WhileStatementAst) init) =>
+                new WhileStatementEntity(cx, init.Item1);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/EntityConstructor.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/EntityConstructor.cs
@@ -1,0 +1,93 @@
+﻿using System.Management.Automation.Language;
+using System.Management.Automation.Runspaces;
+using Semmle.Extraction.PowerShell.Entities;
+
+namespace Semmle.Extraction.PowerShell;
+
+public static class EntityConstructor
+{
+    public static Entity ConstructAppropriateEntity(PowerShellContext powerShellContext, Ast ast)
+    {
+        return ast switch
+        {
+            AssignmentStatementAst assignmentStatementAst => AssignmentStatementEntity.Create(powerShellContext, assignmentStatementAst),
+            ArrayExpressionAst arrayExpressionAst => ArrayExpressionEntity.Create(powerShellContext, arrayExpressionAst),
+            ArrayLiteralAst arrayLiteralAst => ArrayLiteralEntity.Create(powerShellContext, arrayLiteralAst),
+            BinaryExpressionAst binaryExpressionAst => BinaryExpressionEntity.Create(powerShellContext, binaryExpressionAst),
+            CommandAst commandAst => CommandEntity.Create(powerShellContext,  commandAst),
+            CommandExpressionAst commandExpressionAst => CommandExpressionEntity.Create(powerShellContext, commandExpressionAst),
+            CommandParameterAst commandParameterAst => CommandParameterEntity.Create(powerShellContext, commandParameterAst),
+            ConvertExpressionAst convertExpressionAst => ConvertExpressionEntity.Create(powerShellContext, convertExpressionAst),
+            ExitStatementAst exitStatementAst => ExitStatementEntity.Create(powerShellContext,exitStatementAst),
+            IndexExpressionAst indexExpressionAst => IndexExpressionEntity.Create(powerShellContext, indexExpressionAst),
+            InvokeMemberExpressionAst invokeMemberExpressionAst => InvokeMemberExpressionEntity.Create(powerShellContext, invokeMemberExpressionAst),
+            MemberExpressionAst memberExpressionAst => MemberExpressionEntity.Create(powerShellContext, memberExpressionAst),
+            NamedBlockAst namedBlockAst => NamedBlockEntity.Create(powerShellContext, namedBlockAst),
+            ParenExpressionAst parenExpressionAst => ParenExpressionEntity.Create(powerShellContext, parenExpressionAst),
+            PipelineAst pipelineAst => PipelineEntity.Create(powerShellContext, pipelineAst),
+            ScriptBlockAst scriptBlockAst => ScriptBlockEntity.Create(powerShellContext, scriptBlockAst),
+            StatementBlockAst statementBlockAst => StatementBlockEntity.Create(powerShellContext, statementBlockAst),
+            StringConstantExpressionAst stringConstantExpressionAst => StringConstantExpressionEntity.Create(powerShellContext, stringConstantExpressionAst),
+            SubExpressionAst subExpressionAst => SubExpressionEntity.Create(powerShellContext, subExpressionAst),
+            TernaryExpressionAst ternaryExpressionAst => TernaryExpressionEntity.Create(powerShellContext, ternaryExpressionAst),
+            TypeConstraintAst typeConstraintAst => TypeConstraintEntity.Create(powerShellContext, typeConstraintAst),
+            TypeExpressionAst typeExpressionAst => TypeExpressionEntity.Create(powerShellContext, typeExpressionAst),
+            VariableExpressionAst variableExpressionAst => VariableExpressionEntity.Create(powerShellContext, variableExpressionAst),
+            ParamBlockAst paramBlockAst => ParamBlockEntity.Create(powerShellContext, paramBlockAst),
+            ParameterAst parameterAst => ParameterEntity.Create(powerShellContext, parameterAst),
+            AttributeAst attributeAst => AttributeEntity.Create(powerShellContext, attributeAst),
+            FunctionDefinitionAst functionDefinitionAst => FunctionDefinitionEntity.Create(powerShellContext, functionDefinitionAst),
+            NamedAttributeArgumentAst namedAttributeArgumentAst => NamedAttributeArgumentEntity.Create(powerShellContext, namedAttributeArgumentAst),
+            BreakStatementAst breakStatementAst => BreakStatementEntity.Create(powerShellContext, breakStatementAst),
+            ForEachStatementAst forEachStatementAst => ForEachStatementEntity.Create(powerShellContext, forEachStatementAst),
+            ContinueStatementAst continueStatementAst => ContinueStatementEntity.Create(powerShellContext, continueStatementAst),
+            ReturnStatementAst returnStatementAst => ReturnStatementEntity.Create(powerShellContext, returnStatementAst),
+            WhileStatementAst whileStatementAst => WhileStatementEntity.Create(powerShellContext, whileStatementAst),
+            DoUntilStatementAst doUntilStatementAst => DoUntilStatementEntity.Create(powerShellContext, doUntilStatementAst),
+            DoWhileStatementAst doWhileStatementAst => DoWhileStatementEntity.Create(powerShellContext, doWhileStatementAst),
+            ExpandableStringExpressionAst expandableStringExpressionAst => ExpandableStringExpressionEntity.Create(powerShellContext, expandableStringExpressionAst),
+            ForStatementAst forStatementAst => ForStatementEntity.Create(powerShellContext, forStatementAst),
+            IfStatementAst ifStatementAst => IfStatementEntity.Create(powerShellContext, ifStatementAst),
+            UnaryExpressionAst unaryExpressionAst => UnaryExpressionEntity.Create(powerShellContext, unaryExpressionAst),
+            TryStatementAst tryStatementAst => TryStatementEntity.Create(powerShellContext, tryStatementAst),
+            CatchClauseAst catchClauseAst => CatchClauseEntity.Create(powerShellContext, catchClauseAst),
+            ThrowStatementAst throwStatementAst => ThrowStatementEntity.Create(powerShellContext, throwStatementAst),
+            FileRedirectionAst fileRedirectionAst => FileRedirectionEntity.Create(powerShellContext, fileRedirectionAst),
+            TrapStatementAst trapStatementAst => TrapStatementEntity.Create(powerShellContext, trapStatementAst),
+            BlockStatementAst blockStatementAst => BlockStatementEntity.Create(powerShellContext, blockStatementAst),
+            ConfigurationDefinitionAst configurationDefinitionAst => ConfigurationDefinitionEntity.Create(powerShellContext, configurationDefinitionAst),
+            DataStatementAst dataStatementAst => DataStatementEntity.Create(powerShellContext, dataStatementAst),
+            DynamicKeywordStatementAst dynamicKeywordStatementAst => DynamicKeywordStatementEntity.Create(powerShellContext, dynamicKeywordStatementAst),
+            ErrorExpressionAst errorExpressionAst => ErrorExpressionEntity.Create(powerShellContext, errorExpressionAst),
+            ErrorStatementAst errorStatementAst => ErrorStatementEntity.Create(powerShellContext, errorStatementAst),
+            FunctionMemberAst functionMemberAst => FunctionMemberEntity.Create(powerShellContext, functionMemberAst),
+            MergingRedirectionAst mergingRedirectionAst => MergingRedirectionEntity.Create(powerShellContext, mergingRedirectionAst),
+            PipelineChainAst pipelineChainAst => PipelineChainEntity.Create(powerShellContext, pipelineChainAst),
+            PropertyMemberAst propertyMemberAst => PropertyMemberEntity.Create(powerShellContext, propertyMemberAst),
+            ScriptBlockExpressionAst scriptBlockExpressionAst => ScriptBlockExpressionEntity.Create(powerShellContext, scriptBlockExpressionAst),
+            SwitchStatementAst switchStatementAst => SwitchStatementEntity.Create(powerShellContext, switchStatementAst),
+            TypeDefinitionAst typeDefinitionAst => TypeDefinitionEntity.Create(powerShellContext, typeDefinitionAst),
+            UsingExpressionAst usingExpressionAst => UsingExpressionEntity.Create(powerShellContext, usingExpressionAst),
+            UsingStatementAst usingStatementAst => UsingStatementEntity.Create(powerShellContext, usingStatementAst),
+            AttributedExpressionAst attributedExpressionAst => AttributedExpressionEntity.Create(powerShellContext, attributedExpressionAst),
+            HashtableAst hashtableAst => HashtableEntity.Create(powerShellContext, hashtableAst),
+            // Other classes are derived from ConstantExpressionAst, so this switch case must be listed after those classes
+            ConstantExpressionAst constantExpressionAst => ConstantExpressionEntity.Create(powerShellContext, constantExpressionAst),
+            _ => NotImplementedEntity.Create(powerShellContext, ast, ast.GetType()),
+
+            // These base classes are abstract and won't be directly returned from the visitor
+            // AttributeBaseAst attributeBaseAst => throw new NotImplementedException(),
+            // RedirectionAst redirectionAst => RedirectionEntity.Create(powerShellContext, redirectionAst),
+            // MemberAst memberAst => throw new NotImplementedException(),
+            // ChainableAst chainableAst => throw new NotImplementedException(),
+            // BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst => throw new NotImplementedException(),
+            // ExpressionAst expressionAst => throw new NotImplementedException(),
+            // StatementAst statementAst => throw new NotImplementedException(),
+            // CommandBaseAst commandBaseAst => throw new NotImplementedException(),
+            // CommandElementAst commandElementAst => throw new NotImplementedException(),
+            // LabeledStatementAst labeledStatementAst => throw new NotImplementedException(),
+            // LoopStatementAst loopStatementAst => throw new NotImplementedException(),
+            // PipelineBaseAst pipelineBaseAst => throw new NotImplementedException(),
+        };
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/Analyser.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/Analyser.cs
@@ -1,0 +1,188 @@
+using Microsoft.CodeAnalysis.Text;
+using Semmle.Util.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Language;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Semmle.Extraction.PowerShell.Entities;
+using File = System.IO.File;
+
+/*
+ * Test
+ */
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// Encapsulates a PowerShell analysis task.
+    /// </summary>
+    public class Analyser : IDisposable
+    {
+        protected Extraction.Extractor? extractor;
+        protected Layout? layout;
+        protected CommonOptions? options;
+
+        private readonly object progressMutex = new object();
+
+        // The bulk of the extraction work, potentially executed in parallel.
+        protected readonly List<Action> extractionTasks = new List<Action>();
+        private int taskCount = 0;
+
+        private readonly Stopwatch stopWatch = new Stopwatch();
+
+        private readonly IProgressMonitor progressMonitor;
+
+        public ILogger Logger { get; }
+
+        protected readonly bool addAssemblyTrapPrefix;
+
+        public PathTransformer PathTransformer { get; }
+
+        public Analyser(IProgressMonitor pm, ILogger logger, bool addAssemblyTrapPrefix, PathTransformer pathTransformer, CommonOptions options)
+        {
+            Logger = logger;
+            this.addAssemblyTrapPrefix = addAssemblyTrapPrefix;
+            Logger.Log(Severity.Info, "EXTRACTION STARTING at {0}", DateTime.Now);
+            stopWatch.Start();
+            progressMonitor = pm;
+            PathTransformer = pathTransformer;
+            extractor = new StandaloneExtractor(Logger, PathTransformer);
+            this.options = options;
+            layout = new Layout();
+            LogExtractorInfo(Extraction.Extractor.Version);
+        }
+
+        /// <summary>
+        /// Perform an analysis on a source file/syntax tree.
+        /// </summary>
+        /// <param name="script">Syntax tree to analyse.</param>
+        public void QueueAnalyzeScriptTask(CompiledScript script)
+        {
+            extractionTasks.Add(() => DoExtractScript(script));
+        }
+
+#nullable disable warnings
+
+        private Microsoft.CodeAnalysis.Location GetCodeAnalysisLocationForToken(string path, Token token)
+        {
+            return Microsoft.CodeAnalysis.Location.Create(path,
+                new TextSpan(token.Extent.StartOffset, token.Extent.EndOffset - token.Extent.StartOffset),
+                new LinePositionSpan(new LinePosition(token.Extent.StartLineNumber, token.Extent.StartColumnNumber), 
+                    new LinePosition(token.Extent.EndLineNumber, token.Extent.EndColumnNumber)));
+        }
+
+        private void DoExtractScript(CompiledScript script)
+        {
+            try
+            {
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                string sourcePath = script.Location;
+                PathTransformer.ITransformedPath transformedSourcePath = PathTransformer.Transform(sourcePath);
+
+                Layout.SubProject projectLayout = layout.LookupProjectOrNull(transformedSourcePath);
+                bool excluded = projectLayout is null;
+                string trapPath = excluded ? "" : projectLayout!.GetTrapPath(Logger, transformedSourcePath, options.TrapCompression);
+                bool upToDate = false;
+
+                if (!excluded)
+                {
+                    using TrapWriter trapWriter = projectLayout!.CreateTrapWriter(Logger, transformedSourcePath, options.TrapCompression, discardDuplicates: false);
+
+                    upToDate = options.Fast && FileIsUpToDate(sourcePath, trapWriter.TrapFile);
+
+                    if (!upToDate)
+                    {
+                        PowerShellContext cx = new PowerShellContext(extractor, script, trapWriter, addAssemblyTrapPrefix);
+                        // Ensure that the file itself is populated in case the source file is totally empty
+                        Entities.File.Create(cx, sourcePath);
+                        // Parse any comments
+                        foreach (var token in script.Tokens.Where(x => x.Kind == TokenKind.Comment))
+                        {
+                            CommentEntity.Create(cx, token);
+                        }
+                        // Parse the AST contained in script.ParseResult
+                        script.ParseResult.Visit(new PowerShellVisitor2(cx));
+                        cx.PopulateAll();
+                    }
+                }
+
+                ReportProgress(sourcePath, trapPath, stopwatch.Elapsed, excluded
+                    ? AnalysisAction.Excluded
+                    : upToDate
+                        ? AnalysisAction.UpToDate
+                        : AnalysisAction.Extracted);
+            }
+            catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                extractor.Message(new Message($"Unhandled exception processing syntax tree. {ex.Message}", script.Location, null, ex.StackTrace));
+            }
+        }
+
+#nullable restore warnings
+
+        private static bool FileIsUpToDate(string src, string dest)
+        {
+            return File.Exists(dest) &&
+                File.GetLastWriteTime(dest) >= File.GetLastWriteTime(src);
+        }
+
+        private void ReportProgress(string src, string output, TimeSpan time, AnalysisAction action)
+        {
+            lock (progressMutex)
+                progressMonitor.Analysed(++taskCount, extractionTasks.Count, src, output, time, action);
+        }
+
+        /// <summary>
+        /// Run all extraction tasks.
+        /// </summary>
+        /// <param name="numberOfThreads">The number of threads to use.</param>
+        public void PerformExtractionTasks(int numberOfThreads)
+        {
+            Parallel.Invoke(
+                new ParallelOptions { MaxDegreeOfParallelism = numberOfThreads },
+                extractionTasks.ToArray());
+        }
+
+        public virtual void Dispose()
+        {
+            stopWatch.Stop();
+            Logger.Log(Severity.Info, "  Peak working set = {0} MB", Process.GetCurrentProcess().PeakWorkingSet64 / (1024 * 1024));
+
+            if (TotalErrors > 0)
+                Logger.Log(Severity.Info, "EXTRACTION FAILED with {0} error{1} in {2}", TotalErrors, TotalErrors == 1 ? "" : "s", stopWatch.Elapsed);
+            else
+                Logger.Log(Severity.Info, "EXTRACTION SUCCEEDED in {0}", stopWatch.Elapsed);
+
+            Logger.Dispose();
+        }
+
+        /// <summary>
+        /// Number of errors encountered during extraction.
+        /// </summary>
+        private int ExtractorErrors => extractor?.Errors ?? 0;
+
+        /// <summary>
+        /// Number of errors encountered by the compiler.
+        /// </summary>
+        public int CompilationErrors { get; set; }
+
+        /// <summary>
+        /// Total number of errors reported.
+        /// </summary>
+        public int TotalErrors => CompilationErrors + ExtractorErrors;
+
+        /// <summary>
+        /// Logs information about the extractor.
+        /// </summary>
+        public void LogExtractorInfo(string extractorVersion)
+        {
+            Logger.Log(Severity.Info, "  Extractor: {0}", Environment.GetCommandLineArgs().First());
+            Logger.Log(Severity.Info, "  Extractor version: {0}", extractorVersion);
+            Logger.Log(Severity.Info, "  Current working directory: {0}", Directory.GetCurrentDirectory());
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/AnalysisAction.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/AnalysisAction.cs
@@ -1,0 +1,12 @@
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// What action was performed when extracting a file.
+    /// </summary>
+    public enum AnalysisAction
+    {
+        Extracted,
+        UpToDate,
+        Excluded
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/Extractor.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/Extractor.cs
@@ -1,0 +1,321 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Semmle.Util;
+using Semmle.Util.Logging;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell.Extractor
+{
+    public static class Extractor
+    {
+        public enum ExitCode
+        {
+            Ok,         // Everything worked perfectly
+            Errors,     // Trap was generated but there were processing errors
+            Failed      // Trap could not be generated
+        }
+
+        private class LogProgressMonitor : IProgressMonitor
+        {
+            private readonly ILogger logger;
+
+            public LogProgressMonitor(ILogger logger)
+            {
+                this.logger = logger;
+            }
+
+            public void Analysed(int item, int total, string source, string output, TimeSpan time, AnalysisAction action)
+            {
+                if (action != AnalysisAction.UpToDate)
+                {
+                    logger.Log(Severity.Info, "  {0} ({1})", source,
+                        action == AnalysisAction.Extracted
+                            ? time.ToString()
+                            : action == AnalysisAction.Excluded
+                                ? "excluded"
+                                : "up to date");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set the application culture to the invariant culture.
+        ///
+        /// This is required among others to ensure that the invariant culture is used for value formatting during TRAP
+        /// file writing.
+        /// </summary>
+        public static void SetInvariantCulture()
+        {
+            var culture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+        }
+
+        /// <summary>
+        /// Command-line driver for the extractor.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// The extractor can be invoked in one of two ways: Either as an "analyser" passed in via the /a
+        /// option to csc.exe, or as a stand-alone executable. In this case, we need to faithfully
+        /// drive Roslyn in the way that csc.exe would.
+        /// </remarks>
+        ///
+        /// <param name="args">Command line arguments as passed to csc.exe</param>
+        /// <returns><see cref="ExitCode"/></returns>
+        public static ExitCode Run(string[] args)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var options = Options.CreateWithEnvironment(args);
+            var fileLogger = new FileLogger(options.Verbosity, GetPowerShellLogPath());
+            using var logger = options.Console
+                ? new CombinedLogger(new ConsoleLogger(options.Verbosity), fileLogger)
+                : (ILogger)fileLogger;
+
+            var canonicalPathCache = CanonicalPathCache.Create(logger, 1000);
+            var pathTransformer = new PathTransformer(canonicalPathCache);
+
+            using var analyser = new Analyser(new LogProgressMonitor(logger), logger, options.AssemblySensitiveTrap, pathTransformer, options);
+
+            try
+            {
+                var filesToParse = EnumerateSourceFiles(options.ProjectsToLoad, options.CompilerArguments, logger);
+                var sw = new Stopwatch();
+                var progressMon = new LogProgressMonitor(logger);
+                return Analyse(sw, analyser, options, filesToParse, progressMon, (_) => { });
+            }
+            catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                logger.Log(Severity.Error, "  Unhandled exception: {0}", ex);
+                return ExitCode.Errors;
+            }
+        }
+
+        private static IEnumerable<string> EnumerateSourceFiles(IEnumerable<string> scriptsToLoad, IList<string> compilerArguments, ILogger logger)
+        {
+            logger.Log(Severity.Info, "  Loading referenced scripts.");
+            var scripts = new Queue<string>(scriptsToLoad);
+            var processed = new HashSet<string>();
+            while (scripts.Count > 0)
+            {
+                var script = scripts.Dequeue();
+                var fi = new FileInfo(script);
+                if (processed.Contains(fi.FullName))
+                {
+                    continue;
+                }
+
+                processed.Add(fi.FullName);
+                logger.Log(Severity.Info, "  Processing referenced project: " + fi.FullName);
+            }
+            return processed;
+        }
+
+        /// <summary>
+        /// Gets the complete list of locations to locate references.
+        /// </summary>
+        /// <param name="args">Command line arguments.</param>
+        /// <returns>List of directories.</returns>
+        private static IEnumerable<string> FixedReferencePaths(Microsoft.CodeAnalysis.CommandLineArguments args)
+        {
+            // See https://msdn.microsoft.com/en-us/library/s5bac5fx.aspx
+            // on how csc resolves references. Basically,
+            // 1) Current working directory. This is the directory from which the compiler is invoked.
+            // 2) The common language runtime system directory.
+            // 3) Directories specified by / lib.
+            // 4) Directories specified by the LIB environment variable.
+
+            if (args.BaseDirectory is not null)
+            {
+                yield return args.BaseDirectory;
+            }
+
+            foreach (var r in args.ReferencePaths)
+                yield return r;
+
+            var lib = System.Environment.GetEnvironmentVariable("LIB");
+            if (lib is not null)
+                yield return lib;
+        }
+
+        /// <summary>
+        /// Construct tasks for reading source code files (possibly in parallel).
+        ///
+        /// The constructed CompiledScripts trees will be added (thread-safely) to the supplied
+        /// list <paramref name="ret"/>.
+        /// </summary>
+        private static IEnumerable<Action> CompileScripts(IEnumerable<string> sources, Analyser analyser, IList<CompiledScript> ret)
+        {
+            return sources.Select<string, Action>(path =>
+            {
+                Action action = () =>
+                {
+                    try
+                    {
+                        ScriptBlockAst ast = Parser.ParseFile(path, out Token[] tokens, out ParseError[] errors);
+
+                        lock (ret)
+                            ret.Add(new CompiledScript(path, ast, tokens, errors));
+                    }
+                    catch (IOException ex)
+                    {
+                        lock (analyser)
+                        {
+                            analyser.Logger.Log(Severity.Error, "  Unable to open source file {0}: {1}", path, ex.Message);
+                            ++analyser.CompilationErrors;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        lock (analyser)
+                        {
+                            analyser.Logger.Log(Severity.Error, "  Unable to open source file {0}: {1} ({2})", path, e.Message);
+                            ++analyser.CompilationErrors;
+                        }
+                    }
+                };
+                return action;
+            });
+        }
+
+        public static void ExtractStandalone(
+            IEnumerable<string> sources,
+            IProgressMonitor pm,
+            ILogger logger,
+            CommonOptions options)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var canonicalPathCache = CanonicalPathCache.Create(logger, 1000);
+            var pathTransformer = new PathTransformer(canonicalPathCache);
+
+            using var analyser = new Analyser(pm, logger, false, pathTransformer, options);
+            try
+            {
+                AnalyseStandalone(analyser, sources, options, pm, stopwatch);
+            }
+            catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                analyser.Logger.Log(Severity.Error, "  Unhandled exception: {0}", ex);
+            }
+        }
+
+        private static ExitCode Analyse(Stopwatch stopwatch, 
+            Analyser analyser, 
+            CommonOptions options, 
+            IEnumerable<string> sources,
+            IProgressMonitor progressMonitor,
+            Action<Entities.PerformanceMetrics> logPerformance)
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+
+            var compiledScripts = new List<CompiledScript>();
+            var csActions = CompileScripts(sources, analyser, compiledScripts);
+
+            Parallel.Invoke(
+                new ParallelOptions { MaxDegreeOfParallelism = options.Threads },
+                csActions.ToArray());
+
+            if (compiledScripts.Count == 0)
+            {
+                analyser.Logger.Log(Severity.Error, "  No source files");
+                ++analyser.CompilationErrors;
+            }
+
+            foreach (var script in compiledScripts)
+            {
+                analyser.QueueAnalyzeScriptTask(script);
+            }
+
+            sw.Stop();
+            analyser.Logger.Log(Severity.Info, "  Models constructed in {0}", sw.Elapsed);
+            var elapsed = sw.Elapsed;
+
+            var currentProcess = Process.GetCurrentProcess();
+            var cpuTime1 = currentProcess.TotalProcessorTime;
+            var userTime1 = currentProcess.UserProcessorTime;
+
+            sw.Restart();
+            analyser.PerformExtractionTasks(options.Threads);
+            sw.Stop();
+            var cpuTime2 = currentProcess.TotalProcessorTime;
+            var userTime2 = currentProcess.UserProcessorTime;
+
+            var performance = new Entities.PerformanceMetrics()
+            {
+                Frontend = new Entities.Timings() { Elapsed = elapsed, Cpu = cpuTime1, User = userTime1 },
+                Extractor = new Entities.Timings() { Elapsed = sw.Elapsed, Cpu = cpuTime2 - cpuTime1, User = userTime2 - userTime1 },
+                Total = new Entities.Timings() { Elapsed = stopwatch.Elapsed, Cpu = cpuTime2, User = userTime2 },
+                PeakWorkingSet = currentProcess.PeakWorkingSet64
+            };
+
+            logPerformance(performance);
+            analyser.Logger.Log(Severity.Info, "  Extraction took {0}", sw.Elapsed);
+
+            return analyser.TotalErrors == 0 ? ExitCode.Ok : ExitCode.Errors;
+        }
+
+        private static void AnalyseStandalone(
+            Analyser analyser,
+            IEnumerable<string> sources,
+            CommonOptions options,
+            IProgressMonitor progressMonitor,
+            Stopwatch stopwatch)
+        {
+            Analyse(stopwatch, analyser, options, sources, progressMonitor, (_) => { });
+        }
+
+        /// <summary>
+        /// Gets the path to the `powershell.log` file written to by the PowerShell extractor.
+        /// </summary>
+        public static string GetPowerShellLogPath() =>
+            Path.Combine(GetPowerShellLogDirectory(), "powershell.log");
+
+        /// <summary>
+        /// Gets the path to the `powershell.log` file written to by the PowerShell extractor.
+        /// </summary>
+        public static string GetPowerShellArgsLogsPath(string hash) =>
+            Path.Combine(GetPowerShellLogDirectory(), $"powershell.{hash}.txt");
+
+        /// <summary>
+        /// Gets a list of all `powershell.{hash}.txt` files currently written to the log directory.
+        /// </summary>
+        public static IEnumerable<string> GetPowerShellArgsLogs() =>
+            Directory.EnumerateFiles(GetPowerShellLogDirectory(), "powershell.*.txt");
+
+        private static string GetPowerShellLogDirectory()
+        {
+            var codeQlLogDir = Environment.GetEnvironmentVariable("CODEQL_EXTRACTOR_POWERSHELL_LOG_DIR");
+            if (!string.IsNullOrEmpty(codeQlLogDir))
+                return codeQlLogDir;
+
+            var snapshot = Environment.GetEnvironmentVariable("ODASA_SNAPSHOT");
+            if (!string.IsNullOrEmpty(snapshot))
+                return Path.Combine(snapshot, "log");
+
+            var buildErrorDir = Environment.GetEnvironmentVariable("ODASA_BUILD_ERROR_DIR");
+            if (!string.IsNullOrEmpty(buildErrorDir))
+                // Used by `qltest`
+                return buildErrorDir;
+
+            var traps = Environment.GetEnvironmentVariable("TRAP_FOLDER");
+            if (!string.IsNullOrEmpty(traps))
+                return traps;
+
+            return Directory.GetCurrentDirectory();
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/IProgressMonitor.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/IProgressMonitor.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// Callback for various extraction events.
+    /// (Used for display of progress).
+    /// </summary>
+    public interface IProgressMonitor
+    {
+        /// <summary>
+        /// Callback that a particular item has been analysed.
+        /// </summary>
+        /// <param name="item">The item number being processed.</param>
+        /// <param name="total">The total number of items to process.</param>
+        /// <param name="source">The name of the item, e.g. a source file.</param>
+        /// <param name="output">The name of the item being output, e.g. a trap file.</param>
+        /// <param name="time">The time to extract the item.</param>
+        /// <param name="action">What action was taken for the file.</param>
+        void Analysed(int item, int total, string source, string output, TimeSpan time, AnalysisAction action);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/Options.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Extractor/Options.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Semmle.Util;
+
+namespace Semmle.Extraction.PowerShell
+{
+    public sealed class Options : CommonOptions
+    {
+        /// <summary>
+        /// Project files whose source files should be added to the compilation.
+        /// Only used in tests.
+        /// </summary>
+        public IList<string> ProjectsToLoad { get; } = new List<string>();
+
+        /// <summary>
+        /// All other arguments passed to the compilation.
+        /// </summary>
+        public IList<string> CompilerArguments { get; } = new List<string>();
+
+        /// <summary>
+        /// Holds if assembly information should be prefixed to TRAP labels.
+        /// </summary>
+        public bool AssemblySensitiveTrap { get; private set; } = false;
+
+        public static Options CreateWithEnvironment(string[] arguments)
+        {
+            var options = new Options();
+            var extractionOptions = Environment.GetEnvironmentVariable("SEMMLE_EXTRACTOR_OPTIONS") ??
+                Environment.GetEnvironmentVariable("LGTM_INDEX_EXTRACTOR");
+
+            var argsList = new List<string>(arguments);
+
+            if (!string.IsNullOrEmpty(extractionOptions))
+                argsList.AddRange(extractionOptions.Split(' '));
+
+            options.ParseArguments(argsList);
+            return options;
+        }
+
+        public override bool HandleArgument(string argument)
+        {
+            CompilerArguments.Add(argument);
+            return true;
+        }
+
+        public override void InvalidArgument(string argument)
+        {
+            // Unrecognised arguments are passed to the compiler.
+            CompilerArguments.Add(argument);
+        }
+
+        public override bool HandleOption(string key, string value)
+        {
+            switch (key)
+            {
+                case "load-sources-from-project":
+                    ProjectsToLoad.Add(value);
+                    return true;
+                default:
+                    return base.HandleOption(key, value);
+            }
+        }
+
+        public override bool HandleFlag(string flag, bool value)
+        {
+            switch (flag)
+            {
+                case "assemblysensitivetrap":
+                    AssemblySensitiveTrap = value;
+                    return true;
+                default:
+                    return base.HandleFlag(flag, value);
+            }
+        }
+
+        private Options()
+        {
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Layout.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Layout.cs
@@ -1,0 +1,204 @@
+using Semmle.Util.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// An extractor layout file.
+    /// Represents the layout of projects into trap folders and source archives.
+    /// </summary>
+    public sealed class Layout
+    {
+        /// <summary>
+        /// Exception thrown when the layout file is invalid.
+        /// </summary>
+        public class InvalidLayoutException : Exception
+        {
+            public InvalidLayoutException(string file, string message) :
+                base("ODASA_POWERSHELL_LAYOUT " + file + " " + message)
+            {
+            }
+        }
+
+        /// <summary>
+        /// List of blocks in the layout file.
+        /// </summary>
+        private readonly List<LayoutBlock> blocks;
+
+        /// <summary>
+        /// A subproject in the layout file.
+        /// </summary>
+        public class SubProject
+        {
+            /// <summary>
+            /// The trap folder, or null for current directory.
+            /// </summary>
+            public string? TRAP_FOLDER { get; }
+
+            /// <summary>
+            /// The source archive, or null to skip.
+            /// </summary>
+            public string? SOURCE_ARCHIVE { get; }
+
+            public SubProject(string? traps, string? archive)
+            {
+                TRAP_FOLDER = traps;
+                SOURCE_ARCHIVE = archive;
+            }
+
+            /// <summary>
+            /// Gets the name of the trap file for a given source/assembly file.
+            /// </summary>
+            /// <param name="srcFile">The source file.</param>
+            /// <returns>The full filepath of the trap file.</returns>
+            public string GetTrapPath(ILogger logger, PathTransformer.ITransformedPath srcFile, TrapWriter.CompressionMode trapCompression) =>
+                TrapWriter.TrapPath(logger, TRAP_FOLDER, srcFile, trapCompression);
+
+            /// <summary>
+            /// Creates a trap writer for a given source/assembly file.
+            /// </summary>
+            /// <param name="srcFile">The source file.</param>
+            /// <returns>A newly created TrapWriter.</returns>
+            public TrapWriter CreateTrapWriter(ILogger logger, PathTransformer.ITransformedPath srcFile, TrapWriter.CompressionMode trapCompression, bool discardDuplicates) =>
+                new TrapWriter(logger, srcFile, TRAP_FOLDER, SOURCE_ARCHIVE, trapCompression, discardDuplicates);
+        }
+
+        private readonly SubProject defaultProject;
+
+        /// <summary>
+        /// Finds the suitable directories for a given source file.
+        /// Returns null if not included in the layout.
+        /// </summary>
+        /// <param name="sourceFile">The file to look up.</param>
+        /// <returns>The relevant subproject, or null if not found.</returns>
+        public SubProject? LookupProjectOrNull(PathTransformer.ITransformedPath sourceFile)
+        {
+            if (!useLayoutFile)
+                return defaultProject;
+
+            return blocks
+                .Where(block => block.Matches(sourceFile))
+                .Select(block => block.Directories)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Finds the suitable directories for a given source file.
+        /// Returns the default project if not included in the layout.
+        /// </summary>
+        /// <param name="sourceFile">The file to look up.</param>
+        /// <returns>The relevant subproject, or DefaultProject if not found.</returns>
+        public SubProject LookupProjectOrDefault(PathTransformer.ITransformedPath sourceFile)
+        {
+            return LookupProjectOrNull(sourceFile) ?? defaultProject;
+        }
+
+        private readonly bool useLayoutFile;
+
+        /// <summary>
+        /// Default constructor reads parameters from the environment.
+        /// </summary>
+        public Layout() : this(
+            Environment.GetEnvironmentVariable("CODEQL_EXTRACTOR_POWERSHELL_TRAP_DIR") ?? Environment.GetEnvironmentVariable("TRAP_FOLDER"),
+            Environment.GetEnvironmentVariable("CODEQL_EXTRACTOR_POWERSHELL_SOURCE_ARCHIVE_DIR") ?? Environment.GetEnvironmentVariable("SOURCE_ARCHIVE"),
+            Environment.GetEnvironmentVariable("ODASA_POWERSHELL_LAYOUT"))
+        {
+        }
+
+        /// <summary>
+        /// Creates the project layout. Reads the layout file if specified.
+        /// </summary>
+        /// <param name="traps">Directory for trap files, or null to use layout/current directory.</param>
+        /// <param name="archive">Directory for source archive, or null for layout/no archive.</param>
+        /// <param name="layout">Path of layout file, or null for no layout.</param>
+        /// <exception cref="InvalidLayoutException">Failed to read layout file.</exception>
+        public Layout(string? traps, string? archive, string? layout)
+        {
+            useLayoutFile = string.IsNullOrEmpty(traps) && !string.IsNullOrEmpty(layout);
+            blocks = new List<LayoutBlock>();
+
+            if (useLayoutFile)
+            {
+                ReadLayoutFile(layout!);
+                defaultProject = blocks[0].Directories;
+            }
+            else
+            {
+                defaultProject = new SubProject(traps, archive);
+            }
+        }
+
+        /// <summary>
+        /// Is the source file included in the layout?
+        /// </summary>
+        /// <param name="path">The absolute path of the file to query.</param>
+        /// <returns>True iff there is no layout file or the layout file specifies the file.</returns>
+        public bool FileInLayout(PathTransformer.ITransformedPath path) => LookupProjectOrNull(path) is not null;
+
+        private void ReadLayoutFile(string layout)
+        {
+            try
+            {
+                var lines = File.ReadAllLines(layout);
+
+                var i = 0;
+                while (!lines[i].StartsWith("#"))
+                    i++;
+                while (i < lines.Length)
+                {
+                    var block = new LayoutBlock(lines, ref i);
+                    blocks.Add(block);
+                }
+
+                if (blocks.Count == 0)
+                    throw new InvalidLayoutException(layout, "contains no blocks");
+            }
+            catch (IOException ex)
+            {
+                throw new InvalidLayoutException(layout, ex.Message);
+            }
+            catch (IndexOutOfRangeException)
+            {
+                throw new InvalidLayoutException(layout, "is invalid");
+            }
+        }
+    }
+
+    internal sealed class LayoutBlock
+    {
+        private readonly List<FilePattern> filePatterns = new List<FilePattern>();
+
+        public Layout.SubProject Directories { get; }
+
+        private static string? ReadVariable(string name, string line)
+        {
+            var prefix = name + "=";
+            if (!line.StartsWith(prefix))
+                return null;
+            return line.Substring(prefix.Length).Trim();
+        }
+
+        public LayoutBlock(string[] lines, ref int i)
+        {
+            // first line: #name
+            i++;
+            var trapFolder = ReadVariable("TRAP_FOLDER", lines[i++]);
+            // Don't care about ODASA_DB.
+            ReadVariable("ODASA_DB", lines[i++]);
+            var sourceArchive = ReadVariable("SOURCE_ARCHIVE", lines[i++]);
+
+            Directories = new Layout.SubProject(trapFolder, sourceArchive);
+            // Don't care about ODASA_BUILD_ERROR_DIR.
+            ReadVariable("ODASA_BUILD_ERROR_DIR", lines[i++]);
+            while (i < lines.Length && !lines[i].StartsWith("#"))
+            {
+                filePatterns.Add(new FilePattern(lines[i++]));
+            }
+        }
+
+        public bool Matches(PathTransformer.ITransformedPath path) => FilePattern.Matches(filePatterns, path.Value, out var _);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/PowerShellContext.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/PowerShellContext.cs
@@ -1,0 +1,124 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
+using Semmle.Extraction.PowerShell.Entities;
+using Location = Microsoft.CodeAnalysis.Location;
+using GeneratedLocation = Semmle.Extraction.Entities.GeneratedLocation;
+using System.Management.Automation.Language;
+
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// Extraction context for CIL extraction.
+    /// Adds additional context that is specific for CIL extraction.
+    /// One context = one DLL/EXE.
+    /// </summary>
+    public class PowerShellContext : Extraction.Context
+    {
+        public CompiledScript Compilation { get; }
+
+        private HashSet<int> populatedIds = new HashSet<int>();
+        
+        public PowerShellContext(Extraction.Extractor e, CompiledScript c, TrapWriter trapWriter, bool addAssemblyTrapPrefix)
+            : base(e, trapWriter, addAssemblyTrapPrefix)
+        {
+            Compilation = c;
+            folders = new CachedFunction<PathTransformer.ITransformedPath, Folder>(path => new Folder(this, path));
+        }
+
+        internal void Extract(IExtractedEntity entity)
+        {
+            foreach (var content in entity.Contents)
+            {
+                content.Extract(this);
+            }
+        }
+
+        public override Extraction.Entities.Location CreateLocation()
+        {
+            return GeneratedLocation.Create(this);
+        }
+
+        public override Extraction.Entities.Location CreateLocation(Location? location)
+        {
+            return SourceCodeLocation.Create(this, location);
+        }
+
+        public Location ExtentToAnalysisLocation(IScriptExtent extent){
+            return Location.Create(Compilation.Location,
+                new TextSpan(extent.StartOffset, extent.EndOffset - extent.StartOffset),
+                new LinePositionSpan(new LinePosition(extent.StartLineNumber, extent.StartColumnNumber),
+                    new LinePosition(extent.EndLineNumber, extent.EndColumnNumber)));
+        }
+
+        public Location CreateAnalysisLocation(Ast token)
+        {
+            return ExtentToAnalysisLocation(token.Extent);
+        }
+
+        private readonly CachedFunction<PathTransformer.ITransformedPath, Folder> folders;
+
+        /// <summary>
+        /// Creates a folder entity with the given path.
+        /// </summary>
+        /// <param name="path">The path of the folder.</param>
+        /// <returns>A folder entity.</returns>
+        internal Folder CreateFolder(PathTransformer.ITransformedPath path) => folders[path];
+
+        private readonly Dictionary<object, Label> ids = new Dictionary<object, Label>();
+
+        internal T PopulateCachedEntity<T>(T e) where T : CachedEntity
+        {
+            if (!populatedIds.Contains(e.Label.Value))
+            {
+                PopulateLater(() => { e.Populate(TrapWriter.Writer);});
+                populatedIds.Add(e.Label.Value);
+            }
+            
+            return e;
+        }
+        
+        internal T Populate<T>(T e) where T : IExtractedEntity
+        {
+            if (e.Label.Valid)
+            {
+                return e;   // Already populated
+            }
+
+            if (ids.TryGetValue(e, out var existing))
+            {
+                // It exists already
+                e.Label = existing;
+            }
+            else
+            {
+                e.Label = GetNewLabel();
+                DefineLabel(e);
+                ids.Add(e, e.Label);
+                PopulateLater(() =>
+                {
+                    foreach (var c in e.Contents)
+                        c.Extract(this);
+                });
+#if DEBUG_LABELS
+                using var writer = new EscapingTextWriter();
+                e.WriteId(writer);
+                var id = writer.ToString();
+
+                if (debugLabels.TryGetValue(id, out var previousEntity))
+                {
+                    Extractor.Message(new Message("Duplicate trap ID", id, null, severity: Util.Logging.Severity.Warning));
+                }
+                else
+                {
+                    debugLabels.Add(id, e);
+                }
+#endif
+            }
+            return e;
+        }
+
+#if DEBUG_LABELS
+        private readonly Dictionary<string, IExtractedEntity> debugLabels = new Dictionary<string, IExtractedEntity>();
+#endif
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/PowerShellVisitor2.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/PowerShellVisitor2.cs
@@ -1,0 +1,32 @@
+﻿using System.Management.Automation.Language;
+using Semmle.Extraction.PowerShell.Entities;
+
+namespace Semmle.Extraction.PowerShell;
+
+/// <summary>
+/// This is a Visitor that implements the AstVisitor2 abstract class for walking powershell ASTs.
+/// </summary>
+public class PowerShellVisitor2 : AstVisitor2
+{
+    /// <summary>
+    /// The constructor requires the context so it can be passed to entities that are created
+    /// </summary>
+    /// <param name="ctx"></param>
+    public PowerShellVisitor2(PowerShellContext ctx)
+    {
+        this.Context = ctx;
+    }
+    private PowerShellContext Context { get; set; }
+
+    /// <summary>
+    /// Default visit is called by the base class for all properties by default.
+    ///     Until the more specific visitors below are actually overridden this will get called for every ast
+    /// </summary>
+    /// <param name="ast"></param>
+    /// <returns></returns>
+    public override AstVisitAction DefaultVisit(Ast ast)
+    {
+        EntityConstructor.ConstructAppropriateEntity(Context, ast);
+        return AstVisitAction.Continue;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Semmle.Extraction.PowerShell.csproj
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Semmle.Extraction.PowerShell.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+	<AssemblyName>Semmle.Extraction.PowerShell</AssemblyName>
+	<RootNamespace>Semmle.Extraction.PowerShell</RootNamespace>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+	<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+	<Nullable>enable</Nullable>
+	<LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Semmle.Extraction\Semmle.Extraction.csproj" />
+    <ProjectReference Include="..\Semmle.Util\Semmle.Util.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Management.Automation" Version="7.3.3" />
+  </ItemGroup>
+
+</Project>

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Tuples.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Tuples.cs
@@ -1,0 +1,1078 @@
+using Semmle.Util;
+using System.IO;
+using System.Management.Automation.Language;
+using System.Runtime.CompilerServices;
+using Semmle.Extraction.Entities;
+using Folder = Semmle.Extraction.PowerShell.Entities.Folder;
+using Semmle.Extraction.PowerShell.Entities;
+[assembly:InternalsVisibleTo("Microsoft.Extractor.Tests")]
+namespace Semmle.Extraction.PowerShell
+{
+    /// <summary>
+    /// Methods for writing DB tuples.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// The parameters to the tuples are well-typed.
+    /// </remarks>
+    internal static class Tuples
+    {
+        internal static void numlines(this TextWriter trapFile, IEntity label, int total, int code, int comment)
+        {
+            trapFile.WriteTuple("numlines", label, total, code, comment);
+        }
+
+        internal static Tuple containerparent(Folder parent, IFileOrFolder child) =>
+            new Tuple("containerparent", parent, child);
+        //
+        // internal static Tuple files(Entities.File file, string fullName) =>
+        //     new Tuple("files", file, fullName);
+
+        internal static Tuple folders(Folder folder, string path) =>
+            new Tuple("folders", folder, path);
+
+        internal static void comment_entity(this TextWriter trapFile, CommentEntity commentEntity, StringLiteralEntity text)
+        {
+            trapFile.WriteTuple("comment_entity", commentEntity, text);
+        }
+
+        internal static void comment_entity_location(this TextWriter trapFile, CommentEntity commentEntity, Location location)
+        {
+            trapFile.WriteTuple("comment_entity_location", commentEntity, location);
+        }
+
+        internal static void not_implemented(this TextWriter trapFile, NotImplementedEntity notImplementedEntity, string notImplementedTypeName)
+        {
+            trapFile.WriteTuple("not_implemented", notImplementedEntity, notImplementedTypeName);
+        }
+
+        internal static void not_implemented_location(this TextWriter trapFile, NotImplementedEntity notImplementedEntity, Location location)
+        {
+            trapFile.WriteTuple("not_implemented_location", notImplementedEntity, location);
+        }
+        
+        internal static void script_block(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, int numUsings, int numRequiredModules, int numRequiredAssemblies, int numRequiredPsEditions, int numRequiredPsSnapins)
+        {
+            trapFile.WriteTuple("script_block", scriptBlockEntity, numUsings, numRequiredModules, numRequiredAssemblies, numRequiredPsEditions, numRequiredPsSnapins);
+        }
+        
+        internal static void script_block_param_block(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, Entity paramBlock)
+        {
+            trapFile.WriteTuple("script_block_param_block", scriptBlockEntity, paramBlock);
+        }
+        
+        internal static void script_block_begin_block(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, Entity beginBlock)
+        {
+            trapFile.WriteTuple("script_block_begin_block", scriptBlockEntity, beginBlock);
+        }
+        
+        internal static void script_block_clean_block(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, Entity cleanBlock)
+        {
+            trapFile.WriteTuple("script_block_clean_block", scriptBlockEntity, cleanBlock);
+        }
+        
+        internal static void script_block_dynamic_param_block(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, Entity dynamicParamBlock)
+        {
+            trapFile.WriteTuple("script_block_dynamic_param_block", scriptBlockEntity, dynamicParamBlock);
+        }
+        
+        internal static void script_block_end_block(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, Entity endBlock)
+        {
+            trapFile.WriteTuple("script_block_end_block", scriptBlockEntity, endBlock);
+        }
+        
+        internal static void script_block_process_block(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, Entity processBlock)
+        {
+            trapFile.WriteTuple("script_block_process_block", scriptBlockEntity, processBlock);
+        }
+        
+        internal static void script_block_using(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, int index, Entity paramBlock)
+        {
+            trapFile.WriteTuple("script_block_using", scriptBlockEntity, index, paramBlock);
+        }
+
+        internal static void script_block_required_application_id(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, string requiredApplicationId)
+        {
+            trapFile.WriteTuple("script_block_required_application_id", scriptBlockEntity, requiredApplicationId);
+        }
+
+        internal static void script_block_requires_elevation(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, bool requiresElevation)
+        {
+            trapFile.WriteTuple("script_block_requires_elevation", scriptBlockEntity, requiresElevation);
+        }
+
+        internal static void script_block_required_ps_version(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, string requiredPsVersion)
+        {
+            trapFile.WriteTuple("script_block_required_ps_version", scriptBlockEntity, requiredPsVersion);
+        }
+
+        internal static void script_block_required_module(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, int index, ModuleSpecificationEntity module)
+        {
+            trapFile.WriteTuple("script_block_required_module", scriptBlockEntity, index, module);
+        }
+        
+        internal static void module_specification(this TextWriter trapFile, ModuleSpecificationEntity moduleSpecificationEntity, string name, string guid, string maximumVersion, string requiredVersion, string version)
+        {
+            trapFile.WriteTuple("module_specification", moduleSpecificationEntity, name, guid, maximumVersion, requiredVersion, version);
+        }
+
+        internal static void script_block_required_assembly(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, int index, string requiredAssembly)
+        {
+            trapFile.WriteTuple("script_block_required_assembly", scriptBlockEntity, index, requiredAssembly);
+        }
+
+        internal static void script_block_required_ps_edition(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, int index, string requiredPsEdition)
+        {
+            trapFile.WriteTuple("script_block_required_ps_edition", scriptBlockEntity, index, requiredPsEdition);
+        }
+
+        internal static void script_block_requires_ps_snapin(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, int index, string name, string version)
+        {
+            trapFile.WriteTuple("script_block_requires_ps_snapin", scriptBlockEntity, index, name, version);
+        }
+
+        internal static void script_block_location(this TextWriter trapFile, ScriptBlockEntity scriptBlockEntity, Location location)
+        {
+            trapFile.WriteTuple("script_block_location", scriptBlockEntity, location);
+        }
+        
+        internal static void named_block(this TextWriter trapFile, NamedBlockEntity namedBlockEntity, int numStatements, int numTraps)
+        {
+            trapFile.WriteTuple("named_block", namedBlockEntity, numStatements, numTraps);
+        }
+
+        internal static void named_block_statement(this TextWriter trapFile, NamedBlockEntity namedBlockEntity, int index, Entity statement)
+        {
+            trapFile.WriteTuple("named_block_statement", namedBlockEntity, index, statement);
+        }
+
+        internal static void named_block_trap(this TextWriter trapFile, NamedBlockEntity namedBlockEntity,  int index, Entity trap)
+        {
+            trapFile.WriteTuple("named_block_trap", namedBlockEntity, index, trap);
+        }
+
+        internal static void named_block_location(this TextWriter trapFile, NamedBlockEntity namedBlockEntity, Location location)
+        {
+            trapFile.WriteTuple("named_block_location", namedBlockEntity, location);
+        }
+
+        internal static void array_expression(this TextWriter trapFile, ArrayExpressionEntity arrayExpressionEntity, Entity subExpression)
+        {
+            trapFile.WriteTuple("array_expression", arrayExpressionEntity, subExpression);
+        }
+
+        internal static void array_expression_location(this TextWriter trapFile, ArrayExpressionEntity arrayExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("array_expression_location", arrayExpressionEntity, location);
+        }
+
+        internal static void array_literal(this TextWriter trapFile, ArrayLiteralEntity arrayLiteralEntity)
+        {
+            trapFile.WriteTuple("array_literal", arrayLiteralEntity);
+        }
+
+        internal static void array_literal_location(this TextWriter trapFile, ArrayLiteralEntity arrayLiteralEntity, Location location)
+        {
+            trapFile.WriteTuple("array_literal_location", arrayLiteralEntity, location);
+        }
+
+        internal static void array_literal_element(this TextWriter trapFile, ArrayLiteralEntity arrayLiteralEntity, int index, Entity component)
+        {
+            trapFile.WriteTuple("array_literal_element", arrayLiteralEntity, index, component);
+        }
+
+        internal static void assignment_statement(this TextWriter trapFile, AssignmentStatementEntity assignmentStatementEntity, TokenKind operation, Entity left, Entity right)
+        {
+            trapFile.WriteTuple("assignment_statement", assignmentStatementEntity, operation, left, right);
+        }
+
+        internal static void assignment_statement_location(this TextWriter trapFile, AssignmentStatementEntity assignmentStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("assignment_statement_location", assignmentStatementEntity, location);
+        }
+
+        internal static void constant_expression(this TextWriter trapFile, ConstantExpressionEntity contextExpressionEntity, string staticType)
+        {
+            trapFile.WriteTuple("constant_expression", contextExpressionEntity, staticType);
+        }
+        
+        internal static void constant_expression_value(this TextWriter trapFile, ConstantExpressionEntity contextExpressionEntity, StringLiteralEntity value)
+        {
+            trapFile.WriteTuple("constant_expression_value", contextExpressionEntity, value);
+        }
+
+        internal static void constant_expression_location(this TextWriter trapFile, ConstantExpressionEntity contextExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("constant_expression_location", contextExpressionEntity, location);
+        }
+
+        internal static void convert_expression(this TextWriter trapFile, ConvertExpressionEntity convertExpressionEntity, Entity attribute, Entity child, Entity type, string staticType)
+        {
+            trapFile.WriteTuple("convert_expression", convertExpressionEntity, attribute, child, type, staticType);
+        }
+
+        internal static void convert_expression_location(this TextWriter trapFile, ConvertExpressionEntity convertExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("convert_expression_location", convertExpressionEntity, location);
+        }
+
+        internal static void exit_statement_pipeline(this TextWriter trapFile, ExitStatementEntity exitStatementEntity, Entity expression)
+        {
+            trapFile.WriteTuple("exit_statement_pipeline", exitStatementEntity, expression);
+        }
+
+        internal static void exit_statement(this TextWriter trapFile, ExitStatementEntity exitStatementEntity)
+        {
+            trapFile.WriteTuple("exit_statement", exitStatementEntity);
+        }
+
+        internal static void exit_statement_location(this TextWriter trapFile, ExitStatementEntity exitStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("exit_statement_location", exitStatementEntity, location);
+        }
+
+
+        internal static void index_expression(this TextWriter trapFile, IndexExpressionEntity indexExpressionEntity, Entity index, Entity target, bool nullConditional)
+        {
+            trapFile.WriteTuple("index_expression", indexExpressionEntity, index, target, nullConditional);
+        }
+
+        internal static void index_expression_location(this TextWriter trapFile, IndexExpressionEntity indexExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("index_expression_location", indexExpressionEntity, location);
+        }
+
+        internal static void member_expression(this TextWriter trapFile, MemberExpressionEntity memberExpressionEntity, Entity expression, Entity member, bool nullConditional, bool isStatic)
+        {
+            trapFile.WriteTuple("member_expression", memberExpressionEntity, expression, member, nullConditional, isStatic);
+        }
+
+        internal static void member_expression_location(this TextWriter trapFile, MemberExpressionEntity memberExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("member_expression_location", memberExpressionEntity, location);
+        }
+        internal static void statement_block(this TextWriter trapFile, StatementBlockEntity statementBlockEntity, int numStatements, int numTraps)
+        {
+            trapFile.WriteTuple("statement_block", statementBlockEntity, numStatements, numTraps);
+        }
+
+        internal static void statement_block_location(this TextWriter trapFile, StatementBlockEntity statementBlockEntity, Location location)
+        {
+            trapFile.WriteTuple("statement_block_location", statementBlockEntity, location);
+        }
+
+        internal static void statement_block_statement(this TextWriter trapFile, StatementBlockEntity statementBlockEntity, int index, Entity statement)
+        {
+            trapFile.WriteTuple("statement_block_statement", statementBlockEntity, index, statement);
+        }
+
+        internal static void statement_block_trap(this TextWriter trapFile, StatementBlockEntity statementBlockEntity, int index, Entity trap)
+        {
+            trapFile.WriteTuple("statement_block_trap", statementBlockEntity, index, trap);
+        }
+
+        internal static void sub_expression(this TextWriter trapFile, SubExpressionEntity subExpressionEntity, Entity subExpression)
+        {
+            trapFile.WriteTuple("sub_expression", subExpressionEntity, subExpression);
+        }
+
+        internal static void sub_expression_location(this TextWriter trapFile, SubExpressionEntity subExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("sub_expression_location", subExpressionEntity, location);
+        }
+
+        internal static void variable_expression(this TextWriter trapFile, VariableExpressionEntity variableExpressionEntity, string userPath, string driveName, bool isConstant, bool isGlobal, bool isLocal, bool isPrivate, bool isScript, bool isUnqualified, bool isUnscoped, bool isVariable, bool isDriveQualified)
+        {
+            trapFile.WriteTuple("variable_expression", variableExpressionEntity, userPath, driveName, isConstant, isGlobal, isLocal, isPrivate, isScript, isUnqualified, isUnscoped, isVariable, isDriveQualified);
+        }
+
+        internal static void variable_expression_location(this TextWriter trapFile, VariableExpressionEntity variableExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("variable_expression_location", variableExpressionEntity, location);
+        }
+        
+        internal static void command_expression(this TextWriter trapFile, CommandExpressionEntity commandExpressionEntity, Entity wrappedEntity, int numRedirections)
+        {
+            trapFile.WriteTuple("command_expression", commandExpressionEntity, wrappedEntity, numRedirections);
+        }
+
+        internal static void command_expression_location(this TextWriter trapFile, CommandExpressionEntity commandExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("command_expression_location", commandExpressionEntity, location);
+        }
+
+        internal static void command_expression_redirection(this TextWriter trapFile,
+            CommandExpressionEntity commandExpressionEntity, int index, Entity redirection)
+        {
+            trapFile.WriteTuple("command_expression_redirection", commandExpressionEntity, index, redirection);
+        }
+        
+        internal static void string_constant_expression(this TextWriter trapFile, StringConstantExpressionEntity stringConstantExpressionEntity, StringLiteralEntity value)
+        {
+            trapFile.WriteTuple("string_constant_expression", stringConstantExpressionEntity, value);
+        }
+
+        internal static void string_constant_expression_location(this TextWriter trapFile, StringConstantExpressionEntity stringConstantExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("string_constant_expression_location", stringConstantExpressionEntity, location);
+        }
+        
+        internal static void pipeline(this TextWriter trapFile, PipelineEntity pipelineEntity, int numElements)
+        {
+            trapFile.WriteTuple("pipeline", pipelineEntity, numElements);
+        }
+
+        internal static void pipeline_location(this TextWriter trapFile, PipelineEntity pipelineEntity, Location location)
+        {
+            trapFile.WriteTuple("pipeline_location", pipelineEntity, location);
+        }
+        
+        internal static void pipeline_component(this TextWriter trapFile, PipelineEntity pipelineEntity, int index, Entity component)
+        {
+            trapFile.WriteTuple("pipeline_component", pipelineEntity, index, component);
+        }
+        
+        internal static void command(this TextWriter trapFile, CommandEntity commandEntity, string name, TokenKind tokenKind, int numElements, int numRedirections)
+        {
+            trapFile.WriteTuple("command", commandEntity, name, tokenKind, numElements, numRedirections);
+        }
+
+        internal static void command_location(this TextWriter trapFile, CommandEntity commandEntity, Location location)
+        {
+            trapFile.WriteTuple("command_location", commandEntity, location);
+        }
+        
+        internal static void command_command_element(this TextWriter trapFile, CommandEntity commandEntity, int index, Entity component)
+        {
+            trapFile.WriteTuple("command_command_element", commandEntity, index, component);
+        }
+        
+        internal static void command_redirection(this TextWriter trapFile, CommandEntity commandEntity, int index, Entity component)
+        {
+            trapFile.WriteTuple("command_redirection", commandEntity, index, component);
+        }
+        
+        internal static void invoke_member_expression(this TextWriter trapFile, InvokeMemberExpressionEntity invokeMemberExpressionEntity, Entity expression, Entity member)
+        {
+            trapFile.WriteTuple("invoke_member_expression", invokeMemberExpressionEntity, expression, member);
+        }
+
+        internal static void invoke_member_expression_location(this TextWriter trapFile, InvokeMemberExpressionEntity commandEntity, Location location)
+        {
+            trapFile.WriteTuple("invoke_member_expression_location", commandEntity, location);
+        }
+        
+        internal static void invoke_member_expression_argument(this TextWriter trapFile, InvokeMemberExpressionEntity commandEntity, int index, Entity component)
+        {
+            trapFile.WriteTuple("invoke_member_expression_argument", commandEntity, index, component);
+        }
+        
+        internal static void paren_expression(this TextWriter trapFile, ParenExpressionEntity parenExpressionEntity, Entity expression)
+        {
+            trapFile.WriteTuple("paren_expression", parenExpressionEntity, expression);
+        }
+
+        internal static void paren_expression_location(this TextWriter trapFile, ParenExpressionEntity parenExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("paren_expression_location", parenExpressionEntity, location);
+        }
+
+        internal static void ternary_expression(this TextWriter trapFile, TernaryExpressionEntity ternaryExpressionEntity, Entity condition, Entity ifFalse, Entity ifTrue)
+        {
+            trapFile.WriteTuple("ternary_expression", ternaryExpressionEntity, condition, ifFalse, ifTrue);
+        }
+        internal static void ternary_expression_location(this TextWriter trapFile, TernaryExpressionEntity ternaryExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("ternary_expression_location", ternaryExpressionEntity, location);
+        }
+
+        internal static void type_expression(this TextWriter trapFile, TypeExpressionEntity typeExpressionEntity, string typeName, string typeFullName)
+        {
+            trapFile.WriteTuple("type_expression", typeExpressionEntity, typeName, typeFullName);
+        }
+
+        internal static void type_expression_location(this TextWriter trapFile, TypeExpressionEntity typeExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("type_expression_location", typeExpressionEntity, location);
+        }
+
+        internal static void command_parameter(this TextWriter trapFile, CommandParameterEntity commandParameterEntity, string paramName)
+        {
+            trapFile.WriteTuple("command_parameter", commandParameterEntity, paramName);
+        }
+        
+        internal static void command_parameter_argument(this TextWriter trapFile, CommandParameterEntity commandParameterEntity, Entity argument)
+        {
+            trapFile.WriteTuple("command_parameter_argument", commandParameterEntity, argument);
+        }
+
+        internal static void command_parameter_location(this TextWriter trapFile, CommandParameterEntity commandParameterEntity, Location location)
+        {
+            trapFile.WriteTuple("command_parameter_location", commandParameterEntity, location);
+        }
+        
+        internal static void parent(this TextWriter trapFile, Entity parent, Entity child)
+        {
+            trapFile.WriteTuple("parent", parent, child);
+        }
+        internal static void binary_expression(this TextWriter trapFile, BinaryExpressionEntity binaryExpressionEntity, TokenKind operation, Entity left, Entity right)
+        {
+            trapFile.WriteTuple("binary_expression", binaryExpressionEntity, operation, left, right);
+        }
+
+        internal static void binary_expression_location(this TextWriter trapFile, BinaryExpressionEntity binaryExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("binary_expression_location", binaryExpressionEntity, location);
+        }
+
+        internal static void param_block(this TextWriter trapFile, ParamBlockEntity paramBlockEntity, int numAttributes, int numParameters)
+        {
+            trapFile.WriteTuple("param_block", paramBlockEntity, numAttributes, numParameters);
+        }
+        
+        internal static void param_block_attribute(this TextWriter trapFile, ParamBlockEntity paramBlockEntity, int index, Entity attribute)
+        {
+            trapFile.WriteTuple("param_block_attribute", paramBlockEntity, index, attribute);
+        }
+
+        internal static void param_block_parameter(this TextWriter trapFile, ParamBlockEntity paramBlockEntity, int index, Entity parameter)
+        {
+            trapFile.WriteTuple("param_block_parameter", paramBlockEntity, index, parameter);
+        }
+        
+        internal static void param_block_location(this TextWriter trapFile, ParamBlockEntity paramBlockEntity, Location location)
+        {
+            trapFile.WriteTuple("param_block_location", paramBlockEntity, location);
+        }
+        
+        internal static void parameter(this TextWriter trapFile, ParameterEntity parameterEntity, Entity name, string type, int numAttributes)
+        {
+            trapFile.WriteTuple("parameter", parameterEntity, name, type, numAttributes);
+        }
+        
+        internal static void parameter_attribute(this TextWriter trapFile, ParameterEntity parameterEntity, int index, Entity attribute)
+        {
+            trapFile.WriteTuple("parameter_attribute", parameterEntity, index, attribute);
+        }
+
+        internal static void parameter_default_value(this TextWriter trapFile, ParameterEntity parameterEntity, Entity defaultValueExpression)
+        {
+            trapFile.WriteTuple("parameter_default_value", parameterEntity, defaultValueExpression);
+        }
+        
+        internal static void parameter_location(this TextWriter trapFile, ParameterEntity parameterEntity, Location location)
+        {
+            trapFile.WriteTuple("parameter_location", parameterEntity, location);
+        }
+        
+        internal static void attribute(this TextWriter trapFile, AttributeEntity parameterEntity, string type, int numNamedAttributes, int numPositionalAttributes)
+        {
+            trapFile.WriteTuple("attribute", parameterEntity, type, numNamedAttributes, numPositionalAttributes);
+        }
+        
+        internal static void attribute_named_argument(this TextWriter trapFile, AttributeEntity parameterEntity, int index, Entity argument)
+        {
+            trapFile.WriteTuple("attribute_named_argument", parameterEntity, index, argument);
+        }
+        
+        internal static void attribute_positional_argument(this TextWriter trapFile, AttributeEntity parameterEntity, int index, Entity argument)
+        {
+            trapFile.WriteTuple("attribute_positional_argument", parameterEntity, index, argument);
+        }
+        
+        internal static void attribute_location(this TextWriter trapFile, AttributeEntity parameterEntity, Location location)
+        {
+            trapFile.WriteTuple("attribute_location", parameterEntity, location);
+        }
+        
+        internal static void type_constraint(this TextWriter trapFile, TypeConstraintEntity typeConstraintEntity, string name, string fullname)
+        {
+            trapFile.WriteTuple("type_constraint", typeConstraintEntity, name, fullname);
+        }
+        
+        internal static void type_constraint_location(this TextWriter trapFile, TypeConstraintEntity typeConstraintEntity, Location location)
+        {
+            trapFile.WriteTuple("type_constraint_location", typeConstraintEntity, location);
+        }
+        
+        internal static void function_definition(this TextWriter trapFile, FunctionDefinitionEntity functionDefinitionEntity, Entity body, string name, bool isFilter, bool isWorkflow)
+        {
+            trapFile.WriteTuple("function_definition", functionDefinitionEntity, body, name, isFilter, isWorkflow);
+        }
+        
+        internal static void function_definition_parameter(this TextWriter trapFile, FunctionDefinitionEntity functionDefinitionEntity, int index, Entity parameter)
+        {
+            trapFile.WriteTuple("function_definition_parameter", functionDefinitionEntity, index, parameter);
+        }
+        
+        internal static void function_definition_location(this TextWriter trapFile, FunctionDefinitionEntity functionDefinitionEntity, Location location)
+        {
+            trapFile.WriteTuple("function_definition_location", functionDefinitionEntity, location);
+        }
+        
+        internal static void named_attribute_argument(this TextWriter trapFile, NamedAttributeArgumentEntity namedAttributeArgumentEntity, string name, Entity argument)
+        {
+            trapFile.WriteTuple("named_attribute_argument", namedAttributeArgumentEntity, name, argument);
+        }
+
+        internal static void named_attribute_argument_location(this TextWriter trapFile, NamedAttributeArgumentEntity namedAttributeArgumentEntity, Location location)
+        {
+            trapFile.WriteTuple("named_attribute_argument_location", namedAttributeArgumentEntity, location);
+        }
+
+        internal static void if_statement(this TextWriter trapFile, IfStatementEntity ifStatementEntity)
+        {
+            trapFile.WriteTuple("if_statement", ifStatementEntity);
+        }
+
+        internal static void if_statement_location(this TextWriter trapFile, IfStatementEntity ifStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("if_statement_location", ifStatementEntity, location);
+        }
+
+        internal static void if_statement_clause(this TextWriter trapFile, IfStatementEntity ifStatementEntity, int index, Entity pipeline, Entity statementBlock)
+        {
+            trapFile.WriteTuple("if_statement_clause", ifStatementEntity, index, pipeline, statementBlock);
+        }
+
+        internal static void if_statement_else(this TextWriter trapFile, IfStatementEntity ifStatementEntity, Entity elseItem)
+        {
+            trapFile.WriteTuple("if_statement_else", ifStatementEntity, elseItem);
+        }
+        
+        internal static void break_statement(this TextWriter trapFile, BreakStatementEntity breakStatementEntity)
+        {
+            trapFile.WriteTuple("break_statement", breakStatementEntity);
+        }
+
+        internal static void break_statement_location(this TextWriter trapFile, BreakStatementEntity breakStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("break_statement_location", breakStatementEntity, location);
+        }
+
+        internal static void statement_label(this TextWriter trapFile, Entity breakStatementEntity, Entity label)
+        {
+            trapFile.WriteTuple("statement_label", breakStatementEntity, label);
+        }
+
+        internal static void foreach_statement(this TextWriter trapFile, ForEachStatementEntity foreachStatementEntity, Entity variable, Entity condition, Entity body, ForEachFlags flags)
+        {
+            trapFile.WriteTuple("foreach_statement", foreachStatementEntity, variable, condition, body, flags);
+        }
+
+        internal static void foreach_statement_location(this TextWriter trapFile, ForEachStatementEntity foreachStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("foreach_statement_location", foreachStatementEntity, location);
+        }
+
+        internal static void for_statement(this TextWriter trapFile, ForStatementEntity forStatementEntity, Entity body)
+        {
+            trapFile.WriteTuple("for_statement", forStatementEntity, body);
+        }
+
+        internal static void for_statement_condition(this TextWriter trapFile, ForStatementEntity forStatementEntity, Entity condition)
+        {
+            trapFile.WriteTuple("for_statement_condition", forStatementEntity, condition);
+        }
+
+        internal static void for_statement_initializer(this TextWriter trapFile, ForStatementEntity forStatementEntity, Entity initializer)
+        {
+            trapFile.WriteTuple("for_statement_initializer", forStatementEntity, initializer);
+        }
+
+        internal static void for_statement_iterator(this TextWriter trapFile, ForStatementEntity forStatementEntity, Entity iterator)
+        {
+            trapFile.WriteTuple("for_statement_iterator", forStatementEntity, iterator);
+        }
+
+        internal static void for_statement_location(this TextWriter trapFile, ForStatementEntity forStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("for_statement_location", forStatementEntity, location);
+        }
+
+        internal static void continue_statement(this TextWriter trapFile, ContinueStatementEntity continueStatementEntity)
+        {
+            trapFile.WriteTuple("continue_statement", continueStatementEntity);
+        }
+
+        internal static void continue_statement_location(this TextWriter trapFile, ContinueStatementEntity continueStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("continue_statement_location", continueStatementEntity, location);
+        }
+
+        internal static void return_statement(this TextWriter trapFile, ReturnStatementEntity returnStatementEntity)
+        {
+            trapFile.WriteTuple("return_statement", returnStatementEntity);
+        }
+
+        internal static void return_statement_location(this TextWriter trapFile, ReturnStatementEntity returnStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("return_statement_location", returnStatementEntity, location);
+        }
+
+        internal static void return_statement_pipeline(this TextWriter trapFile, ReturnStatementEntity returnStatementEntity, Entity pipeline)
+        {
+            trapFile.WriteTuple("return_statement_pipeline", returnStatementEntity, pipeline);
+        }
+
+        internal static void while_statement(this TextWriter trapFile, WhileStatementEntity whileStatementEntity, Entity body)
+        {
+            trapFile.WriteTuple("while_statement", whileStatementEntity, body);
+        }
+
+        internal static void while_statement_condition(this TextWriter trapFile, WhileStatementEntity whileStatementEntity, Entity condition)
+        {
+            trapFile.WriteTuple("while_statement_condition", whileStatementEntity, condition);
+        }
+
+        internal static void while_statement_location(this TextWriter trapFile, WhileStatementEntity whileStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("while_statement_location", whileStatementEntity, location);
+        }
+
+        internal static void do_until_statement(this TextWriter trapFile, DoUntilStatementEntity doUntilStatementEntity, Entity body)
+        {
+            trapFile.WriteTuple("do_until_statement", doUntilStatementEntity, body);
+        }
+
+        internal static void do_until_statement_condition(this TextWriter trapFile, DoUntilStatementEntity doUntilStatementEntity, Entity condition)
+        {
+            trapFile.WriteTuple("do_until_statement_condition", doUntilStatementEntity, condition);
+        }
+
+        internal static void do_until_statement_location(this TextWriter trapFile, DoUntilStatementEntity doUntilStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("do_until_statement_location", doUntilStatementEntity, location);
+        }
+
+        internal static void do_while_statement(this TextWriter trapFile, DoWhileStatementEntity doWhileStatementEntity, Entity body)
+        {
+            trapFile.WriteTuple("do_while_statement", doWhileStatementEntity, body);
+        }
+
+        internal static void do_while_statement_condition(this TextWriter trapFile, DoWhileStatementEntity doWhileStatementEntity, Entity condition)
+        {
+            trapFile.WriteTuple("do_while_statement_condition", doWhileStatementEntity, condition);
+        }
+
+        internal static void do_while_statement_location(this TextWriter trapFile, DoWhileStatementEntity doWhileStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("do_while_statement_location", doWhileStatementEntity, location);
+        }
+
+        internal static void label(this TextWriter trapFile, CachedEntity labelledStatementEntity, string label)
+        {
+            trapFile.WriteTuple("label", labelledStatementEntity, label);
+        }
+
+        internal static void expandable_string_expression(this TextWriter trapFile, ExpandableStringExpressionEntity expandableStringExpressionEntity, StringLiteralEntity value, StringConstantType type, int numExpressions)
+        {
+            trapFile.WriteTuple("expandable_string_expression", expandableStringExpressionEntity, value, type, numExpressions);
+        }
+
+        internal static void expandable_string_expression_location(this TextWriter trapFile, ExpandableStringExpressionEntity expandableStringExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("expandable_string_expression_location", expandableStringExpressionEntity, location);
+        }
+
+        internal static void expandable_string_expression_nested_expression(this TextWriter trapFile, ExpandableStringExpressionEntity expandableStringExpressionEntity, int index, Entity nestedExpression)
+        {
+            trapFile.WriteTuple("expandable_string_expression_nested_expression", expandableStringExpressionEntity, index, nestedExpression);
+        }
+
+        internal static void unary_expression(this TextWriter trapFile, UnaryExpressionEntity unaryExpressionEntity, Entity child, TokenKind kind, string staticType)
+        {
+            trapFile.WriteTuple("unary_expression", unaryExpressionEntity, child, kind, staticType);
+        }
+
+        internal static void unary_expression_location(this TextWriter trapFile, UnaryExpressionEntity unaryExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("unary_expression_location", unaryExpressionEntity, location);
+        }
+
+        internal static void catch_clause(this TextWriter trapFile, CatchClauseEntity catchClauseEntity, Entity body, bool isCatchAll){
+            trapFile.WriteTuple("catch_clause", catchClauseEntity, body, isCatchAll);
+        }
+
+        internal static void catch_clause_catch_type(this TextWriter trapFile, CatchClauseEntity catchClauseEntity, int index, Entity catchType)
+        {
+            trapFile.WriteTuple("catch_clause_catch_type", catchClauseEntity, index, catchType);
+        }
+
+        internal static void catch_clause_location(this TextWriter trapFile, CatchClauseEntity catchClauseEntity, Location location)
+        {
+            trapFile.WriteTuple("catch_clause_location", catchClauseEntity, location);
+        }
+
+        internal static void try_statement(this TextWriter trapFile, TryStatementEntity tryStatementEntity, Entity body)
+        {
+            trapFile.WriteTuple("try_statement", tryStatementEntity, body);
+        }
+
+        internal static void try_statement_catch_clause(this TextWriter trapFile, TryStatementEntity tryStatementEntity, int index, Entity catchClause)
+        {
+            trapFile.WriteTuple("try_statement_catch_clause", tryStatementEntity, index, catchClause);
+        }
+
+        internal static void try_statement_finally(this TextWriter trapFile, TryStatementEntity tryStatementEntity, Entity finallyClause)
+        {
+            trapFile.WriteTuple("try_statement_finally", tryStatementEntity, finallyClause);
+        }
+
+        internal static void try_statement_location(this TextWriter trapFile, TryStatementEntity tryStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("try_statement_location", tryStatementEntity, location);
+        }
+
+        internal static void throw_statement(this TextWriter trapFile, ThrowStatementEntity throwStatementEntity, bool isRethrow)
+        {
+            trapFile.WriteTuple("throw_statement", throwStatementEntity, isRethrow);
+        }
+
+        internal static void throw_statement_location(this TextWriter trapFile, ThrowStatementEntity throwStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("throw_statement_location", throwStatementEntity, location);
+        }
+
+        internal static void throw_statement_pipeline(this TextWriter trapFile, ThrowStatementEntity throwStatementEntity, Entity pipeline)
+        {
+            trapFile.WriteTuple("throw_statement_pipeline", throwStatementEntity, pipeline);
+        }
+
+        internal static void string_literal(this TextWriter trapFile, StringLiteralEntity stringLiteralEntity)
+        {
+            trapFile.WriteTuple("string_literal", stringLiteralEntity);
+        }
+
+        internal static void string_literal_location(this TextWriter trapFile, StringLiteralEntity stringLiteralEntity, Location location)
+        {
+            trapFile.WriteTuple("string_literal_location", stringLiteralEntity, location);
+        }
+
+        internal static void string_literal_line(this TextWriter trapFile, StringLiteralEntity stringLiteralEntity,
+            int index, string line)
+        {
+            trapFile.WriteTuple("string_literal_line", stringLiteralEntity, index, line);
+        }
+
+        internal static void trap_statement(this TextWriter trapFile, TrapStatementEntity trapStatementEntity, Entity body)
+        {
+            trapFile.WriteTuple("trap_statement", trapStatementEntity, body);
+        }
+
+        internal static void trap_statement_type(this TextWriter trapFile, TrapStatementEntity trapStatementEntity,
+            TypeConstraintEntity typeConstraintEntity)
+        {
+            trapFile.WriteTuple("trap_statement_type", trapStatementEntity, typeConstraintEntity);
+        }
+
+        internal static void trap_statement_location(this TextWriter trapFile, TrapStatementEntity trapStatementEntity, Entity location)
+        {
+            trapFile.WriteTuple("trap_statement_location", trapStatementEntity, location);
+        }
+        
+        internal static void file_redirection(this TextWriter trapFile, FileRedirectionEntity fileRedirectionEntity, Entity location, bool isAppend, RedirectionStream stream)
+        {
+            trapFile.WriteTuple("file_redirection", fileRedirectionEntity, location, isAppend, stream);
+        }
+
+        internal static void file_redirection_location(this TextWriter trapFile, FileRedirectionEntity fileRedirectionEntity, Location location)
+        {
+            trapFile.WriteTuple("file_redirection_location", fileRedirectionEntity, location);
+        }
+
+        internal static void block_statement(this TextWriter trapFile, BlockStatementEntity blockStatementEntity, Entity body, TokenEntity token)
+        {
+            trapFile.WriteTuple("block_statement", blockStatementEntity, body, token);
+        }
+
+        internal static void block_statement_location(this TextWriter trapFile, BlockStatementEntity blockStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("block_statement_location", blockStatementEntity, location);
+        }
+
+        internal static void token(this TextWriter trapFile, TokenEntity tokenEntity, bool hasError, TokenKind kind, string text, TokenFlags flags)
+        {
+            trapFile.WriteTuple("token", tokenEntity, hasError, kind, text, flags);
+        }
+
+        internal static void token_location(this TextWriter trapFile, TokenEntity tokenEntity, Location location)
+        {
+            trapFile.WriteTuple("token_location", tokenEntity, location);
+        }
+
+        internal static void configuration_definition(this TextWriter trapFile, ConfigurationDefinitionEntity configurationDefinitionEntity, Entity body, ConfigurationType type, Entity name)
+        {
+            trapFile.WriteTuple("configuration_definition", configurationDefinitionEntity, body, type, name);
+        }
+
+        internal static void configuration_definition_location(this TextWriter trapFile, ConfigurationDefinitionEntity configurationDefinitionEntity, Location location)
+        {
+            trapFile.WriteTuple("configuration_definition_location", configurationDefinitionEntity, location);
+        }
+
+        internal static void data_statement(this TextWriter trapFile, DataStatementEntity dataStatementEntity, Entity body)
+        {
+            trapFile.WriteTuple("data_statement", dataStatementEntity, body);
+        }
+
+        internal static void data_statement_location(this TextWriter trapFile, DataStatementEntity dataStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("data_statement_location", dataStatementEntity, location);
+        }
+
+        internal static void data_statement_variable(this TextWriter trapFile, DataStatementEntity dataStatementEntity, string variable)
+        {
+            trapFile.WriteTuple("data_statement_variable", dataStatementEntity, variable);
+        }
+
+        internal static void data_statement_commands_allowed(this TextWriter trapFile, DataStatementEntity dataStatementEntity, int index, Entity commandAllowed)
+        {
+            trapFile.WriteTuple("data_statement_commands_allowed", dataStatementEntity, index, commandAllowed);
+        }
+
+        internal static void dynamic_keyword_statement(this TextWriter trapFile, DynamicKeywordStatementEntity dynamicKeywordStatementEntity)
+        {
+            trapFile.WriteTuple("dynamic_keyword_statement", dynamicKeywordStatementEntity);
+        }
+
+        internal static void dynamic_keyword_statement_location(this TextWriter trapFile, DynamicKeywordStatementEntity dynamicKeywordStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("dynamic_keyword_statement_location", dynamicKeywordStatementEntity, location);
+        }
+
+        internal static void dynamic_keyword_statement_command_elements(this TextWriter trapFile, DynamicKeywordStatementEntity dynamicKeywordStatementEntity, int index, Entity commandElement)
+        {
+            trapFile.WriteTuple("dynamic_keyword_statement_command_elements", dynamicKeywordStatementEntity, index, commandElement);
+        }
+
+        internal static void error_expression(this TextWriter trapFile, ErrorExpressionEntity errorExpressionEntity)
+        {
+            trapFile.WriteTuple("error_expression", errorExpressionEntity);
+        }
+
+        internal static void error_expression_nested_ast(this TextWriter trapFile, ErrorExpressionEntity errorExpressionEntity, int index, Entity nestedAst)
+        {
+            trapFile.WriteTuple("error_expression_nested_ast", errorExpressionEntity, index, nestedAst);
+        }
+
+        internal static void error_expression_location(this TextWriter trapFile, ErrorExpressionEntity errorExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("error_expression_location", errorExpressionEntity, location);
+        }
+
+        internal static void error_statement(this TextWriter trapFile, ErrorStatementEntity errorStatementEntity, TokenEntity token)
+        {
+            trapFile.WriteTuple("error_statement", errorStatementEntity, token);
+        }
+
+        internal static void error_statement_flag(this TextWriter trapFile, ErrorStatementEntity errorStatementEntity, int index, string flagKey, TokenEntity token, Entity ast)
+        {
+            trapFile.WriteTuple("error_statement_flag", errorStatementEntity, index, flagKey, token, ast);    
+        }
+
+        internal static void error_statement_nested_ast(this TextWriter trapFile, ErrorStatementEntity errorStatementEntity, int index, Entity nestedAst)
+        {
+            trapFile.WriteTuple("error_statement_nested_ast", errorStatementEntity, index, nestedAst);
+        }
+
+        internal static void error_statement_conditions(this TextWriter trapFile, ErrorStatementEntity errorStatementEntity, int index, Entity condition)
+        {
+            trapFile.WriteTuple("error_statement_conditions", errorStatementEntity, index, condition);
+        }
+
+        internal static void error_statement_bodies(this TextWriter trapFile, ErrorStatementEntity errorStatementEntity, int index, Entity body)
+        {
+            trapFile.WriteTuple("error_statement_bodies", errorStatementEntity, index, body);
+        }
+
+        internal static void error_statement_location(this TextWriter trapFile, ErrorStatementEntity errorStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("error_statement_location", errorStatementEntity, location);
+        }
+
+        internal static void function_member(this TextWriter trapFile, FunctionMemberEntity functionMemberEntity, Entity body, bool isConstructor, bool isHidden, bool isPrivate, bool isPublic, bool isStatic, string name, MethodAttributes attributes)
+        {
+            trapFile.WriteTuple("function_member", functionMemberEntity, body, isConstructor, isHidden, isPrivate, isPublic, isStatic, name, attributes);
+        }
+
+        internal static void function_member_parameter(this TextWriter trapFile, FunctionMemberEntity functionMemberEntity, int index, Entity parameter)
+        {
+            trapFile.WriteTuple("function_member_parameter", functionMemberEntity, index, parameter);
+        }
+
+        internal static void function_member_attribute(this TextWriter trapFile, FunctionMemberEntity functionMemberEntity, int index, Entity attribute)
+        {
+            trapFile.WriteTuple("function_member_attribute", functionMemberEntity, index, attribute);
+        }
+
+        internal static void function_member_return_type(this TextWriter trapFile, FunctionMemberEntity functionMemberEntity, Entity returnType)
+        {
+            trapFile.WriteTuple("function_member_return_type", functionMemberEntity, returnType);
+        }
+
+        internal static void function_member_location(this TextWriter trapFile, FunctionMemberEntity functionMemberEntity, Location location)
+        {
+            trapFile.WriteTuple("function_member_location", functionMemberEntity, location);
+        }
+
+        internal static void merging_redirection(this TextWriter trapFile, MergingRedirectionEntity mergingRedirectionEntity, RedirectionStream from, RedirectionStream to)
+        {
+            trapFile.WriteTuple("merging_redirection", mergingRedirectionEntity, from, to);
+        }
+
+        internal static void merging_redirection_location(this TextWriter trapFile, MergingRedirectionEntity mergingRedirectionEntity, Location location)
+        {
+            trapFile.WriteTuple("merging_redirection_location", mergingRedirectionEntity, location);
+        }
+
+        internal static void pipeline_chain(this TextWriter trapFile, PipelineChainEntity pipelineChainEntity, bool isBackground, TokenKind kind, Entity left, Entity right)
+        {
+            trapFile.WriteTuple("pipeline_chain", pipelineChainEntity, isBackground, kind, left, right);
+        }
+
+        internal static void pipeline_chain_location(this TextWriter trapFile, PipelineChainEntity pipelineChainEntity, Location location)
+        {
+            trapFile.WriteTuple("pipeline_chain_location", pipelineChainEntity, location);
+        }
+
+        internal static void property_member(this TextWriter trapFile, PropertyMemberEntity propertyMemberEntity, bool isHidden, bool isPrivate, bool isPublic, bool isStatic, string name, PropertyAttributes attributes)
+        {
+            trapFile.WriteTuple("property_member", propertyMemberEntity, isHidden, isPrivate, isPublic, isStatic, name, attributes);
+        }
+
+        internal static void property_member_attribute(this TextWriter trapFile, PropertyMemberEntity propertyMemberEntity, int index, Entity attribute)
+        {
+            trapFile.WriteTuple("property_member_attribute", propertyMemberEntity, index, attribute);
+        }
+
+        internal static void property_member_property_type(this TextWriter trapFile, PropertyMemberEntity propertyMemberEntity, Entity propertyType)
+        {
+            trapFile.WriteTuple("property_member_property_type", propertyMemberEntity, propertyType);
+        }
+
+        internal static void property_member_initial_value(this TextWriter trapFile, PropertyMemberEntity propertyMemberEntity, Entity initialValue)
+        {
+            trapFile.WriteTuple("property_member_initial_value", propertyMemberEntity, initialValue);
+        }
+
+        internal static void property_member_location(this TextWriter trapFile, PropertyMemberEntity propertyMemberEntity, Location location)
+        {
+            trapFile.WriteTuple("property_member_location", propertyMemberEntity, location);
+        }
+
+        internal static void script_block_expression(this TextWriter trapFile, ScriptBlockExpressionEntity scriptBlockExpressionEntity, ScriptBlockEntity body)
+        {
+            trapFile.WriteTuple("script_block_expression", scriptBlockExpressionEntity, body);
+        }
+
+        internal static void script_block_expression_location(this TextWriter trapFile, ScriptBlockExpressionEntity scriptBlockExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("script_block_expression_location", scriptBlockExpressionEntity, location);
+        }
+
+        internal static void switch_statement(this TextWriter trapFile, SwitchStatementEntity switchStatementEntity, Entity expression, SwitchFlags flags)
+        {
+            trapFile.WriteTuple("switch_statement", switchStatementEntity, expression, flags);
+        }
+
+        internal static void switch_statement_clauses(this TextWriter trapFile, SwitchStatementEntity switchStatementEntity, int index, Entity expression, Entity statementBlock)
+        {
+            trapFile.WriteTuple("switch_statement_clauses", switchStatementEntity, index, expression, statementBlock);
+        }
+
+        internal static void switch_statement_default(this TextWriter trapFile, SwitchStatementEntity switchStatementEntity, Entity defaultAst)
+        {
+            trapFile.WriteTuple("switch_statement_default", switchStatementEntity, defaultAst);
+        }
+
+        internal static void switch_statement_location(this TextWriter trapFile, SwitchStatementEntity switchStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("switch_statement_location", switchStatementEntity, location);
+        }
+
+        internal static void type_definition(this TextWriter trapFile, TypeDefinitionEntity typeDefinitionEntity, string name, TypeAttributes typeAttributes, bool isClass, bool isEnum, bool IsInterface)
+        {
+            trapFile.WriteTuple("type_definition", typeDefinitionEntity, name, typeAttributes, isClass, isEnum, IsInterface);
+        }
+
+        internal static void type_definition_location(this TextWriter trapFile, TypeDefinitionEntity typeDefinitionEntity, Location location)
+        {
+            trapFile.WriteTuple("type_definition_location", typeDefinitionEntity, location);
+        }
+
+        internal static void type_definition_members(this TextWriter trapFile, TypeDefinitionEntity typeDefinitionEntity, int index, Entity member)
+        {
+            trapFile.WriteTuple("type_definition_members", typeDefinitionEntity, index, member);
+        }
+
+        internal static void type_definition_attributes(this TextWriter trapFile, TypeDefinitionEntity typeDefinitionEntity, int index, Entity attribute)
+        {
+            trapFile.WriteTuple("type_definition_attributes", typeDefinitionEntity, index, attribute);
+        }
+
+        internal static void type_definition_base_type(this TextWriter trapFile, TypeDefinitionEntity typeDefinitionEntity, int index, TypeConstraintEntity baseType)
+        {
+            trapFile.WriteTuple("type_definition_base_type", typeDefinitionEntity, index, baseType);
+        }
+
+        internal static void using_expression(this TextWriter trapFile, UsingExpressionEntity usingExpressionEntity, Entity expression)
+        {
+            trapFile.WriteTuple("using_expression", usingExpressionEntity, expression);
+        }
+
+        internal static void using_expression_location(this TextWriter trapFile, UsingExpressionEntity usingExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("using_expression_location", usingExpressionEntity, location);
+        }
+
+        internal static void using_statement(this TextWriter trapFile, UsingStatementEntity usingStatementEntity, UsingStatementKind kind){
+            trapFile.WriteTuple("using_statement", usingStatementEntity, kind);
+        }
+
+        internal static void using_statement_location(this TextWriter trapFile, UsingStatementEntity usingStatementEntity, Location location)
+        {
+            trapFile.WriteTuple("using_statement_location", usingStatementEntity, location);
+        }
+
+        internal static void using_statement_alias(this TextWriter trapFile, UsingStatementEntity usingStatementEntity, Entity alias)
+        {
+            trapFile.WriteTuple("using_statement_alias", usingStatementEntity, alias);
+        }
+
+        internal static void using_statement_module_specification(this TextWriter trapFile, UsingStatementEntity usingStatementEntity, HashtableEntity moduleSpecification)
+        {
+            trapFile.WriteTuple("using_statement_module_specification", usingStatementEntity, moduleSpecification);
+        }
+
+        internal static void using_statement_name(this TextWriter trapFile, UsingStatementEntity usingStatementEntity, Entity name)
+        {
+            trapFile.WriteTuple("using_statement_name", usingStatementEntity, name);
+        }
+
+        internal static void hash_table(this TextWriter trapFile, HashtableEntity hashtableEntity)
+        {
+            trapFile.WriteTuple("hash_table", hashtableEntity);
+        }
+
+        internal static void hash_table_location(this TextWriter trapFile, HashtableEntity hashtableEntity, Location location)
+        {
+            trapFile.WriteTuple("hash_table_location", hashtableEntity, location);
+        }
+
+        internal static void hash_table_key_value_pairs(this TextWriter trapFile, HashtableEntity hashtableEntity, int index, Entity key, Entity value)
+        {
+            trapFile.WriteTuple("hash_table_key_value_pairs", hashtableEntity, index, key, value);
+        }
+
+        internal static void attributed_expression(this TextWriter trapFile, AttributedExpressionEntity attributedExpressionEntity, Entity attribute, Entity child)
+        {
+            trapFile.WriteTuple("attributed_expression", attributedExpressionEntity, attribute, child);
+        }
+
+        internal static void attributed_expression_location(this TextWriter trapFile, AttributedExpressionEntity attributedExpressionEntity, Location location)
+        {
+            trapFile.WriteTuple("attributed_expression_location", attributedExpressionEntity, location);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.Tests/FilePattern.cs
+++ b/powershell/extractor/Semmle.Extraction.Tests/FilePattern.cs
@@ -1,0 +1,48 @@
+﻿using Xunit;
+
+namespace Semmle.Extraction.Tests
+{
+    public class FilePatternTests
+    {
+        [Fact]
+        public void TestRegexCompilation()
+        {
+            var fp = new FilePattern("/hadoop*");
+            Assert.Equal("^hadoop[^/]*.*", fp.RegexPattern);
+            fp = new FilePattern("**/org/apache/hadoop");
+            Assert.Equal("^.*/org/apache/hadoop.*", fp.RegexPattern);
+            fp = new FilePattern("hadoop-common/**/test//    ");
+            Assert.Equal("^hadoop-common/.*/test(?<doubleslash>/).*", fp.RegexPattern);
+            fp = new FilePattern(@"-C:\agent\root\asdf//");
+            Assert.Equal("^C:/agent/root/asdf(?<doubleslash>/).*", fp.RegexPattern);
+            fp = new FilePattern(@"-C:\agent+\[root]\asdf//");
+            Assert.Equal(@"^C:/agent\+/\[root]/asdf(?<doubleslash>/).*", fp.RegexPattern);
+        }
+
+        [Fact]
+        public void TestMatching()
+        {
+            var fp1 = new FilePattern(@"C:\agent\root\abc//");
+            var fp2 = new FilePattern(@"C:\agent\root\def//ghi");
+            var patterns = new[] { fp1, fp2 };
+
+            var success = FilePattern.Matches(patterns, @"C:\agent\root\abc\file.cs", out var s);
+            Assert.True(success);
+            Assert.Equal("/file.cs", s);
+
+            success = FilePattern.Matches(patterns, @"C:\agent\root\def\ghi\file.cs", out s);
+            Assert.True(success);
+            Assert.Equal("/ghi/file.cs", s);
+
+            success = FilePattern.Matches(patterns, @"C:\agent\root\def\file.cs", out _);
+            Assert.False(success);
+        }
+
+        [Fact]
+        public void TestInvalidPatterns()
+        {
+            Assert.Throws<InvalidFilePatternException>(() => new FilePattern("/abc//def//ghi"));
+            Assert.Throws<InvalidFilePatternException>(() => new FilePattern("/abc**def"));
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.Tests/Layout.cs
+++ b/powershell/extractor/Semmle.Extraction.Tests/Layout.cs
@@ -1,0 +1,231 @@
+using System.IO;
+using Xunit;
+using Semmle.Util.Logging;
+using System.Runtime.InteropServices;
+
+namespace Semmle.Extraction.Tests
+{
+    internal struct TransformedPathStub : PathTransformer.ITransformedPath
+    {
+        private readonly string value;
+        public TransformedPathStub(string value) => this.value = value;
+        public string Value => value;
+
+        public string Extension => throw new System.NotImplementedException();
+
+        public string NameWithoutExtension => throw new System.NotImplementedException();
+
+        public PathTransformer.ITransformedPath ParentDirectory => throw new System.NotImplementedException();
+
+        public string DatabaseId => throw new System.NotImplementedException();
+
+        public PathTransformer.ITransformedPath WithSuffix(string suffix)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    public class Layout
+    {
+        private readonly ILogger logger = new LoggerMock();
+
+        [Fact]
+        public void TestDefaultLayout()
+        {
+            var layout = new Semmle.Extraction.Layout(null, null, null);
+            var project = layout.LookupProjectOrNull(new TransformedPathStub("foo.cs"));
+
+            Assert.NotNull(project);
+
+            // All files are mapped when there's no layout file.
+            Assert.True(layout.FileInLayout(new TransformedPathStub("foo.cs")));
+
+            // Test trap filename
+            var tmpDir = Path.GetTempPath();
+            Directory.SetCurrentDirectory(tmpDir);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // `Directory.SetCurrentDirectory()` seems to slightly change the path on macOS,
+                // so adjusting it:
+                Assert.NotEqual(Directory.GetCurrentDirectory(), tmpDir);
+                tmpDir = "/private" + tmpDir;
+                // Remove trailing slash:
+                Assert.Equal('/', tmpDir[tmpDir.Length - 1]);
+                tmpDir = tmpDir.Substring(0, tmpDir.Length - 1);
+                Assert.Equal(Directory.GetCurrentDirectory(), tmpDir);
+            }
+            var f1 = project!.GetTrapPath(logger, new TransformedPathStub("foo.cs"), TrapWriter.CompressionMode.Gzip);
+            var g1 = TrapWriter.NestPaths(logger, tmpDir, "foo.cs.trap.gz");
+            Assert.Equal(f1, g1);
+
+            // Test trap file generation
+            var trapwriterFilename = project.GetTrapPath(logger, new TransformedPathStub("foo.cs"), TrapWriter.CompressionMode.Gzip);
+            using (var trapwriter = project.CreateTrapWriter(logger, new TransformedPathStub("foo.cs"), TrapWriter.CompressionMode.Gzip, discardDuplicates: false))
+            {
+                trapwriter.Emit("1=*");
+                Assert.False(File.Exists(trapwriterFilename));
+            }
+            Assert.True(File.Exists(trapwriterFilename));
+            File.Delete(trapwriterFilename);
+        }
+
+        [Fact]
+        public void TestLayoutFile()
+        {
+            File.WriteAllLines("layout.txt", new string[]
+            {
+                "# Section",
+                "TRAP_FOLDER=" + Path.GetFullPath("snapshot\\trap"),
+                "ODASA_DB=snapshot\\db-csharp",
+                "SOURCE_ARCHIVE=" + Path.GetFullPath("snapshot\\archive"),
+                "ODASA_BUILD_ERROR_DIR=snapshot\build-errors",
+                "-foo.cs",
+                "bar.cs",
+                "-excluded",
+                "excluded/foo.cs",
+                "included"
+            });
+
+            var layout = new Semmle.Extraction.Layout(null, null, "layout.txt");
+
+            // Test general pattern matching
+            Assert.True(layout.FileInLayout(new TransformedPathStub("bar.cs")));
+            Assert.False(layout.FileInLayout(new TransformedPathStub("foo.cs")));
+            Assert.False(layout.FileInLayout(new TransformedPathStub("goo.cs")));
+            Assert.False(layout.FileInLayout(new TransformedPathStub("excluded/bar.cs")));
+            Assert.True(layout.FileInLayout(new TransformedPathStub("excluded/foo.cs")));
+            Assert.True(layout.FileInLayout(new TransformedPathStub("included/foo.cs")));
+
+            // Test the trap file
+            var project = layout.LookupProjectOrNull(new TransformedPathStub("bar.cs"));
+            Assert.NotNull(project);
+            var trapwriterFilename = project!.GetTrapPath(logger, new TransformedPathStub("bar.cs"), TrapWriter.CompressionMode.Gzip);
+            Assert.Equal(TrapWriter.NestPaths(logger, Path.GetFullPath("snapshot\\trap"), "bar.cs.trap.gz"),
+                trapwriterFilename);
+
+            // Test the source archive
+            var trapWriter = project.CreateTrapWriter(logger, new TransformedPathStub("bar.cs"), TrapWriter.CompressionMode.Gzip, discardDuplicates: false);
+            trapWriter.Archive("layout.txt", new TransformedPathStub("layout.txt"), System.Text.Encoding.ASCII);
+            var writtenFile = TrapWriter.NestPaths(logger, Path.GetFullPath("snapshot\\archive"), "layout.txt");
+            Assert.True(File.Exists(writtenFile));
+            File.Delete("layout.txt");
+        }
+
+        [Fact]
+        public void TestTrapOverridesLayout()
+        {
+            // When you specify both a trap file and a layout, use the trap file.
+            var layout = new Semmle.Extraction.Layout(Path.GetFullPath("snapshot\\trap"), null, "something.txt");
+            Assert.True(layout.FileInLayout(new TransformedPathStub("bar.cs")));
+            var subProject = layout.LookupProjectOrNull(new TransformedPathStub("foo.cs"));
+            Assert.NotNull(subProject);
+            var f1 = subProject!.GetTrapPath(logger, new TransformedPathStub("foo.cs"), TrapWriter.CompressionMode.Gzip);
+            var g1 = TrapWriter.NestPaths(logger, Path.GetFullPath("snapshot\\trap"), "foo.cs.trap.gz");
+            Assert.Equal(f1, g1);
+        }
+
+        [Fact]
+        public void TestMultipleSections()
+        {
+            File.WriteAllLines("layout.txt", new string[]
+            {
+                "# Section 1",
+                "TRAP_FOLDER=" + Path.GetFullPath("snapshot\\trap1"),
+                "ODASA_DB=snapshot\\db-csharp",
+                "SOURCE_ARCHIVE=" + Path.GetFullPath("snapshot\\archive1"),
+                "ODASA_BUILD_ERROR_DIR=snapshot\build-errors",
+                "foo.cs",
+                "# Section 2",
+                "TRAP_FOLDER=" + Path.GetFullPath("snapshot\\trap2"),
+                "ODASA_DB=snapshot\\db-csharp",
+                "SOURCE_ARCHIVE=" + Path.GetFullPath("snapshot\\archive2"),
+                "ODASA_BUILD_ERROR_DIR=snapshot\build-errors",
+                "bar.cs",
+            });
+
+            var layout = new Semmle.Extraction.Layout(null, null, "layout.txt");
+
+            // Use Section 2
+            Assert.True(layout.FileInLayout(new TransformedPathStub("bar.cs")));
+            var subProject = layout.LookupProjectOrNull(new TransformedPathStub("bar.cs"));
+            Assert.NotNull(subProject);
+            var f1 = subProject!.GetTrapPath(logger, new TransformedPathStub("bar.cs"), TrapWriter.CompressionMode.Gzip);
+            var g1 = TrapWriter.NestPaths(logger, Path.GetFullPath("snapshot\\trap2"), "bar.cs.trap.gz");
+            Assert.Equal(f1, g1);
+
+            // Use Section 1
+            Assert.True(layout.FileInLayout(new TransformedPathStub("foo.cs")));
+            subProject = layout.LookupProjectOrNull(new TransformedPathStub("foo.cs"));
+            Assert.NotNull(subProject);
+            var f2 = subProject!.GetTrapPath(logger, new TransformedPathStub("foo.cs"), TrapWriter.CompressionMode.Gzip);
+            var g2 = TrapWriter.NestPaths(logger, Path.GetFullPath("snapshot\\trap1"), "foo.cs.trap.gz");
+            Assert.Equal(f2, g2);
+
+            // boo.dll is not in the layout, so use layout from first section.
+            Assert.False(layout.FileInLayout(new TransformedPathStub("boo.dll")));
+            var f3 = layout.LookupProjectOrDefault(new TransformedPathStub("boo.dll")).GetTrapPath(logger, new TransformedPathStub("boo.dll"), TrapWriter.CompressionMode.Gzip);
+            var g3 = TrapWriter.NestPaths(logger, Path.GetFullPath("snapshot\\trap1"), "boo.dll.trap.gz");
+            Assert.Equal(f3, g3);
+
+            // boo.cs is not in the layout, so return null
+            Assert.False(layout.FileInLayout(new TransformedPathStub("boo.cs")));
+            Assert.Null(layout.LookupProjectOrNull(new TransformedPathStub("boo.cs")));
+        }
+
+        [Fact]
+        public void MissingLayout()
+        {
+            Assert.Throws<Extraction.Layout.InvalidLayoutException>(() =>
+               new Semmle.Extraction.Layout(null, null, "nosuchfile.txt"));
+        }
+
+        [Fact]
+        public void EmptyLayout()
+        {
+            File.Create("layout.txt").Close();
+            Assert.Throws<Extraction.Layout.InvalidLayoutException>(() =>
+                new Semmle.Extraction.Layout(null, null, "layout.txt"));
+        }
+
+        [Fact]
+        public void InvalidLayout()
+        {
+            File.WriteAllLines("layout.txt", new string[]
+            {
+                "# Section 1"
+            });
+
+            Assert.Throws<Extraction.Layout.InvalidLayoutException>(() =>
+                new Semmle.Extraction.Layout(null, null, "layout.txt"));
+        }
+
+        private sealed class LoggerMock : ILogger
+        {
+            public void Dispose() { }
+
+            public void Log(Severity s, string text) { }
+        }
+    }
+
+    internal static class TrapWriterTestExtensions
+    {
+        public static void Emit(this TrapWriter trapFile, string s)
+        {
+            trapFile.Emit(new StringTrapEmitter(s));
+        }
+
+        private class StringTrapEmitter : ITrapEmitter
+        {
+            private readonly string content;
+            public StringTrapEmitter(string content)
+            {
+                this.content = content;
+            }
+
+            public void EmitTrap(TextWriter trapFile)
+            {
+                trapFile.Write(content);
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.Tests/Options.cs
+++ b/powershell/extractor/Semmle.Extraction.Tests/Options.cs
@@ -1,0 +1,209 @@
+using Xunit;
+using Semmle.Util.Logging;
+using System;
+using System.IO;
+using Semmle.Util;
+using System.Text.RegularExpressions;
+
+namespace Semmle.Extraction.Tests
+{
+    public class OptionsTests
+    {
+        private CSharp.Options? options;
+        private CSharp.Standalone.Options? standaloneOptions;
+
+        public OptionsTests()
+        {
+            Environment.SetEnvironmentVariable("SEMMLE_EXTRACTOR_OPTIONS", "");
+            Environment.SetEnvironmentVariable("LGTM_INDEX_EXTRACTOR", "");
+        }
+
+        [Fact]
+        public void DefaultOptions()
+        {
+            options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
+            Assert.True(options.Cache);
+            Assert.False(options.CIL);
+            Assert.Null(options.Framework);
+            Assert.Null(options.CompilerName);
+            Assert.Empty(options.CompilerArguments);
+            Assert.True(options.Threads >= 1);
+            Assert.Equal(Verbosity.Info, options.Verbosity);
+            Assert.False(options.Console);
+            Assert.False(options.ClrTracer);
+            Assert.False(options.PDB);
+            Assert.False(options.Fast);
+        }
+
+        [Fact]
+        public void Threads()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--threads", "3" });
+            Assert.Equal(3, options.Threads);
+        }
+
+        [Fact]
+        public void Cache()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--nocache" });
+            Assert.False(options.Cache);
+        }
+
+        [Fact]
+        public void CIL()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--cil" });
+            Assert.True(options.CIL);
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--cil", "--nocil" });
+            Assert.False(options.CIL);
+        }
+
+        [Fact]
+        public void CompilerArguments()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "x", "y", "z" });
+            Assert.Equal("x", options.CompilerArguments[0]);
+            Assert.Equal("y", options.CompilerArguments[1]);
+            Assert.Equal("z", options.CompilerArguments[2]);
+        }
+
+        [Fact]
+        public void VerbosityTests()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--verbose" });
+            Assert.Equal(Verbosity.Debug, options.Verbosity);
+
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--verbosity", "0" });
+            Assert.Equal(Verbosity.Off, options.Verbosity);
+
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--verbosity", "1" });
+            Assert.Equal(Verbosity.Error, options.Verbosity);
+
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--verbosity", "2" });
+            Assert.Equal(Verbosity.Warning, options.Verbosity);
+
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--verbosity", "3" });
+            Assert.Equal(Verbosity.Info, options.Verbosity);
+
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--verbosity", "4" });
+            Assert.Equal(Verbosity.Debug, options.Verbosity);
+
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--verbosity", "5" });
+            Assert.Equal(Verbosity.Trace, options.Verbosity);
+
+            Assert.Throws<FormatException>(() => CSharp.Options.CreateWithEnvironment(new string[] { "--verbosity", "X" }));
+        }
+
+        [Fact]
+        public void Console()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--console" });
+            Assert.True(options.Console);
+        }
+
+        [Fact]
+        public void PDB()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--pdb" });
+            Assert.True(options.PDB);
+        }
+
+        [Fact]
+        public void Compiler()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--compiler", "foo" });
+            Assert.Equal("foo", options.CompilerName);
+        }
+
+        [Fact]
+        public void Framework()
+        {
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--framework", "foo" });
+            Assert.Equal("foo", options.Framework);
+        }
+
+        [Fact]
+        public void EnvironmentVariables()
+        {
+            Environment.SetEnvironmentVariable("SEMMLE_EXTRACTOR_OPTIONS", "--cil c");
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "a", "b" });
+            Assert.True(options.CIL);
+            Assert.Equal("a", options.CompilerArguments[0]);
+            Assert.Equal("b", options.CompilerArguments[1]);
+            Assert.Equal("c", options.CompilerArguments[2]);
+
+            Environment.SetEnvironmentVariable("SEMMLE_EXTRACTOR_OPTIONS", "");
+            Environment.SetEnvironmentVariable("LGTM_INDEX_EXTRACTOR", "--nocil");
+            options = CSharp.Options.CreateWithEnvironment(new string[] { "--cil" });
+            Assert.False(options.CIL);
+        }
+
+        [Fact]
+        public void StandaloneDefaults()
+        {
+            standaloneOptions = CSharp.Standalone.Options.Create(Array.Empty<string>());
+            Assert.Equal(0, standaloneOptions.DllDirs.Count);
+            Assert.True(standaloneOptions.UseNuGet);
+            Assert.True(standaloneOptions.UseMscorlib);
+            Assert.False(standaloneOptions.SkipExtraction);
+            Assert.Null(standaloneOptions.SolutionFile);
+            Assert.True(standaloneOptions.ScanNetFrameworkDlls);
+            Assert.False(standaloneOptions.Errors);
+        }
+
+        [Fact]
+        public void StandaloneOptions()
+        {
+            standaloneOptions = CSharp.Standalone.Options.Create(new string[] { "--references:foo", "--silent", "--skip-nuget", "--skip-dotnet", "--exclude", "bar", "--nostdlib" });
+            Assert.Equal("foo", standaloneOptions.DllDirs[0]);
+            Assert.Equal("bar", standaloneOptions.Excludes[0]);
+            Assert.Equal(Verbosity.Off, standaloneOptions.Verbosity);
+            Assert.False(standaloneOptions.UseNuGet);
+            Assert.False(standaloneOptions.UseMscorlib);
+            Assert.False(standaloneOptions.ScanNetFrameworkDlls);
+            Assert.False(standaloneOptions.Errors);
+            Assert.False(standaloneOptions.Help);
+        }
+
+        [Fact]
+        public void InvalidOptions()
+        {
+            standaloneOptions = CSharp.Standalone.Options.Create(new string[] { "--references:foo", "--silent", "--no-such-option" });
+            Assert.True(standaloneOptions.Errors);
+        }
+
+        [Fact]
+        public void ShowingHelp()
+        {
+            standaloneOptions = CSharp.Standalone.Options.Create(new string[] { "--help" });
+            Assert.False(standaloneOptions.Errors);
+            Assert.True(standaloneOptions.Help);
+        }
+
+        [Fact]
+        public void Fast()
+        {
+            Environment.SetEnvironmentVariable("LGTM_INDEX_EXTRACTOR", "--fast");
+            options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
+            Assert.True(options.Fast);
+        }
+
+        [Fact]
+        public void ArchiveArguments()
+        {
+            using var sw = new StringWriter();
+            var file = Path.GetTempFileName();
+
+            try
+            {
+                File.AppendAllText(file, "Test");
+                new string[] { "/noconfig", "@" + file }.WriteCommandLine(sw);
+                Assert.Equal("Test", Regex.Replace(sw.ToString(), @"\t|\n|\r", ""));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.Tests/PathTransformer.cs
+++ b/powershell/extractor/Semmle.Extraction.Tests/PathTransformer.cs
@@ -1,0 +1,45 @@
+﻿using Semmle.Util;
+using Xunit;
+
+namespace Semmle.Extraction.Tests
+{
+    internal class PathCacheStub : IPathCache
+    {
+        public string GetCanonicalPath(string path) => path;
+    }
+
+    public class PathTransformerTests
+    {
+        [Fact]
+        public void TestTransformerFile()
+        {
+            var spec = new string[]
+            {
+                @"#D:\src",
+                @"C:\agent*\src//",
+                @"-C:\agent*\src\external",
+                @"",
+                @"#empty",
+                @"",
+                @"#src2",
+                @"/agent*//src",
+                @"",
+                @"#optsrc",
+                @"opt/src//"
+            };
+
+            var pathTransformer = new PathTransformer(new PathCacheStub(), spec);
+
+            // Windows-style matching
+            Assert.Equal(@"C:/bar.cs", pathTransformer.Transform(@"C:\bar.cs").Value);
+            Assert.Equal("D:/src/file.cs", pathTransformer.Transform(@"C:\agent42\src\file.cs").Value);
+            Assert.Equal("D:/src/file.cs", pathTransformer.Transform(@"C:\agent43\src\file.cs").Value);
+            Assert.Equal(@"C:/agent43/src/external/file.cs", pathTransformer.Transform(@"C:\agent43\src\external\file.cs").Value);
+
+            // Linux-style matching
+            Assert.Equal(@"src2/src/file.cs", pathTransformer.Transform(@"/agent/src/file.cs").Value);
+            Assert.Equal(@"src2/src/file.cs", pathTransformer.Transform(@"/agent42/src/file.cs").Value);
+            Assert.Equal(@"optsrc/file.cs", pathTransformer.Transform(@"/opt/src/file.cs").Value);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction.Tests/Properties/AssemblyInfo.cs
+++ b/powershell/extractor/Semmle.Extraction.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Semmle.Extraction.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Semmle.Extraction.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("23237396-31ef-41f8-b466-ee96ddd7b7bc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/powershell/extractor/Semmle.Extraction.Tests/Semmle.Extraction.Tests.csproj
+++ b/powershell/extractor/Semmle.Extraction.Tests/Semmle.Extraction.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Semmle.Extraction.CSharp.Standalone\Semmle.Extraction.CSharp.Standalone.csproj" />
+    <ProjectReference Include="..\Semmle.Extraction.CSharp\Semmle.Extraction.CSharp.csproj" />
+    <ProjectReference Include="..\Semmle.Extraction\Semmle.Extraction.csproj" />
+    <ProjectReference Include="..\Semmle.Util\Semmle.Util.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/powershell/extractor/Semmle.Extraction.Tests/TrapWriter.cs
+++ b/powershell/extractor/Semmle.Extraction.Tests/TrapWriter.cs
@@ -1,0 +1,52 @@
+using Xunit;
+using Semmle.Util.Logging;
+using Semmle.Util;
+
+namespace Semmle.Extraction.Tests
+{
+    public class TrapWriterTests
+    {
+        [Fact]
+        public void NestedPaths()
+        {
+            string tempDir = System.IO.Path.GetTempPath();
+            string root1, root2, root3;
+
+            if (Win32.IsWindows())
+            {
+                root1 = "E:";
+                root2 = "e:";
+                root3 = @"\";
+            }
+            else
+            {
+                root1 = "/E_";
+                root2 = "/e_";
+                root3 = "/";
+            }
+
+            using var logger = new LoggerMock();
+
+            Assert.Equal($@"C:\Temp\source_archive\def.cs", TrapWriter.NestPaths(logger, @"C:\Temp\source_archive", "def.cs").Replace('/', '\\'));
+
+            Assert.Equal(@"C:\Temp\source_archive\def.cs", TrapWriter.NestPaths(logger, @"C:\Temp\source_archive", "def.cs").Replace('/', '\\'));
+
+            Assert.Equal(@"C:\Temp\source_archive\E_\source\def.cs", TrapWriter.NestPaths(logger, @"C:\Temp\source_archive", $@"{root1}\source\def.cs").Replace('/', '\\'));
+
+            Assert.Equal(@"C:\Temp\source_archive\e_\source\def.cs", TrapWriter.NestPaths(logger, @"C:\Temp\source_archive", $@"{root2}\source\def.cs").Replace('/', '\\'));
+
+            Assert.Equal(@"C:\Temp\source_archive\source\def.cs", TrapWriter.NestPaths(logger, @"C:\Temp\source_archive", $@"{root3}source\def.cs").Replace('/', '\\'));
+
+            Assert.Equal(@"C:\Temp\source_archive\source\def.cs", TrapWriter.NestPaths(logger, @"C:\Temp\source_archive", $@"{root3}source\def.cs").Replace('/', '\\'));
+
+            Assert.Equal(@"C:\Temp\source_archive\diskstation\share\source\def.cs", TrapWriter.NestPaths(logger, @"C:\Temp\source_archive", $@"{root3}{root3}diskstation\share\source\def.cs").Replace('/', '\\'));
+        }
+
+        private sealed class LoggerMock : ILogger
+        {
+            public void Dispose() { }
+
+            public void Log(Severity s, string text) { }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/AssemblyScope.cs
+++ b/powershell/extractor/Semmle.Extraction/AssemblyScope.cs
@@ -1,0 +1,25 @@
+using Microsoft.CodeAnalysis;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// The scope of symbols in an assembly.
+    /// </summary>
+    public class AssemblyScope : IExtractionScope
+    {
+        private readonly IAssemblySymbol assembly;
+        private readonly string filepath;
+
+        public AssemblyScope(IAssemblySymbol symbol, string path)
+        {
+            assembly = symbol;
+            filepath = path;
+        }
+
+        public bool InFileScope(string path) => path == filepath;
+
+        public bool InScope(ISymbol symbol) =>
+            SymbolEqualityComparer.Default.Equals(symbol.ContainingAssembly, assembly) ||
+            SymbolEqualityComparer.Default.Equals(symbol, assembly);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Context.cs
+++ b/powershell/extractor/Semmle.Extraction/Context.cs
@@ -1,0 +1,482 @@
+using Microsoft.CodeAnalysis;
+using Semmle.Extraction.Entities;
+using Semmle.Util.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// State that needs to be available throughout the extraction process.
+    /// There is one Context object per trap output file.
+    /// </summary>
+    public class Context
+    {
+        /// <summary>
+        /// Access various extraction functions, e.g. logger, trap writer.
+        /// </summary>
+        public Extractor Extractor { get; }
+
+        /// <summary>
+        /// Access to the trap file.
+        /// </summary>
+        public TrapWriter TrapWriter { get; }
+
+        /// <summary>
+        /// Holds if assembly information should be prefixed to TRAP labels.
+        /// </summary>
+        public bool ShouldAddAssemblyTrapPrefix { get; }
+
+        public IList<object> TrapStackSuffix { get; } = new List<object>();
+
+        private int GetNewId() => TrapWriter.IdCounter++;
+
+        // A recursion guard against writing to the trap file whilst writing an id to the trap file.
+        private bool writingLabel = false;
+
+        private readonly Queue<IEntity> labelQueue = new();
+
+        protected void DefineLabel(IEntity entity)
+        {
+            if (writingLabel)
+            {
+                // Don't define a label whilst writing a label.
+                labelQueue.Enqueue(entity);
+            }
+            else
+            {
+                try
+                {
+                    writingLabel = true;
+                    entity.DefineLabel(TrapWriter.Writer, Extractor);
+                }
+                finally
+                {
+                    writingLabel = false;
+                    if (labelQueue.Any())
+                    {
+                        DefineLabel(labelQueue.Dequeue());
+                    }
+                }
+            }
+        }
+
+#if DEBUG_LABELS
+        private void CheckEntityHasUniqueLabel(string id, CachedEntity entity)
+        {
+            if (idLabelCache.ContainsKey(id))
+            {
+                this.Extractor.Message(new Message("Label collision for " + id, entity.Label.ToString(), CreateLocation(entity.ReportingLocation), "", Severity.Warning));
+            }
+            else
+            {
+                idLabelCache[id] = entity;
+            }
+        }
+#endif
+
+        protected Label GetNewLabel() => new Label(GetNewId());
+
+        internal TEntity CreateEntity<TInit, TEntity>(CachedEntityFactory<TInit, TEntity> factory, object cacheKey, TInit init)
+            where TEntity : CachedEntity =>
+                cacheKey is ISymbol s ? CreateEntity(factory, s, init, symbolEntityCache) : CreateEntity(factory, cacheKey, init, objectEntityCache);
+
+        internal TEntity CreateEntityFromSymbol<TSymbol, TEntity>(CachedEntityFactory<TSymbol, TEntity> factory, TSymbol init)
+            where TSymbol : ISymbol
+            where TEntity : CachedEntity => CreateEntity(factory, init, init, symbolEntityCache);
+
+        /// <summary>
+        /// Creates and populates a new entity, or returns the existing one from the cache.
+        /// </summary>
+        /// <param name="factory">The entity factory.</param>
+        /// <param name="cacheKey">The key used for caching.</param>
+        /// <param name="init">The initializer for the entity.</param>
+        /// <param name="dictionary">The dictionary to use for caching.</param>
+        /// <returns>The new/existing entity.</returns>
+        private TEntity CreateEntity<TInit, TCacheKey, TEntity>(CachedEntityFactory<TInit, TEntity> factory, TCacheKey cacheKey, TInit init, IDictionary<TCacheKey, CachedEntity> dictionary)
+            where TCacheKey : notnull
+            where TEntity : CachedEntity
+        {
+            if (dictionary.TryGetValue(cacheKey, out var cached))
+                return (TEntity)cached;
+
+            using (StackGuard)
+            {
+                var label = GetNewLabel();
+                var entity = factory.Create(this, init);
+                entity.Label = label;
+
+                dictionary[cacheKey] = entity;
+
+                DefineLabel(entity);
+                if (entity.NeedsPopulation)
+                    Populate(init as ISymbol, entity);
+
+#if DEBUG_LABELS
+                using var id = new EscapingTextWriter();
+                entity.WriteQuotedId(id);
+                CheckEntityHasUniqueLabel(id.ToString(), entity);
+#endif
+
+                return entity;
+            }
+        }
+
+        /// <summary>
+        /// Creates a fresh label with ID "*", and set it on the
+        /// supplied <paramref name="entity"/> object.
+        /// </summary>
+        internal void AddFreshLabel(Entity entity)
+        {
+            entity.Label = GetNewLabel();
+            entity.DefineFreshLabel(TrapWriter.Writer);
+        }
+
+#if DEBUG_LABELS
+        private readonly Dictionary<string, CachedEntity> idLabelCache = new Dictionary<string, CachedEntity>();
+#endif
+
+        private readonly IDictionary<object, CachedEntity> objectEntityCache = new Dictionary<object, CachedEntity>();
+        private readonly IDictionary<ISymbol, CachedEntity> symbolEntityCache = new Dictionary<ISymbol, CachedEntity>(10000, SymbolEqualityComparer.Default);
+
+        /// <summary>
+        /// Queue of items to populate later.
+        /// The only reason for this is so that the call stack does not
+        /// grow indefinitely, causing a potential stack overflow.
+        /// </summary>
+        private readonly Queue<Action> populateQueue = new Queue<Action>();
+
+        /// <summary>
+        /// Enqueue the given action to be performed later.
+        /// </summary>
+        /// <param name="toRun">The action to run.</param>
+        public void PopulateLater(Action a)
+        {
+            var key = GetCurrentTagStackKey();
+            if (key is not null)
+            {
+                // If we are currently executing with a duplication guard, then the same
+                // guard must be used for the deferred action
+                populateQueue.Enqueue(() => WithDuplicationGuard(key, a));
+            }
+            else
+            {
+                populateQueue.Enqueue(a);
+            }
+        }
+
+        /// <summary>
+        /// Runs the main populate loop until there's nothing left to populate.
+        /// </summary>
+        public void PopulateAll()
+        {
+            while (populateQueue.Any())
+            {
+                try
+                {
+                    populateQueue.Dequeue()();
+                }
+                catch (InternalError ex)
+                {
+                    ExtractionError(new Message(ex.Text, ex.EntityText, CreateLocation(ex.Location), ex.StackTrace));
+                }
+                catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+                {
+                    ExtractionError($"Uncaught exception. {ex.Message}", null, CreateLocation(), ex.StackTrace);
+                }
+            }
+        }
+
+        protected Context(Extractor extractor, TrapWriter trapWriter, bool shouldAddAssemblyTrapPrefix = false)
+        {
+            Extractor = extractor;
+            TrapWriter = trapWriter;
+            ShouldAddAssemblyTrapPrefix = shouldAddAssemblyTrapPrefix;
+        }
+
+        private int currentRecursiveDepth = 0;
+        private const int maxRecursiveDepth = 150;
+
+        private void EnterScope()
+        {
+            if (currentRecursiveDepth >= maxRecursiveDepth)
+                throw new StackOverflowException(string.Format("Maximum nesting depth of {0} exceeded", maxRecursiveDepth));
+            ++currentRecursiveDepth;
+        }
+
+        private void ExitScope()
+        {
+            --currentRecursiveDepth;
+        }
+
+        public IDisposable StackGuard => new ScopeGuard(this);
+
+        private sealed class ScopeGuard : IDisposable
+        {
+            private readonly Context cx;
+
+            public ScopeGuard(Context c)
+            {
+                cx = c;
+                cx.EnterScope();
+            }
+
+            public void Dispose()
+            {
+                cx.ExitScope();
+            }
+        }
+
+        private class PushEmitter : ITrapEmitter
+        {
+            private readonly Key key;
+
+            public PushEmitter(Key key)
+            {
+                this.key = key;
+            }
+
+            public void EmitTrap(TextWriter trapFile)
+            {
+                trapFile.Write(".push ");
+                key.AppendTo(trapFile);
+                trapFile.WriteLine();
+            }
+        }
+
+        private class PopEmitter : ITrapEmitter
+        {
+            public void EmitTrap(TextWriter trapFile)
+            {
+                trapFile.WriteLine(".pop");
+            }
+        }
+
+        private readonly Stack<Key> tagStack = new Stack<Key>();
+
+        /// <summary>
+        /// Populates an entity, handling the tag stack appropriately
+        /// </summary>
+        /// <param name="optionalSymbol">Symbol for reporting errors.</param>
+        /// <param name="entity">The entity to populate.</param>
+        /// <exception cref="InternalError">Thrown on invalid trap stack behaviour.</exception>
+        private void Populate(ISymbol? optionalSymbol, CachedEntity entity)
+        {
+            if (writingLabel)
+            {
+                // Don't write tuples etc if we're currently defining a label
+                PopulateLater(() => Populate(optionalSymbol, entity));
+                return;
+            }
+
+            bool duplicationGuard, deferred;
+
+            switch (entity.TrapStackBehaviour)
+            {
+                case TrapStackBehaviour.NeedsLabel:
+                    if (!tagStack.Any())
+                        ExtractionError("TagStack unexpectedly empty", optionalSymbol, entity);
+                    duplicationGuard = false;
+                    deferred = false;
+                    break;
+                case TrapStackBehaviour.NoLabel:
+                    duplicationGuard = false;
+                    deferred = tagStack.Any();
+                    break;
+                case TrapStackBehaviour.OptionalLabel:
+                    duplicationGuard = false;
+                    deferred = false;
+                    break;
+                case TrapStackBehaviour.PushesLabel:
+                    duplicationGuard = true;
+                    deferred = duplicationGuard && tagStack.Any();
+                    break;
+                default:
+                    throw new InternalError("Unexpected TrapStackBehaviour");
+            }
+
+            var a = duplicationGuard && IsEntityDuplicationGuarded(entity, out var loc)
+                ? (() =>
+                {
+                    var args = new object[TrapStackSuffix.Count + 2];
+                    args[0] = entity;
+                    args[1] = loc;
+                    for (var i = 0; i < TrapStackSuffix.Count; i++)
+                    {
+                        args[i + 2] = TrapStackSuffix[i];
+                    }
+                    WithDuplicationGuard(new Key(args), () => entity.Populate(TrapWriter.Writer));
+                })
+                : (Action)(() => this.Try(null, optionalSymbol, () => entity.Populate(TrapWriter.Writer)));
+
+            if (deferred)
+                populateQueue.Enqueue(a);
+            else
+                a();
+        }
+
+        protected virtual bool IsEntityDuplicationGuarded(IEntity entity, [NotNullWhen(returnValue: true)] out Entities.Location? loc)
+        {
+            loc = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Runs the given action <paramref name="a"/>, guarding for trap duplication
+        /// based on key <paramref name="key"/>.
+        /// </summary>
+        public virtual void WithDuplicationGuard(Key key, Action a)
+        {
+            tagStack.Push(key);
+            TrapWriter.Emit(new PushEmitter(key));
+            try
+            {
+                a();
+            }
+            finally
+            {
+                TrapWriter.Emit(new PopEmitter());
+                tagStack.Pop();
+            }
+        }
+
+        protected Key? GetCurrentTagStackKey() => tagStack.Count > 0
+            ? tagStack.Peek()
+            : null;
+
+        /// <summary>
+        /// Log an extraction error.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="entityText">A textual representation of the failed entity.</param>
+        /// <param name="location">The location of the error.</param>
+        /// <param name="stackTrace">An optional stack trace of the error, or null.</param>
+        /// <param name="severity">The severity of the error.</param>
+        public void ExtractionError(string message, string? entityText, Entities.Location? location, string? stackTrace = null, Severity severity = Severity.Error)
+        {
+            var msg = new Message(message, entityText, location, stackTrace, severity);
+            ExtractionError(msg);
+        }
+
+        /// <summary>
+        /// Log an extraction error.
+        /// </summary>
+        /// <param name="message">The text of the message.</param>
+        /// <param name="optionalSymbol">The symbol of the error, or null.</param>
+        /// <param name="optionalEntity">The entity of the error, or null.</param>
+        private void ExtractionError(string message, ISymbol? optionalSymbol, Entity optionalEntity)
+        {
+            if (!(optionalSymbol is null))
+            {
+                ExtractionError(message, optionalSymbol.ToDisplayString(), CreateLocation(optionalSymbol.Locations.FirstOrDefault()));
+            }
+            else if (!(optionalEntity is null))
+            {
+                ExtractionError(message, optionalEntity.Label.ToString(), CreateLocation(optionalEntity.ReportingLocation));
+            }
+            else
+            {
+                ExtractionError(message, null, CreateLocation());
+            }
+        }
+
+        /// <summary>
+        /// Log an extraction message.
+        /// </summary>
+        /// <param name="msg">The message to log.</param>
+        private void ExtractionError(Message msg)
+        {
+            new ExtractionMessage(this, msg);
+            Extractor.Message(msg);
+        }
+
+        private void ExtractionError(InternalError error)
+        {
+            ExtractionError(new Message(error.Message, error.EntityText, CreateLocation(error.Location), error.StackTrace, Severity.Error));
+        }
+
+        private void ReportError(InternalError error)
+        {
+            if (!Extractor.Standalone)
+                throw error;
+
+            ExtractionError(error);
+        }
+
+        /// <summary>
+        /// Signal an error in the program model.
+        /// </summary>
+        /// <param name="node">The syntax node causing the failure.</param>
+        /// <param name="msg">The error message.</param>
+        public void ModelError(SyntaxNode node, string msg)
+        {
+            ReportError(new InternalError(node, msg));
+        }
+
+        /// <summary>
+        /// Signal an error in the program model.
+        /// </summary>
+        /// <param name="symbol">Symbol causing the error.</param>
+        /// <param name="msg">The error message.</param>
+        public void ModelError(ISymbol symbol, string msg)
+        {
+            ReportError(new InternalError(symbol, msg));
+        }
+
+        /// <summary>
+        /// Signal an error in the program model.
+        /// </summary>
+        /// <param name="msg">The error message.</param>
+        public void ModelError(string msg)
+        {
+            ReportError(new InternalError(msg));
+        }
+
+        /// <summary>
+        /// Tries the supplied action <paramref name="a"/>, and logs an uncaught
+        /// exception error if the action fails.
+        /// </summary>
+        /// <param name="node">Optional syntax node for error reporting.</param>
+        /// <param name="symbol">Optional symbol for error reporting.</param>
+        /// <param name="a">The action to perform.</param>
+        public void Try(SyntaxNode? node, ISymbol? symbol, Action a)
+        {
+            try
+            {
+                a();
+            }
+            catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                Message message;
+
+                if (node is not null)
+                {
+                    message = Message.Create(this, ex.Message, node, ex.StackTrace);
+                }
+                else if (symbol is not null)
+                {
+                    message = Message.Create(this, ex.Message, symbol, ex.StackTrace);
+                }
+                else if (ex is InternalError ie)
+                {
+                    message = new Message(ie.Text, ie.EntityText, CreateLocation(ie.Location), ex.StackTrace);
+                }
+                else
+                {
+                    message = new Message($"Uncaught exception. {ex.Message}", null, CreateLocation(), ex.StackTrace);
+                }
+
+                ExtractionError(message);
+            }
+        }
+
+        public virtual Entities.Location CreateLocation() =>
+            GeneratedLocation.Create(this);
+
+        public virtual Entities.Location CreateLocation(Microsoft.CodeAnalysis.Location? location) =>
+            CreateLocation();
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/CachedEntityFactory.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/CachedEntityFactory.cs
@@ -1,0 +1,15 @@
+using Microsoft.CodeAnalysis;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// A factory for creating cached entities.
+    /// </summary>
+    public abstract class CachedEntityFactory<TInit, TEntity> where TEntity : CachedEntity
+    {
+        /// <summary>
+        /// Initializes the entity, but does not generate any trap code.
+        /// </summary>
+        public abstract TEntity Create(Context cx, TInit init);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/CachedEntityFactoryExtensions.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/CachedEntityFactoryExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.CodeAnalysis;
+
+namespace Semmle.Extraction
+{
+    public static class CachedEntityFactoryExtensions
+    {
+        /// <summary>
+        /// Creates and populates a new entity, or returns the existing one from the cache,
+        /// based on the supplied cache key.
+        /// </summary>
+        /// <typeparam name="TInit">The type used to construct the entity.</typeparam>
+        /// <typeparam name="TEntity">The type of the entity to create.</typeparam>
+        /// <param name="factory">The factory used to construct the entity.</param>
+        /// <param name="cx">The extractor context.</param>
+        /// <param name="cacheKey">The key used for caching.</param>
+        /// <param name="init">The initializer for the entity.</param>
+        /// <returns>The entity.</returns>
+        public static TEntity CreateEntity<TInit, TEntity>(this CachedEntityFactory<TInit, TEntity> factory, Context cx, object cacheKey, TInit init)
+            where TEntity : CachedEntity => cx.CreateEntity(factory, cacheKey, init);
+
+        /// <summary>
+        /// Creates and populates a new entity from an `ISymbol`, or returns the existing one
+        /// from the cache.
+        /// </summary>
+        /// <typeparam name="TSymbol">The type used to construct the entity.</typeparam>
+        /// <typeparam name="TEntity">The type of the entity to create.</typeparam>
+        /// <param name="factory">The factory used to construct the entity.</param>
+        /// <param name="cx">The extractor context.</param>
+        /// <param name="init">The initializer for the entity.</param>
+        /// <returns>The entity.</returns>
+        public static TEntity CreateEntityFromSymbol<TSymbol, TEntity>(this CachedEntityFactory<TSymbol, TEntity> factory, Context cx, TSymbol init)
+            where TSymbol : ISymbol
+            where TEntity : CachedEntity => cx.CreateEntityFromSymbol(factory, init);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/CachedEntity`1.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/CachedEntity`1.cs
@@ -1,0 +1,81 @@
+using System.IO;
+using Microsoft.CodeAnalysis;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// A cached entity.
+    ///
+    /// The <see cref="Entity.Id"/> property is used as label in caching.
+    /// </summary>
+    public abstract class CachedEntity : LabelledEntity
+    {
+        protected CachedEntity(Context context) : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Populates the <see cref="Label"/> field and generates output in the trap file
+        /// as required. Is only called when <see cref="NeedsPopulation"/> returns
+        /// <code>true</code> and the entity has not already been populated.
+        /// </summary>
+        public abstract void Populate(TextWriter trapFile);
+
+        public abstract bool NeedsPopulation { get; }
+    }
+
+    /// <summary>
+    /// An abstract symbol, which encapsulates a data type (such as a C# symbol).
+    /// </summary>
+    /// <typeparam name="TSymbol">The type of the symbol.</typeparam>
+    public abstract class CachedEntity<TSymbol> : CachedEntity where TSymbol : notnull
+    {
+        public TSymbol Symbol { get; }
+
+        protected CachedEntity(Context context, TSymbol symbol) : base(context)
+        {
+            this.Symbol = symbol;
+        }
+
+        /// <summary>
+        /// For debugging.
+        /// </summary>
+        public string DebugContents
+        {
+            get
+            {
+                using var trap = new StringWriter();
+                Populate(trap);
+                return trap.ToString();
+            }
+        }
+
+        public override bool NeedsPopulation { get; }
+
+        public override int GetHashCode() => Symbol is null ? 0 : Symbol.GetHashCode();
+
+        public override bool Equals(object? obj)
+        {
+            var other = obj as CachedEntity<TSymbol>;
+            return other?.GetType() == GetType() && Equals(other.Symbol, Symbol);
+        }
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
+    }
+
+    /// <summary>
+    /// A class used to wrap an `ISymbol` object, which uses `SymbolEqualityComparer.Default`
+    /// for comparison.
+    /// </summary>
+    public struct SymbolEqualityWrapper
+    {
+        public ISymbol Symbol { get; }
+
+        public SymbolEqualityWrapper(ISymbol symbol) { Symbol = symbol; }
+
+        public override bool Equals(object? other) =>
+            other is SymbolEqualityWrapper sew && SymbolEqualityComparer.Default.Equals(Symbol, sew.Symbol);
+
+        public override int GetHashCode() => 11 * SymbolEqualityComparer.Default.GetHashCode(Symbol);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/Entity.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/Entity.cs
@@ -1,0 +1,70 @@
+using Microsoft.CodeAnalysis;
+using System;
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    public abstract class Entity : IEntity
+    {
+        public virtual Context Context { get; }
+
+        protected Entity(Context context)
+        {
+            this.Context = context;
+        }
+
+        public Label Label { get; set; }
+
+        public abstract void WriteId(EscapingTextWriter trapFile);
+
+        public virtual void WriteQuotedId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteUnescaped("@\"");
+            WriteId(trapFile);
+            trapFile.WriteUnescaped('\"');
+        }
+
+        public abstract Location? ReportingLocation { get; }
+
+        public abstract TrapStackBehaviour TrapStackBehaviour { get; }
+
+        public void DefineLabel(TextWriter trapFile, Extractor extractor)
+        {
+            trapFile.WriteLabel(this);
+            trapFile.Write("=");
+            using var escaping = new EscapingTextWriter(trapFile);
+            try
+            {
+                WriteQuotedId(escaping);
+            }
+            catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                trapFile.WriteLine("\"");
+                extractor.Message(new Message($"Unhandled exception generating id: {ex.Message}", ToString() ?? "", null, ex.StackTrace));
+            }
+            trapFile.WriteLine();
+        }
+
+        public void DefineFreshLabel(TextWriter trapFile)
+        {
+            trapFile.WriteLabel(this);
+            trapFile.WriteLine("=*");
+        }
+
+#if DEBUG_LABELS
+        /// <summary>
+        /// Generates a debug string for this entity.
+        /// </summary>
+        public string GetDebugLabel()
+        {
+            using var writer = new EscapingTextWriter();
+            writer.WriteLabel(Label.Value);
+            writer.Write('=');
+            WriteQuotedId(writer);
+            return writer.ToString();
+        }
+#endif
+
+        public override string ToString() => Label.ToString();
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/FreshEntity.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/FreshEntity.cs
@@ -1,0 +1,38 @@
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// An entity which has a default "*" ID assigned to it.
+    /// </summary>
+    public abstract class FreshEntity : UnlabelledEntity
+    {
+        protected FreshEntity(Context cx) : base(cx)
+        {
+        }
+
+        protected abstract void Populate(TextWriter trapFile);
+
+        public void TryPopulate()
+        {
+            Context.Try(null, null, () => Populate(Context.TrapWriter.Writer));
+        }
+
+        /// <summary>
+        /// For debugging.
+        /// </summary>
+        public string DebugContents
+        {
+            get
+            {
+                using var writer = new StringWriter();
+                Populate(writer);
+                return writer.ToString();
+            }
+        }
+
+        public override Microsoft.CodeAnalysis.Location? ReportingLocation => null;
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/IEntity.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/IEntity.cs
@@ -1,0 +1,53 @@
+using Microsoft.CodeAnalysis;
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// Any program entity which has a corresponding label in the trap file.
+    ///
+    /// Entities are divided into two types: normal entities and cached
+    /// entities.
+    ///
+    /// Normal entities implement <see cref="FreshEntity"/> directly, and they
+    /// (may) emit contents to the trap file during object construction.
+    ///
+    /// Cached entities implement <see cref="CachedEntity"/>, and they
+    /// emit contents to the trap file when <see cref="CachedEntity.Populate"/>
+    /// is called. Caching prevents <see cref="CachedEntity.Populate"/>
+    /// from being called on entities that have already been emitted.
+    /// </summary>
+    public interface IEntity
+    {
+        /// <summary>
+        /// The label of the entity, as it is in the trap file.
+        /// For example, "#123".
+        /// </summary>
+        Label Label { get; set; }
+
+        /// <summary>
+        /// Writes the unique identifier of this entitiy to a trap file.
+        /// </summary>
+        /// <param name="trapFile">The trapfile to write to.</param>
+        void WriteId(EscapingTextWriter trapFile);
+
+        /// <summary>
+        /// Writes the quoted identifier of this entity,
+        /// which could be @"..." or *
+        /// </summary>
+        /// <param name="trapFile">The trapfile to write to.</param>
+        void WriteQuotedId(EscapingTextWriter trapFile);
+
+        /// <summary>
+        /// The location for reporting purposes.
+        /// </summary>
+        Location? ReportingLocation { get; }
+
+        /// <summary>
+        /// How the entity handles .push and .pop.
+        /// </summary>
+        TrapStackBehaviour TrapStackBehaviour { get; }
+
+        void DefineLabel(TextWriter trapFile, Extractor extractor);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/LabelledEntity.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/LabelledEntity.cs
@@ -1,0 +1,11 @@
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    public abstract class LabelledEntity : Entity
+    {
+        protected LabelledEntity(Context cx) : base(cx)
+        {
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Base/UnlabelledEntity.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Base/UnlabelledEntity.cs
@@ -1,0 +1,22 @@
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    public abstract class UnlabelledEntity : Entity
+    {
+        protected UnlabelledEntity(Context cx) : base(cx)
+        {
+            cx.AddFreshLabel(this);
+        }
+
+        public sealed override void WriteId(EscapingTextWriter writer)
+        {
+            writer.Write('*');
+        }
+
+        public sealed override void WriteQuotedId(EscapingTextWriter writer)
+        {
+            writer.Write('*');
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/ExtractionError.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/ExtractionError.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace Semmle.Extraction.Entities
+{
+    internal class ExtractionMessage : FreshEntity
+    {
+        private readonly Message msg;
+
+        public ExtractionMessage(Context cx, Message msg) : base(cx)
+        {
+            this.msg = msg;
+            TryPopulate();
+        }
+
+        protected override void Populate(TextWriter trapFile)
+        {
+            trapFile.extractor_messages(this, msg.Severity, "C# extractor", msg.Text, msg.EntityText ?? string.Empty,
+                msg.Location ?? Context.CreateLocation(), msg.StackTrace ?? string.Empty);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/File.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/File.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Semmle.Extraction.Entities
+{
+    public abstract class File : CachedEntity<string>
+    {
+        protected File(Context cx, string path)
+            : base(cx, path)
+        {
+            originalPath = path;
+            transformedPathLazy = new Lazy<PathTransformer.ITransformedPath>(() => Context.Extractor.PathTransformer.Transform(originalPath));
+        }
+
+        protected readonly string originalPath;
+        private readonly Lazy<PathTransformer.ITransformedPath> transformedPathLazy;
+        protected PathTransformer.ITransformedPath TransformedPath => transformedPathLazy.Value;
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.Write(TransformedPath.DatabaseId);
+            trapFile.Write(";sourcefile");
+        }
+
+        public override Microsoft.CodeAnalysis.Location? ReportingLocation => null;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Folder.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Folder.cs
@@ -1,0 +1,43 @@
+using System.IO;
+
+namespace Semmle.Extraction.Entities
+{
+    public sealed class Folder : CachedEntity<PathTransformer.ITransformedPath>
+    {
+        private Folder(Context cx, PathTransformer.ITransformedPath init) : base(cx, init) { }
+
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.folders(this, Symbol.Value);
+            if (Symbol.ParentDirectory is PathTransformer.ITransformedPath parent)
+                trapFile.containerparent(Create(Context, parent), this);
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.Write(Symbol.DatabaseId);
+            trapFile.Write(";folder");
+        }
+
+        public static Folder Create(Context cx, PathTransformer.ITransformedPath folder) =>
+            FolderFactory.Instance.CreateEntity(cx, folder, folder);
+
+        public override Microsoft.CodeAnalysis.Location? ReportingLocation => null;
+
+        private class FolderFactory : CachedEntityFactory<PathTransformer.ITransformedPath, Folder>
+        {
+            public static FolderFactory Instance { get; } = new FolderFactory();
+
+            public override Folder Create(Context cx, PathTransformer.ITransformedPath init) => new Folder(cx, init);
+        }
+
+        public override int GetHashCode() => Symbol.GetHashCode();
+
+        public override bool Equals(object? obj)
+        {
+            return obj is Folder folder && Equals(folder.Symbol, Symbol);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/GeneratedFile.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/GeneratedFile.cs
@@ -1,0 +1,31 @@
+using System.IO;
+
+namespace Semmle.Extraction.Entities
+{
+    internal class GeneratedFile : File
+    {
+        private GeneratedFile(Context cx) : base(cx, "") { }
+
+        public override bool NeedsPopulation => true;
+
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.files(this, "");
+        }
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.Write("GENERATED;sourcefile");
+        }
+
+        public static GeneratedFile Create(Context cx) =>
+            GeneratedFileFactory.Instance.CreateEntity(cx, typeof(GeneratedFile), null);
+
+        private class GeneratedFileFactory : CachedEntityFactory<string?, GeneratedFile>
+        {
+            public static GeneratedFileFactory Instance { get; } = new GeneratedFileFactory();
+
+            public override GeneratedFile Create(Context cx, string? init) => new GeneratedFile(cx);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/GeneratedLocation.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/GeneratedLocation.cs
@@ -1,0 +1,40 @@
+using System.IO;
+
+namespace Semmle.Extraction.Entities
+{
+    public class GeneratedLocation : SourceLocation
+    {
+        private readonly File generatedFile;
+
+        private GeneratedLocation(Context cx)
+            : base(cx, null)
+        {
+            generatedFile = GeneratedFile.Create(cx);
+        }
+
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.locations_default(this, generatedFile, 0, 0, 0, 0);
+        }
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.Write("loc,");
+            trapFile.WriteSubId(generatedFile);
+            trapFile.Write(",0,0,0,0");
+        }
+
+        public override int GetHashCode() => 98732567;
+
+        public override bool Equals(object? obj) => obj is not null && obj.GetType() == typeof(GeneratedLocation);
+
+        public static GeneratedLocation Create(Context cx) => GeneratedLocationFactory.Instance.CreateEntity(cx, typeof(GeneratedLocation), null);
+
+        private class GeneratedLocationFactory : CachedEntityFactory<string?, GeneratedLocation>
+        {
+            public static GeneratedLocationFactory Instance { get; } = new GeneratedLocationFactory();
+
+            public override GeneratedLocation Create(Context cx, string? init) => new GeneratedLocation(cx);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/Location.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/Location.cs
@@ -1,0 +1,17 @@
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Semmle.Extraction.Entities
+{
+#nullable disable warnings
+    public abstract class Location : CachedEntity<Microsoft.CodeAnalysis.Location?>
+    {
+#nullable restore warnings
+        protected Location(Context cx, Microsoft.CodeAnalysis.Location? init)
+            : base(cx, init) { }
+
+        public override Microsoft.CodeAnalysis.Location? ReportingLocation => Symbol;
+
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.OptionalLabel;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Entities/SourceLocation.cs
+++ b/powershell/extractor/Semmle.Extraction/Entities/SourceLocation.cs
@@ -1,0 +1,11 @@
+namespace Semmle.Extraction.Entities
+{
+    public abstract class SourceLocation : Location
+    {
+        protected SourceLocation(Context cx, Microsoft.CodeAnalysis.Location? init) : base(cx, init)
+        {
+        }
+
+        public override bool NeedsPopulation => true;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/EscapingTextWriter.cs
+++ b/powershell/extractor/Semmle.Extraction/EscapingTextWriter.cs
@@ -1,0 +1,340 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// A `TextWriter` object that wraps another `TextWriter` object, and which
+    /// HTML escapes the characters `&`, `{`, `}`, `"`, `@`, and `#`, before
+    /// writing to the underlying object.
+    /// </summary>
+    public sealed class EscapingTextWriter : TextWriter
+    {
+        private readonly TextWriter wrapped;
+        private readonly bool disposeUnderlying;
+
+        public EscapingTextWriter(TextWriter wrapped, bool disposeUnderlying = false)
+        {
+            this.wrapped = wrapped;
+            this.disposeUnderlying = disposeUnderlying;
+        }
+
+        /// <summary>
+        /// Creates a new instance with a new underlying `StringWriter` object. The
+        /// underlying object is disposed of when this object is.
+        /// </summary>
+        public EscapingTextWriter() : this(new StringWriter(), true) { }
+
+        public EscapingTextWriter(IFormatProvider? formatProvider) : base(formatProvider)
+            => throw new NotImplementedException();
+
+        private void WriteEscaped(char c)
+        {
+            switch (c)
+            {
+                case '&':
+                    wrapped.Write("&amp;");
+                    break;
+                case '{':
+                    wrapped.Write("&lbrace;");
+                    break;
+                case '}':
+                    wrapped.Write("&rbrace;");
+                    break;
+                case '"':
+                    wrapped.Write("&quot;");
+                    break;
+                case '@':
+                    wrapped.Write("&commat;");
+                    break;
+                case '#':
+                    wrapped.Write("&num;");
+                    break;
+                default:
+                    wrapped.Write(c);
+                    break;
+            };
+        }
+
+        public void WriteSubId(IEntity entity)
+        {
+            if (entity is null)
+            {
+                wrapped.Write("<null>");
+                return;
+            }
+
+            WriteUnescaped('{');
+            wrapped.WriteLabel(entity);
+            WriteUnescaped('}');
+        }
+
+        public void WriteUnescaped(char c)
+            => wrapped.Write(c);
+
+        public void WriteUnescaped(string s)
+            => wrapped.Write(s);
+
+        #region overrides
+
+        public override Encoding Encoding => wrapped.Encoding;
+
+        public override IFormatProvider FormatProvider => wrapped.FormatProvider;
+
+        public override string NewLine { get => wrapped.NewLine; }
+
+        public override void Close()
+            => throw new NotImplementedException();
+
+        public override ValueTask DisposeAsync()
+            => throw new NotImplementedException();
+
+        public override bool Equals(object? obj)
+            => wrapped.Equals(obj) && obj is EscapingTextWriter other && disposeUnderlying == other.disposeUnderlying;
+
+        public override void Flush()
+            => wrapped.Flush();
+
+        public override Task FlushAsync()
+            => wrapped.FlushAsync();
+
+        public override int GetHashCode()
+            => HashCode.Combine(wrapped, disposeUnderlying);
+
+        public override string ToString()
+            => wrapped.ToString() ?? "";
+
+        public override void Write(bool value)
+            => wrapped.Write(value);
+
+        public override void Write(char value)
+            => WriteEscaped(value);
+
+        public override void Write(char[]? buffer)
+        {
+            if (buffer is null)
+                return;
+            Write(buffer, 0, buffer.Length);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            for (var i = index; i < buffer.Length && i < index + count; i++)
+            {
+                WriteEscaped(buffer[i]);
+            }
+        }
+
+
+        public override void Write(decimal value)
+            => wrapped.Write(value);
+
+        public override void Write(double value)
+            => wrapped.Write(value);
+
+        public override void Write(int value)
+            => wrapped.Write(value);
+
+        public override void Write(long value)
+            => wrapped.Write(value);
+
+        public override void Write(object? value)
+            => Write(value?.ToString());
+
+        public override void Write(ReadOnlySpan<char> buffer)
+        {
+            foreach (var c in buffer)
+            {
+                WriteEscaped(c);
+            }
+        }
+
+        public override void Write(float value)
+            => wrapped.Write(value);
+
+        public override void Write(string? value)
+        {
+            if (value is null)
+            {
+                wrapped.Write(value);
+            }
+            else
+            {
+                foreach (var c in value)
+                {
+                    WriteEscaped(c);
+                }
+            }
+        }
+
+        public override void Write(string format, object? arg0)
+            => Write(string.Format(format, arg0));
+
+        public override void Write(string format, object? arg0, object? arg1)
+            => Write(string.Format(format, arg0, arg1));
+
+        public override void Write(string format, object? arg0, object? arg1, object? arg2)
+            => Write(string.Format(format, arg0, arg1, arg2));
+
+        public override void Write(string format, params object?[] arg)
+            => Write(string.Format(format, arg));
+
+        public override void Write(StringBuilder? value)
+        {
+            if (value is null)
+            {
+                wrapped.Write(value);
+            }
+            else
+            {
+                for (var i = 0; i < value.Length; i++)
+                {
+                    WriteEscaped(value[i]);
+                }
+            }
+        }
+
+        public override void Write(uint value)
+            => wrapped.Write(value);
+
+        public override void Write(ulong value)
+            => wrapped.Write(value);
+
+        public override Task WriteAsync(char value)
+            => throw new NotImplementedException();
+
+        public override Task WriteAsync(char[] buffer, int index, int count)
+            => throw new NotImplementedException();
+
+        public override Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public override Task WriteAsync(string? value)
+            => throw new NotImplementedException();
+
+        public override Task WriteAsync(StringBuilder? value, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public override void WriteLine()
+            => wrapped.WriteLine();
+
+        public override void WriteLine(bool value)
+            => wrapped.WriteLine(value);
+
+        public override void WriteLine(char value)
+        {
+            Write(value);
+            WriteLine();
+        }
+
+        public override void WriteLine(char[]? buffer)
+        {
+            Write(buffer);
+            WriteLine();
+        }
+
+        public override void WriteLine(char[] buffer, int index, int count)
+        {
+            Write(buffer, index, count);
+            WriteLine();
+        }
+
+        public override void WriteLine(decimal value)
+            => wrapped.WriteLine(value);
+
+        public override void WriteLine(double value)
+            => wrapped.WriteLine(value);
+
+        public override void WriteLine(int value)
+            => wrapped.WriteLine(value);
+
+        public override void WriteLine(long value)
+            => wrapped.WriteLine(value);
+
+        public override void WriteLine(object? value)
+        {
+            Write(value);
+            WriteLine();
+        }
+
+        public override void WriteLine(ReadOnlySpan<char> buffer)
+        {
+            Write(buffer);
+            WriteLine();
+        }
+
+        public override void WriteLine(float value)
+            => wrapped.WriteLine(value);
+
+        public override void WriteLine(string? value)
+        {
+            Write(value);
+            WriteLine();
+        }
+
+        public override void WriteLine(string format, object? arg0)
+        {
+            Write(format, arg0);
+            WriteLine();
+        }
+
+        public override void WriteLine(string format, object? arg0, object? arg1)
+        {
+            Write(format, arg0, arg1);
+            WriteLine();
+        }
+
+        public override void WriteLine(string format, object? arg0, object? arg1, object? arg2)
+        {
+            Write(format, arg0, arg1, arg2);
+            WriteLine();
+        }
+
+        public override void WriteLine(string format, params object?[] arg)
+        {
+            Write(format, arg);
+            WriteLine();
+        }
+
+        public override void WriteLine(StringBuilder? value)
+        {
+            Write(value);
+            WriteLine();
+        }
+
+        public override void WriteLine(uint value)
+            => wrapped.WriteLine(value);
+
+        public override void WriteLine(ulong value)
+            => wrapped.WriteLine(value);
+
+        public override Task WriteLineAsync()
+            => throw new NotImplementedException();
+
+        public override Task WriteLineAsync(char value)
+            => throw new NotImplementedException();
+
+        public override Task WriteLineAsync(char[] buffer, int index, int count)
+            => throw new NotImplementedException();
+
+        public override Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public override Task WriteLineAsync(string? value)
+            => throw new NotImplementedException();
+
+        public override Task WriteLineAsync(StringBuilder? value, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && disposeUnderlying)
+                wrapped.Dispose();
+        }
+
+        #endregion overrides
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Extractor/Extractor.cs
+++ b/powershell/extractor/Semmle.Extraction/Extractor/Extractor.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using Semmle.Util.Logging;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// Implementation of the main extractor state.
+    /// </summary>
+    public abstract class Extractor
+    {
+        public abstract bool Standalone { get; }
+
+        /// <summary>
+        /// Creates a new extractor instance for one compilation unit.
+        /// </summary>
+        /// <param name="logger">The object used for logging.</param>
+        /// <param name="pathTransformer">The object used for path transformations.</param>
+        protected Extractor(ILogger logger, PathTransformer pathTransformer)
+        {
+            Logger = logger;
+            PathTransformer = pathTransformer;
+        }
+
+        // Limit the number of error messages in the log file
+        // to handle pathological cases.
+        private const int maxErrors = 1000;
+
+        private readonly object mutex = new object();
+
+        public void Message(Message msg)
+        {
+            lock (mutex)
+            {
+
+                if (msg.Severity == Severity.Error)
+                {
+                    ++Errors;
+                    if (Errors == maxErrors)
+                    {
+                        Logger.Log(Severity.Info, "  Stopping logging after {0} errors", Errors);
+                    }
+                }
+
+                if (Errors >= maxErrors)
+                {
+                    return;
+                }
+
+                Logger.Log(msg.Severity, $"  {msg.ToLogString()}");
+            }
+        }
+
+        // Roslyn framework has no apparent mechanism to associate assemblies with their files.
+        // So this lookup table needs to be populated.
+        private readonly Dictionary<string, string> referenceFilenames = new Dictionary<string, string>();
+
+        public void SetAssemblyFile(string assembly, string file)
+        {
+            referenceFilenames[assembly] = file;
+        }
+
+        public string GetAssemblyFile(string assembly)
+        {
+            return referenceFilenames[assembly];
+        }
+
+        public int Errors
+        {
+            get; private set;
+        }
+
+        private readonly ISet<string> missingTypes = new SortedSet<string>();
+        private readonly ISet<string> missingNamespaces = new SortedSet<string>();
+
+        public void MissingType(string fqn, bool fromSource)
+        {
+            if (fromSource)
+            {
+                lock (mutex)
+                    missingTypes.Add(fqn);
+            }
+        }
+
+        public void MissingNamespace(string fqdn, bool fromSource)
+        {
+            if (fromSource)
+            {
+                lock (mutex)
+                    missingNamespaces.Add(fqdn);
+            }
+        }
+
+        public IEnumerable<string> MissingTypes => missingTypes;
+
+        public IEnumerable<string> MissingNamespaces => missingNamespaces;
+
+        public ILogger Logger { get; private set; }
+
+        public static string Version => $"{ThisAssembly.Git.BaseTag} ({ThisAssembly.Git.Sha})";
+
+        public PathTransformer PathTransformer { get; }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Extractor/StandaloneExtractor.cs
+++ b/powershell/extractor/Semmle.Extraction/Extractor/StandaloneExtractor.cs
@@ -1,0 +1,18 @@
+using Semmle.Util.Logging;
+
+namespace Semmle.Extraction
+{
+    public class StandaloneExtractor : Extractor
+    {
+        public override bool Standalone => true;
+
+        /// <summary>
+        /// Creates a new extractor instance for one compilation unit.
+        /// </summary>
+        /// <param name="logger">The object used for logging.</param>
+        /// <param name="pathTransformer">The object used for path transformations.</param>
+        public StandaloneExtractor(ILogger logger, PathTransformer pathTransformer) : base(logger, pathTransformer)
+        {
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Extractor/TracingExtractor.cs
+++ b/powershell/extractor/Semmle.Extraction/Extractor/TracingExtractor.cs
@@ -1,0 +1,22 @@
+using Semmle.Util.Logging;
+
+namespace Semmle.Extraction
+{
+    public class TracingExtractor : Extractor
+    {
+        public override bool Standalone => false;
+
+        public string OutputPath { get; }
+
+        /// <summary>
+        /// Creates a new extractor instance for one compilation unit.
+        /// </summary>
+        /// <param name="outputPath">The name of the output DLL/EXE, or null if not specified (standalone extraction).</param>
+        /// <param name="logger">The object used for logging.</param>
+        /// <param name="pathTransformer">The object used for path transformations.</param>
+        public TracingExtractor(string outputPath, ILogger logger, PathTransformer pathTransformer) : base(logger, pathTransformer)
+        {
+            OutputPath = outputPath;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/FilePattern.cs
+++ b/powershell/extractor/Semmle.Extraction/FilePattern.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Diagnostics.CodeAnalysis;
+using Semmle.Util;
+
+namespace Semmle.Extraction
+{
+    public sealed class InvalidFilePatternException : Exception
+    {
+        public InvalidFilePatternException(string pattern, string message) :
+            base($"Invalid file pattern '{pattern}': {message}")
+        { }
+    }
+
+    /// <summary>
+    /// A file pattern, as used in either an extractor layout file or
+    /// a path transformer file.
+    /// </summary>
+    public sealed class FilePattern
+    {
+        /// <summary>
+        /// Whether this is an inclusion pattern.
+        /// </summary>
+        public bool Include { get; }
+
+        public FilePattern(string pattern)
+        {
+            Include = true;
+            if (pattern.StartsWith("-"))
+            {
+                pattern = pattern.Substring(1);
+                Include = false;
+            }
+            pattern = FileUtils.ConvertToUnix(pattern.Trim()).TrimStart('/');
+            RegexPattern = BuildRegex(pattern).ToString();
+        }
+
+        /// <summary>
+        /// Constructs a regex string from a file pattern. Throws
+        /// `InvalidFilePatternException` for invalid patterns.
+        /// </summary>
+        private static StringBuilder BuildRegex(string pattern)
+        {
+            bool HasCharAt(int i, Predicate<char> p) =>
+                i >= 0 && i < pattern.Length && p(pattern[i]);
+            var sb = new StringBuilder();
+            var i = 0;
+            var seenDoubleSlash = false;
+            sb.Append('^');
+            while (i < pattern.Length)
+            {
+                if (pattern[i] == '/')
+                {
+                    if (HasCharAt(i + 1, c => c == '/'))
+                    {
+                        if (seenDoubleSlash)
+                            throw new InvalidFilePatternException(pattern, "'//' is allowed at most once.");
+                        sb.Append("(?<doubleslash>/)");
+                        i += 2;
+                        seenDoubleSlash = true;
+                    }
+                    else
+                    {
+                        sb.Append('/');
+                        i++;
+                    }
+                }
+                else if (pattern[i] == '*')
+                {
+                    if (HasCharAt(i + 1, c => c == '*'))
+                    {
+                        if (HasCharAt(i - 1, c => c != '/'))
+                            throw new InvalidFilePatternException(pattern, "'**' preceeded by non-`/` character.");
+                        if (HasCharAt(i + 2, c => c != '/'))
+                            throw new InvalidFilePatternException(pattern, "'**' succeeded by non-`/` character");
+                        sb.Append(".*");
+                        i += 2;
+                    }
+                    else
+                    {
+                        sb.Append("[^/]*");
+                        i++;
+                    }
+                }
+                else
+                {
+                    sb.Append(Regex.Escape(pattern[i++].ToString()));
+                }
+            }
+            return sb.Append(".*");
+        }
+
+
+        /// <summary>
+        /// The regex pattern compiled from this file pattern.
+        /// </summary>
+        public string RegexPattern { get; }
+
+        /// <summary>
+        /// Returns `true` if the set of file patterns `patterns` match the path `path`.
+        /// If so, `transformerSuffix` will contain the part of `path` that needs to be
+        /// suffixed when using path transformers.
+        /// </summary>
+        public static bool Matches(IEnumerable<FilePattern> patterns, string path, [NotNullWhen(true)] out string? transformerSuffix)
+        {
+            path = FileUtils.ConvertToUnix(path).TrimStart('/');
+
+            foreach (var pattern in patterns.Reverse())
+            {
+                var m = new Regex(pattern.RegexPattern).Match(path);
+                if (m.Success)
+                {
+                    if (pattern.Include)
+                    {
+                        transformerSuffix = m.Groups.TryGetValue("doubleslash", out var group)
+                            ? path.Substring(group.Index)
+                            : path;
+                        return true;
+                    }
+
+                    transformerSuffix = null;
+                    return false;
+                }
+            }
+
+            transformerSuffix = null;
+            return false;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/IExtractionScope.cs
+++ b/powershell/extractor/Semmle.Extraction/IExtractionScope.cs
@@ -1,0 +1,26 @@
+using Microsoft.CodeAnalysis;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// Defines which entities belong in the trap file
+    /// for the currently extracted entity. This is used to ensure that
+    /// trap files do not contain redundant information. Generally a symbol
+    /// should have an affinity with exactly one trap file, except for constructed
+    /// symbols.
+    /// </summary>
+    public interface IExtractionScope
+    {
+        /// <summary>
+        /// Whether the given symbol belongs in the trap file.
+        /// </summary>
+        /// <param name="symbol">The symbol to populate.</param>
+        bool InScope(ISymbol symbol);
+
+        /// <summary>
+        /// Whether the given file belongs in the trap file.
+        /// </summary>
+        /// <param name="path">The path to populate.</param>
+        bool InFileScope(string path);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Id.cs
+++ b/powershell/extractor/Semmle.Extraction/Id.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// An ID. Either a fresh ID (`*`), a key, or a label (https://semmle.com/wiki/display/IN/TRAP+Files):
+    ///
+    /// ```
+    /// id ::= '*' | key | label
+    /// ```
+    /// </summary>
+    public interface IId
+    {
+        /// <summary>
+        /// Appends this ID to the supplied trap builder.
+        /// </summary>
+        void AppendTo(TextWriter trapFile);
+    }
+
+    /// <summary>
+    /// A fresh ID (`*`).
+    /// </summary>
+    public class FreshId : IId
+    {
+        private FreshId() { }
+
+        /// <summary>
+        /// Gets the singleton <see cref="FreshId"/> instance.
+        /// </summary>
+        public static IId Instance { get; } = new FreshId();
+
+        public override string ToString() => "*";
+
+        public override bool Equals(object? obj) => obj?.GetType() == GetType();
+
+        public override int GetHashCode() => 0;
+
+        public void AppendTo(TextWriter trapFile)
+        {
+            trapFile.Write('*');
+        }
+    }
+
+    /// <summary>
+    /// A key. Either a simple key, e.g. `@"bool A.M();method"`, or a compound key, e.g.
+    /// `@"{0} {1}.M();method"` where `0` and `1` are both labels.
+    /// </summary>
+    public class Key : IId
+    {
+        private readonly StringWriter trapBuilder = new StringWriter();
+
+        /// <summary>
+        /// Creates a new key by concatenating the contents of the supplied arguments.
+        /// </summary>
+        public Key(params object[] args)
+        {
+            trapBuilder = new StringWriter();
+            foreach (var arg in args)
+            {
+                if (arg is IEntity entity)
+                {
+                    var key = entity.Label;
+                    trapBuilder.Write("{#");
+                    trapBuilder.Write(key.Value.ToString());
+                    trapBuilder.Write("}");
+                }
+                else
+                {
+                    trapBuilder.Write(arg.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a new key by applying the supplied action to an empty
+        /// trap builder.
+        /// </summary>
+        public Key(Action<TextWriter> action)
+        {
+            action(trapBuilder);
+        }
+
+        public override string ToString()
+        {
+            return trapBuilder.ToString();
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null || obj.GetType() != GetType())
+                return false;
+            var id = (Key)obj;
+            return trapBuilder.ToString() == id.trapBuilder.ToString();
+        }
+
+        public override int GetHashCode() => trapBuilder.ToString().GetHashCode();
+
+        public void AppendTo(TextWriter trapFile)
+        {
+            trapFile.Write("@\"");
+            trapFile.Write(trapBuilder.ToString());
+            trapFile.Write("\"");
+        }
+    }
+
+    /// <summary>
+    /// A label referencing an entity, of the form "#123".
+    /// </summary>
+    public struct Label
+    {
+        public Label(int value) : this()
+        {
+            Value = value;
+        }
+
+        public int Value { get; private set; }
+
+        public static Label InvalidLabel { get; } = new Label(0);
+
+        public bool Valid => Value > 0;
+
+        public override string ToString()
+        {
+            if (!Valid)
+                throw new InvalidOperationException("Attempt to use an invalid label");
+
+            return "#" + Value;
+        }
+
+        public static bool operator ==(Label l1, Label l2) => l1.Value == l2.Value;
+
+        public static bool operator !=(Label l1, Label l2) => l1.Value != l2.Value;
+
+        public override bool Equals(object? other)
+        {
+            if (other is null)
+                return false;
+            return GetType() == other.GetType() && ((Label)other).Value == Value;
+        }
+
+        public override int GetHashCode() => 61 * Value;
+
+        /// <summary>
+        /// Constructs a unique string for this label.
+        /// </summary>
+        /// <param name="trapFile">The trap builder used to store the result.</param>
+        public void AppendTo(System.IO.TextWriter trapFile)
+        {
+            if (!Valid)
+                throw new InvalidOperationException("Attempt to use an invalid label");
+
+            trapFile.Write('#');
+            trapFile.Write(Value);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/InternalError.cs
+++ b/powershell/extractor/Semmle.Extraction/InternalError.cs
@@ -1,0 +1,39 @@
+using Microsoft.CodeAnalysis;
+using System;
+using System.Linq;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// Exception thrown whenever extraction encounters something unexpected.
+    /// </summary>
+    public class InternalError : Exception
+    {
+        public InternalError(ISymbol symbol, string msg)
+        {
+            Text = msg;
+            EntityText = symbol.ToString() ?? "";
+            Location = symbol.Locations.FirstOrDefault();
+        }
+
+        public InternalError(SyntaxNode node, string msg)
+        {
+            Text = msg;
+            EntityText = node.ToString();
+            Location = node.GetLocation();
+        }
+
+        public InternalError(string msg)
+        {
+            Text = msg;
+            EntityText = "";
+            Location = null;
+        }
+
+        public Location? Location { get; }
+        public string Text { get; }
+        public string EntityText { get; }
+
+        public override string Message => Text;
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Layout.cs
+++ b/powershell/extractor/Semmle.Extraction/Layout.cs
@@ -1,0 +1,204 @@
+using Semmle.Util.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// An extractor layout file.
+    /// Represents the layout of projects into trap folders and source archives.
+    /// </summary>
+    public sealed class Layout
+    {
+        /// <summary>
+        /// Exception thrown when the layout file is invalid.
+        /// </summary>
+        public class InvalidLayoutException : Exception
+        {
+            public InvalidLayoutException(string file, string message) :
+                base("ODASA_POWERSHELL_LAYOUT " + file + " " + message)
+            {
+            }
+        }
+
+        /// <summary>
+        /// List of blocks in the layout file.
+        /// </summary>
+        private readonly List<LayoutBlock> blocks;
+
+        /// <summary>
+        /// A subproject in the layout file.
+        /// </summary>
+        public class SubProject
+        {
+            /// <summary>
+            /// The trap folder, or null for current directory.
+            /// </summary>
+            public string? TRAP_FOLDER { get; }
+
+            /// <summary>
+            /// The source archive, or null to skip.
+            /// </summary>
+            public string? SOURCE_ARCHIVE { get; }
+
+            public SubProject(string? traps, string? archive)
+            {
+                TRAP_FOLDER = traps;
+                SOURCE_ARCHIVE = archive;
+            }
+
+            /// <summary>
+            /// Gets the name of the trap file for a given source/assembly file.
+            /// </summary>
+            /// <param name="srcFile">The source file.</param>
+            /// <returns>The full filepath of the trap file.</returns>
+            public string GetTrapPath(ILogger logger, PathTransformer.ITransformedPath srcFile, TrapWriter.CompressionMode trapCompression) =>
+                TrapWriter.TrapPath(logger, TRAP_FOLDER, srcFile, trapCompression);
+
+            /// <summary>
+            /// Creates a trap writer for a given source/assembly file.
+            /// </summary>
+            /// <param name="srcFile">The source file.</param>
+            /// <returns>A newly created TrapWriter.</returns>
+            public TrapWriter CreateTrapWriter(ILogger logger, PathTransformer.ITransformedPath srcFile, TrapWriter.CompressionMode trapCompression, bool discardDuplicates) =>
+                new TrapWriter(logger, srcFile, TRAP_FOLDER, SOURCE_ARCHIVE, trapCompression, discardDuplicates);
+        }
+
+        private readonly SubProject defaultProject;
+
+        /// <summary>
+        /// Finds the suitable directories for a given source file.
+        /// Returns null if not included in the layout.
+        /// </summary>
+        /// <param name="sourceFile">The file to look up.</param>
+        /// <returns>The relevant subproject, or null if not found.</returns>
+        public SubProject? LookupProjectOrNull(PathTransformer.ITransformedPath sourceFile)
+        {
+            if (!useLayoutFile)
+                return defaultProject;
+
+            return blocks
+                .Where(block => block.Matches(sourceFile))
+                .Select(block => block.Directories)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Finds the suitable directories for a given source file.
+        /// Returns the default project if not included in the layout.
+        /// </summary>
+        /// <param name="sourceFile">The file to look up.</param>
+        /// <returns>The relevant subproject, or DefaultProject if not found.</returns>
+        public SubProject LookupProjectOrDefault(PathTransformer.ITransformedPath sourceFile)
+        {
+            return LookupProjectOrNull(sourceFile) ?? defaultProject;
+        }
+
+        private readonly bool useLayoutFile;
+
+        /// <summary>
+        /// Default constructor reads parameters from the environment.
+        /// </summary>
+        public Layout() : this(
+            Environment.GetEnvironmentVariable("CODEQL_EXTRACTOR_POWERSHELL_TRAP_DIR") ?? Environment.GetEnvironmentVariable("TRAP_FOLDER"),
+            Environment.GetEnvironmentVariable("CODEQL_EXTRACTOR_POWERSHELL_SOURCE_ARCHIVE_DIR") ?? Environment.GetEnvironmentVariable("SOURCE_ARCHIVE"),
+            Environment.GetEnvironmentVariable("ODASA_POWERSHELL_LAYOUT"))
+        {
+        }
+
+        /// <summary>
+        /// Creates the project layout. Reads the layout file if specified.
+        /// </summary>
+        /// <param name="traps">Directory for trap files, or null to use layout/current directory.</param>
+        /// <param name="archive">Directory for source archive, or null for layout/no archive.</param>
+        /// <param name="layout">Path of layout file, or null for no layout.</param>
+        /// <exception cref="InvalidLayoutException">Failed to read layout file.</exception>
+        public Layout(string? traps, string? archive, string? layout)
+        {
+            useLayoutFile = string.IsNullOrEmpty(traps) && !string.IsNullOrEmpty(layout);
+            blocks = new List<LayoutBlock>();
+
+            if (useLayoutFile)
+            {
+                ReadLayoutFile(layout!);
+                defaultProject = blocks[0].Directories;
+            }
+            else
+            {
+                defaultProject = new SubProject(traps, archive);
+            }
+        }
+
+        /// <summary>
+        /// Is the source file included in the layout?
+        /// </summary>
+        /// <param name="path">The absolute path of the file to query.</param>
+        /// <returns>True iff there is no layout file or the layout file specifies the file.</returns>
+        public bool FileInLayout(PathTransformer.ITransformedPath path) => LookupProjectOrNull(path) is not null;
+
+        private void ReadLayoutFile(string layout)
+        {
+            try
+            {
+                var lines = File.ReadAllLines(layout);
+
+                var i = 0;
+                while (!lines[i].StartsWith("#"))
+                    i++;
+                while (i < lines.Length)
+                {
+                    var block = new LayoutBlock(lines, ref i);
+                    blocks.Add(block);
+                }
+
+                if (blocks.Count == 0)
+                    throw new InvalidLayoutException(layout, "contains no blocks");
+            }
+            catch (IOException ex)
+            {
+                throw new InvalidLayoutException(layout, ex.Message);
+            }
+            catch (IndexOutOfRangeException)
+            {
+                throw new InvalidLayoutException(layout, "is invalid");
+            }
+        }
+    }
+
+    internal sealed class LayoutBlock
+    {
+        private readonly List<FilePattern> filePatterns = new List<FilePattern>();
+
+        public Layout.SubProject Directories { get; }
+
+        private static string? ReadVariable(string name, string line)
+        {
+            var prefix = name + "=";
+            if (!line.StartsWith(prefix))
+                return null;
+            return line.Substring(prefix.Length).Trim();
+        }
+
+        public LayoutBlock(string[] lines, ref int i)
+        {
+            // first line: #name
+            i++;
+            var trapFolder = ReadVariable("TRAP_FOLDER", lines[i++]);
+            // Don't care about ODASA_DB.
+            ReadVariable("ODASA_DB", lines[i++]);
+            var sourceArchive = ReadVariable("SOURCE_ARCHIVE", lines[i++]);
+
+            Directories = new Layout.SubProject(trapFolder, sourceArchive);
+            // Don't care about ODASA_BUILD_ERROR_DIR.
+            ReadVariable("ODASA_BUILD_ERROR_DIR", lines[i++]);
+            while (i < lines.Length && !lines[i].StartsWith("#"))
+            {
+                filePatterns.Add(new FilePattern(lines[i++]));
+            }
+        }
+
+        public bool Matches(PathTransformer.ITransformedPath path) => FilePattern.Matches(filePatterns, path.Value, out var _);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/LocationExtensions.cs
+++ b/powershell/extractor/Semmle.Extraction/LocationExtensions.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Semmle.Extraction
+{
+    public static class LocationExtensions
+    {
+        public static int StartLine(this Location loc) => loc.GetLineSpan().Span.Start.Line;
+
+        public static int StartColumn(this Location loc) => loc.GetLineSpan().Span.Start.Character;
+
+        public static int EndLine(this Location loc) => loc.GetLineSpan().Span.End.Line;
+
+        /// <summary>
+        /// Whether one Location outer completely contains another Location inner.
+        /// </summary>
+        /// <param name="outer">The outer location.</param>
+        /// <param name="inner">The inner location</param>
+        /// <returns>Whether inner is completely container in outer.</returns>
+        public static bool Contains(this Location outer, Location inner)
+        {
+            var sameFile = outer.SourceTree == inner.SourceTree;
+            var startsBefore = outer.SourceSpan.Start <= inner.SourceSpan.Start;
+            var endsAfter = outer.SourceSpan.End >= inner.SourceSpan.End;
+            return sameFile && startsBefore && endsAfter;
+        }
+
+        /// <summary>
+        /// Whether one Location ends before another starts.
+        /// </summary>
+        /// <param name="before">The Location coming before</param>
+        /// <param name="after">The Location coming after</param>
+        /// <returns>Whether 'before' comes before 'after'.</returns>
+        public static bool Before(this Location before, Location after)
+        {
+            var sameFile = before.SourceTree == after.SourceTree;
+            var endsBefore = before.SourceSpan.End <= after.SourceSpan.Start;
+            return sameFile && endsBefore;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Message.cs
+++ b/powershell/extractor/Semmle.Extraction/Message.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.CodeAnalysis;
+using Semmle.Util.Logging;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// Encapsulates information for a log message.
+    /// </summary>
+    public class Message
+    {
+        public Severity Severity { get; }
+        public string Text { get; }
+        public string? StackTrace { get; }
+        public string? EntityText { get; }
+        public Entities.Location? Location { get; }
+
+        public Message(string text, string? entityText, Entities.Location? location, string? stackTrace = null, Severity severity = Severity.Error)
+        {
+            Severity = severity;
+            Text = text;
+            StackTrace = stackTrace;
+            EntityText = entityText;
+            Location = location;
+        }
+
+        public static Message Create(Context cx, string text, ISymbol symbol, string? stackTrace = null, Severity severity = Severity.Error)
+        {
+            return new Message(text, symbol.ToString(), cx.CreateLocation(symbol.Locations.FirstOrDefault()), stackTrace, severity);
+        }
+
+        public static Message Create(Context cx, string text, SyntaxNode node, string? stackTrace = null, Severity severity = Severity.Error)
+        {
+            return new Message(text, node.ToString(), cx.CreateLocation(node.GetLocation()), stackTrace, severity);
+        }
+
+        public override string ToString() => Text;
+
+        public string ToLogString()
+        {
+            var sb = new StringBuilder();
+            sb.Append(Text);
+            if (!string.IsNullOrEmpty(EntityText))
+                sb.Append(" in ").Append(EntityText);
+            if (!(Location is null) && !(Location.Symbol is null))
+                sb.Append(" at ").Append(Location.Symbol.GetLineSpan());
+            if (!string.IsNullOrEmpty(StackTrace))
+                sb.Append(" ").Append(StackTrace);
+            return sb.ToString();
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Options.cs
+++ b/powershell/extractor/Semmle.Extraction/Options.cs
@@ -1,0 +1,103 @@
+using Semmle.Util.Logging;
+using Semmle.Util;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// Represents the parsed state of the command line arguments.
+    /// This represents the common options.
+    /// </summary>
+    public abstract class CommonOptions : ICommandLineOptions
+    {
+        /// <summary>
+        /// The specified number of threads, or the default if unspecified.
+        /// </summary>
+        public int Threads { get; private set; } = System.Environment.ProcessorCount;
+
+        /// <summary>
+        /// The verbosity used in output and logging.
+        /// </summary>
+        public Verbosity Verbosity { get; protected set; } = Verbosity.Info;
+
+        /// <summary>
+        /// Whether to output to the console.
+        /// </summary>
+        public bool Console { get; private set; } = false;
+
+        /// <summary>
+        /// Holds if CIL should be extracted.
+        /// </summary>
+        public bool CIL { get; private set; } = false;
+
+        /// <summary>
+        /// Holds if assemblies shouldn't be extracted twice.
+        /// </summary>
+        public bool Cache { get; private set; } = true;
+
+        /// <summary>
+        /// Whether to extract PDB information.
+        /// </summary>
+        public bool PDB { get; private set; } = false;
+
+        /// <summary>
+        /// Whether "fast extraction mode" has been enabled.
+        /// </summary>
+        public bool Fast { get; private set; } = false;
+
+        /// <summary>
+        /// The compression algorithm used for trap files.
+        /// </summary>
+        public TrapWriter.CompressionMode TrapCompression { get; set; } = TrapWriter.CompressionMode.Gzip;
+
+        public virtual bool HandleOption(string key, string value)
+        {
+            switch (key)
+            {
+                case "threads":
+                    Threads = int.Parse(value);
+                    return true;
+                case "verbosity":
+                    Verbosity = (Verbosity)int.Parse(value);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public abstract bool HandleArgument(string argument);
+
+        public virtual bool HandleFlag(string flag, bool value)
+        {
+            switch (flag)
+            {
+                case "verbose":
+                    Verbosity = value ? Verbosity.Debug : Verbosity.Error;
+                    return true;
+                case "console":
+                    Console = value;
+                    return true;
+                case "cache":
+                    Cache = value;
+                    return true;
+                case "cil":
+                    CIL = value;
+                    return true;
+                case "pdb":
+                    PDB = value;
+                    CIL = true;
+                    return true;
+                case "fast":
+                    CIL = !value;
+                    Fast = value;
+                    return true;
+                case "brotli":
+                    TrapCompression = value ? TrapWriter.CompressionMode.Brotli : TrapWriter.CompressionMode.Gzip;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public abstract void InvalidArgument(string argument);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/PathTransformer.cs
+++ b/powershell/extractor/Semmle.Extraction/PathTransformer.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Diagnostics.CodeAnalysis;
+using Semmle.Util;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// A class for interpreting path transformers specified using the environment
+    /// variable `CODEQL_PATH_TRANSFORMER`.
+    /// </summary>
+    public sealed class PathTransformer
+    {
+        public class InvalidPathTransformerException : Exception
+        {
+            public InvalidPathTransformerException(string message) :
+                base($"Invalid path transformer specification: {message}")
+            { }
+        }
+
+        /// <summary>
+        /// A transformed path.
+        /// </summary>
+        public interface ITransformedPath
+        {
+            string Value { get; }
+
+            string Extension { get; }
+
+            string NameWithoutExtension { get; }
+
+            ITransformedPath? ParentDirectory { get; }
+
+            ITransformedPath WithSuffix(string suffix);
+
+            string DatabaseId { get; }
+        }
+
+        private struct TransformedPath : ITransformedPath
+        {
+            public TransformedPath(string value) { this.value = value; }
+            private readonly string value;
+
+            public string Value => value;
+
+            public string Extension
+            {
+                get
+                {
+                    var extension = Path.GetExtension(value);
+                    return string.IsNullOrEmpty(extension) ? "" : extension.Substring(1);
+                }
+            }
+
+            public string NameWithoutExtension => Path.GetFileNameWithoutExtension(value);
+
+            public ITransformedPath? ParentDirectory
+            {
+                get
+                {
+                    var dir = Path.GetDirectoryName(value);
+                    if (dir is null)
+                        return null;
+                    var isWindowsDriveLetter = dir.Length == 2 && char.IsLetter(dir[0]) && dir[1] == ':';
+                    if (isWindowsDriveLetter)
+                        return null;
+                    return new TransformedPath(FileUtils.ConvertToUnix(dir));
+                }
+            }
+
+            public ITransformedPath WithSuffix(string suffix) => new TransformedPath(value + suffix);
+
+            public string DatabaseId
+            {
+                get
+                {
+                    var ret = value;
+                    if (ret.Length >= 2 && ret[1] == ':' && Char.IsLower(ret[0]))
+                        ret = Char.ToUpper(ret[0]) + "_" + ret.Substring(2);
+                    return ret.Replace('\\', '/').Replace(":", "_");
+                }
+            }
+
+            public override int GetHashCode() => 11 * value.GetHashCode();
+
+            public override bool Equals(object? obj) => obj is TransformedPath tp && tp.value == value;
+
+            public override string ToString() => value;
+        }
+
+        private readonly Func<string, string> transform;
+
+        /// <summary>
+        /// Returns the path obtained by transforming `path`.
+        /// </summary>
+        public ITransformedPath Transform(string path) => new TransformedPath(transform(path));
+
+        /// <summary>
+        /// Default constructor reads parameters from the environment.
+        /// </summary>
+        public PathTransformer(IPathCache pathCache) :
+            this(pathCache, Environment.GetEnvironmentVariable("CODEQL_PATH_TRANSFORMER") is string file ? File.ReadAllLines(file) : null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a path transformer based on the specification in `lines`.
+        /// Throws `InvalidPathTransformerException` for invalid specifications.
+        /// </summary>
+        public PathTransformer(IPathCache pathCache, string[]? lines)
+        {
+            if (lines is null)
+            {
+                transform = path => FileUtils.ConvertToUnix(pathCache.GetCanonicalPath(path));
+                return;
+            }
+
+            var sections = ParsePathTransformerSpec(lines);
+            transform = path =>
+            {
+                path = FileUtils.ConvertToUnix(pathCache.GetCanonicalPath(path));
+                foreach (var section in sections)
+                {
+                    if (section.Matches(path, out var transformed))
+                        return transformed;
+                }
+                return path;
+            };
+        }
+
+        private static IEnumerable<TransformerSection> ParsePathTransformerSpec(string[] lines)
+        {
+            var sections = new List<TransformerSection>();
+            try
+            {
+                var i = 0;
+                while (i < lines.Length && !lines[i].StartsWith("#"))
+                    i++;
+                while (i < lines.Length)
+                {
+                    var section = new TransformerSection(lines, ref i);
+                    sections.Add(section);
+                }
+
+                if (sections.Count == 0)
+                    throw new InvalidPathTransformerException("contains no sections.");
+            }
+            catch (InvalidFilePatternException ex)
+            {
+                throw new InvalidPathTransformerException(ex.Message);
+            }
+            return sections;
+        }
+    }
+
+    internal sealed class TransformerSection
+    {
+        private readonly string name;
+        private readonly List<FilePattern> filePatterns = new List<FilePattern>();
+
+        public TransformerSection(string[] lines, ref int i)
+        {
+            name = lines[i++].Substring(1); // skip the '#'
+            for (; i < lines.Length && !lines[i].StartsWith("#"); i++)
+            {
+                var line = lines[i];
+                if (!string.IsNullOrWhiteSpace(line))
+                    filePatterns.Add(new FilePattern(line));
+            }
+        }
+
+        public bool Matches(string path, [NotNullWhen(true)] out string? transformed)
+        {
+            if (FilePattern.Matches(filePatterns, path, out var suffix))
+            {
+                transformed = FileUtils.ConvertToUnix(name) + suffix;
+                return true;
+            }
+            transformed = null;
+            return false;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Properties/AssemblyInfo.cs
+++ b/powershell/extractor/Semmle.Extraction/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Semmle.Extraction")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Semmle.Extraction")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3ccd1a26-1621-4f4d-afc3-21ef67eee1da")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/powershell/extractor/Semmle.Extraction/Semmle.Extraction.csproj
+++ b/powershell/extractor/Semmle.Extraction/Semmle.Extraction.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <AssemblyName>Semmle.Extraction</AssemblyName>
+    <RootNamespace>Semmle.Extraction</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <CodeAnalysisRuleSet>Semmle.Extraction.ruleset</CodeAnalysisRuleSet>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;DEBUG_LABELS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.9.0" />
+    <PackageReference Include="GitInfo" Version="2.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Semmle.Util\Semmle.Util.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/powershell/extractor/Semmle.Extraction/Semmle.Extraction.ruleset
+++ b/powershell/extractor/Semmle.Extraction/Semmle.Extraction.ruleset
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
+
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Analyzers">
+    <Rule Id="RS1022" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers" />
+</RuleSet>

--- a/powershell/extractor/Semmle.Extraction/SourceScope.cs
+++ b/powershell/extractor/Semmle.Extraction/SourceScope.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.CodeAnalysis;
+using System.Linq;
+
+namespace Semmle.Extraction
+{
+
+    /// <summary>
+    /// The scope of symbols in a source file.
+    /// </summary>
+    public class SourceScope : IExtractionScope
+    {
+        public SyntaxTree SourceTree { get; }
+
+        public SourceScope(SyntaxTree tree)
+        {
+            SourceTree = tree;
+        }
+
+        public bool InFileScope(string path) => path == SourceTree.FilePath;
+
+        public bool InScope(ISymbol symbol) => symbol.Locations.Any(loc => loc.SourceTree == SourceTree);
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/TrapExtensions.cs
+++ b/powershell/extractor/Semmle.Extraction/TrapExtensions.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    public static class TrapExtensions
+    {
+        public static void WriteLabel(this TextWriter trapFile, int value)
+        {
+            trapFile.Write('#');
+            trapFile.Write(value);
+        }
+
+        public static void WriteLabel(this TextWriter trapFile, IEntity entity)
+        {
+            trapFile.WriteLabel(entity.Label.Value);
+        }
+
+        public static void WriteSeparator(this TextWriter trapFile, string separator, ref int index)
+        {
+            if (index++ > 0)
+                trapFile.Write(separator);
+        }
+
+
+        public static TextWriter WriteColumn(this TextWriter trapFile, int i)
+        {
+            trapFile.Write(i);
+            return trapFile;
+        }
+
+        public static TextWriter WriteColumn(this TextWriter trapFile, bool b)
+        {
+            trapFile.Write(b.ToString().ToLowerInvariant());
+            return trapFile;
+        }
+
+        public static TextWriter WriteColumn(this TextWriter trapFile, string s)
+        {
+            trapFile.WriteTrapString(s);
+            return trapFile;
+        }
+
+        public static TextWriter WriteColumn(this TextWriter trapFile, IEntity entity)
+        {
+            trapFile.WriteLabel(entity.Label.Value);
+            return trapFile;
+        }
+
+        public static TextWriter WriteColumn(this TextWriter trapFile, Label label)
+        {
+            trapFile.WriteLabel(label.Value);
+            return trapFile;
+        }
+
+
+        public static TextWriter WriteColumn(this TextWriter trapFile, float f)
+        {
+            trapFile.WriteTrapFloat(f);
+            return trapFile;
+        }
+
+        public static TextWriter WriteColumn(this TextWriter trapFile, object o)
+        {
+            switch (o)
+            {
+                case int i:
+                    return trapFile.WriteColumn(i);
+                case float f:
+                    return trapFile.WriteColumn(f);
+                case string s:
+                    return trapFile.WriteColumn(s);
+                case IEntity e:
+                    return trapFile.WriteColumn(e);
+                case Label l:
+                    return trapFile.WriteColumn(l);
+                case Enum _:
+                    return trapFile.WriteColumn((int)o);
+                case bool b:
+                    return trapFile.WriteColumn(b);
+                default:
+                    throw new NotSupportedException($"Unsupported object type '{o.GetType()}' received");
+            }
+        }
+
+        private const int maxStringBytes = 1 << 20;  // 1MB
+        private static readonly System.Text.Encoding encoding = System.Text.Encoding.UTF8;
+
+        private static bool NeedsTruncation(string s)
+        {
+            // Optimization: only count the actual number of bytes if there is the possibility
+            // of the string exceeding maxStringBytes
+            return encoding.GetMaxByteCount(s.Length) > maxStringBytes &&
+                encoding.GetByteCount(s) > maxStringBytes;
+        }
+
+        private static void WriteString(TextWriter trapFile, string s) => trapFile.Write(EncodeString(s));
+
+        /// <summary>
+        /// Truncates a string such that the output UTF8 does not exceed <paramref name="bytesRemaining"/> bytes.
+        /// </summary>
+        /// <param name="s">The input string to truncate.</param>
+        /// <param name="bytesRemaining">The number of bytes available.</param>
+        /// <returns>The truncated string.</returns>
+        private static string TruncateString(string s, ref int bytesRemaining)
+        {
+            var outputLen = encoding.GetByteCount(s);
+            if (outputLen > bytesRemaining)
+            {
+                outputLen = 0;
+                int chars;
+                for (chars = 0; chars < s.Length; ++chars)
+                {
+                    var bytes = encoding.GetByteCount(s, chars, 1);
+                    if (outputLen + bytes <= bytesRemaining)
+                        outputLen += bytes;
+                    else
+                        break;
+                }
+                s = s.Substring(0, chars);
+            }
+            bytesRemaining -= outputLen;
+            return s;
+        }
+
+        public static string EncodeString(string s) => s.Replace("\"", "\"\"");
+
+        /// <summary>
+        /// Output a string to the trap file, such that the encoded output does not exceed
+        /// <paramref name="bytesRemaining"/> bytes.
+        /// </summary>
+        /// <param name="trapFile">The trapbuilder</param>
+        /// <param name="s">The string to output.</param>
+        /// <param name="bytesRemaining">The remaining bytes available to output.</param>
+        private static void WriteTruncatedString(TextWriter trapFile, string s, ref int bytesRemaining)
+        {
+            WriteString(trapFile, TruncateString(s, ref bytesRemaining));
+        }
+
+        public static void WriteTrapString(this TextWriter trapFile, string s)
+        {
+            trapFile.Write('\"');
+            if (NeedsTruncation(s))
+            {
+                // Slow path
+                var remaining = maxStringBytes;
+                WriteTruncatedString(trapFile, s, ref remaining);
+            }
+            else
+            {
+                // Fast path
+                WriteString(trapFile, s);
+            }
+            trapFile.Write('\"');
+        }
+
+        public static void WriteTrapFloat(this TextWriter trapFile, float f)
+        {
+            trapFile.Write(f.ToString("F5", System.Globalization.CultureInfo.InvariantCulture));  // Trap importer won't accept ints
+        }
+
+        public static void WriteTuple(this TextWriter trapFile, string name, params object[] @params)
+        {
+            trapFile.Write(name);
+            trapFile.Write('(');
+            var index = 0;
+            foreach (var p in @params)
+            {
+                trapFile.WriteSeparator(",", ref index);
+                trapFile.WriteColumn(p);
+            }
+            trapFile.WriteLine(')');
+        }
+
+        public static void WriteTuple(this TextWriter trapFile, string name, IEntity p1)
+        {
+            trapFile.Write(name);
+            trapFile.Write('(');
+            trapFile.WriteColumn(p1);
+            trapFile.WriteLine(')');
+        }
+
+        public static void WriteTuple(this TextWriter trapFile, string name, IEntity p1, object p2)
+        {
+            trapFile.Write(name);
+            trapFile.Write('(');
+            trapFile.WriteColumn(p1);
+            trapFile.Write(',');
+            trapFile.WriteColumn(p2);
+            trapFile.WriteLine(')');
+        }
+
+        public static void WriteTuple(this TextWriter trapFile, string name, IEntity p1, object p2, object p3)
+        {
+            trapFile.Write(name);
+            trapFile.Write('(');
+            trapFile.WriteColumn(p1);
+            trapFile.Write(',');
+            trapFile.WriteColumn(p2);
+            trapFile.Write(',');
+            trapFile.WriteColumn(p3);
+            trapFile.WriteLine(')');
+        }
+
+        public static void WriteTuple(this TextWriter trapFile, string name, IEntity p1, object p2, object p3, object p4)
+        {
+            trapFile.Write(name);
+            trapFile.Write('(');
+            trapFile.WriteColumn(p1);
+            trapFile.Write(',');
+            trapFile.WriteColumn(p2);
+            trapFile.Write(',');
+            trapFile.WriteColumn(p3);
+            trapFile.Write(',');
+            trapFile.WriteColumn(p4);
+            trapFile.WriteLine(')');
+        }
+
+        /// <summary>
+        /// Appends a [comma] separated list to a trap builder.
+        /// </summary>
+        /// <typeparam name="T">The type of the list.</typeparam>
+        /// <param name="trapFile">The trap builder to append to.</param>
+        /// <param name="separator">The separator string (e.g. ",")</param>
+        /// <param name="items">The list of items.</param>
+        /// <returns>The original trap builder (fluent interface).</returns>
+        public static TextWriter AppendList<T>(this EscapingTextWriter trapFile, string separator, IEnumerable<T> items) where T : IEntity
+        {
+            return trapFile.BuildList(separator, items, x => trapFile.WriteSubId(x));
+        }
+
+        /// <summary>
+        /// Builds a trap builder using a separator and an action for each item in the list.
+        /// </summary>
+        /// <typeparam name="T">The type of the items.</typeparam>
+        /// <param name="trapFile">The trap builder to append to.</param>
+        /// <param name="separator">The separator string (e.g. ",")</param>
+        /// <param name="items">The list of items.</param>
+        /// <param name="action">The action on each item.</param>
+        /// <returns>The original trap builder (fluent interface).</returns>
+        public static T1 BuildList<T1, T2>(this T1 trapFile, string separator, IEnumerable<T2> items, Action<T2> action)
+            where T1 : TextWriter
+        {
+            var first = true;
+            foreach (var item in items)
+            {
+                if (first)
+                    first = false;
+                else
+                    trapFile.Write(separator);
+                action(item);
+            }
+            return trapFile;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/TrapStackBehaviour.cs
+++ b/powershell/extractor/Semmle.Extraction/TrapStackBehaviour.cs
@@ -1,0 +1,28 @@
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// How an entity behaves with respect to .push and .pop
+    /// </summary>
+    public enum TrapStackBehaviour
+    {
+        /// <summary>
+        /// The entity must not be extracted inside a .push/.pop
+        /// </summary>
+        NoLabel,
+
+        /// <summary>
+        /// The entity defines its own label, creating a .push/.pop
+        /// </summary>
+        PushesLabel,
+
+        /// <summary>
+        /// The entity must be extracted inside a .push/.pop
+        /// </summary>
+        NeedsLabel,
+
+        /// <summary>
+        /// The entity can be extracted inside or outside of a .push/.pop
+        /// </summary>
+        OptionalLabel
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/TrapWriter.cs
+++ b/powershell/extractor/Semmle.Extraction/TrapWriter.cs
@@ -1,0 +1,286 @@
+using Semmle.Util;
+using Semmle.Util.Logging;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Semmle.Extraction
+{
+    public interface ITrapEmitter
+    {
+        void EmitTrap(TextWriter trapFile);
+    }
+
+    public sealed class TrapWriter : IDisposable
+    {
+        public enum CompressionMode
+        {
+            None,
+            Gzip,
+            Brotli
+        }
+
+        /// <summary>
+        /// The location of the src_archive directory.
+        /// </summary>
+        private readonly string? archive;
+        private static readonly Encoding utf8 = new UTF8Encoding(false);
+
+        private readonly bool discardDuplicates;
+
+        public int IdCounter { get; set; } = 1;
+
+        private readonly Lazy<StreamWriter> writerLazy;
+
+        public StreamWriter Writer => writerLazy.Value;
+
+        private readonly ILogger logger;
+
+        private readonly CompressionMode trapCompression;
+
+        public TrapWriter(ILogger logger, PathTransformer.ITransformedPath outputfile, string? trap, string? archive, CompressionMode trapCompression, bool discardDuplicates)
+        {
+            this.logger = logger;
+            this.trapCompression = trapCompression;
+
+            TrapFile = TrapPath(this.logger, trap, outputfile, trapCompression);
+
+            writerLazy = new Lazy<StreamWriter>(() =>
+            {
+                var tempPath = trap ?? Path.GetTempPath();
+
+                do
+                {
+                    /*
+                     * Write the trap to a random filename in the trap folder.
+                     * Since the trap path can be very long, we need to deal with the possibility of
+                     * PathTooLongExceptions. So we use a short filename in the trap folder,
+                     * then move it later.
+                     *
+                     * Although GetRandomFileName() is cryptographically secure,
+                     * there's a tiny chance the file could already exists.
+                     */
+                    tmpFile = Path.Combine(tempPath, Path.GetRandomFileName());
+                }
+                while (File.Exists(tmpFile));
+
+                var fileStream = new FileStream(tmpFile, FileMode.CreateNew, FileAccess.Write);
+
+                Stream compressionStream;
+
+                switch (trapCompression)
+                {
+                    case CompressionMode.Brotli:
+                        compressionStream = new BrotliStream(fileStream, CompressionLevel.Fastest);
+                        break;
+                    case CompressionMode.Gzip:
+                        compressionStream = new GZipStream(fileStream, CompressionLevel.Fastest);
+                        break;
+                    case CompressionMode.None:
+                        compressionStream = fileStream;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(trapCompression), trapCompression, "Unsupported compression type");
+                }
+
+
+                return new StreamWriter(compressionStream, utf8, 2000000);
+            });
+            this.archive = archive;
+            this.discardDuplicates = discardDuplicates;
+        }
+
+        /// <summary>
+        /// The output filename of the trap.
+        /// </summary>
+        public string TrapFile { get; }
+        private string tmpFile = "";     // The temporary file which is moved to trapFile once written.
+
+        /// <summary>
+        /// Adds the specified input file to the source archive. It may end up in either the normal or long path area
+        /// of the source archive, depending on the length of its full path.
+        /// </summary>
+        /// <param name="originalPath">The path to the input file.</param>
+        /// <param name="transformedPath">The transformed path to the input file.</param>
+        /// <param name="inputEncoding">The encoding used by the input file.</param>
+        public void Archive(string originalPath, PathTransformer.ITransformedPath transformedPath, Encoding inputEncoding)
+        {
+            if (string.IsNullOrEmpty(archive))
+                return;
+
+            // Calling GetFullPath makes this use the canonical capitalisation, if the file exists.
+            var fullInputPath = Path.GetFullPath(originalPath);
+
+            ArchivePath(fullInputPath, transformedPath, inputEncoding);
+        }
+
+        /// <summary>
+        /// Archive a file given the file contents.
+        /// </summary>
+        /// <param name="inputPath">The path of the file.</param>
+        /// <param name="contents">The contents of the file.</param>
+        public void Archive(PathTransformer.ITransformedPath inputPath, string contents)
+        {
+            if (string.IsNullOrEmpty(archive))
+                return;
+
+            ArchiveContents(inputPath, contents);
+        }
+
+        /// <summary>
+        /// Try to move a file from sourceFile to destFile.
+        /// If successful returns true,
+        /// otherwise returns false and leaves the file in its original place.
+        /// </summary>
+        /// <param name="sourceFile">The source filename.</param>
+        /// <param name="destFile">The destination filename.</param>
+        /// <returns>true if the file was moved.</returns>
+        private static bool TryMove(string sourceFile, string destFile)
+        {
+            try
+            {
+                // Prefer to avoid throwing an exception
+                if (File.Exists(destFile))
+                    return false;
+
+                File.Move(sourceFile, destFile);
+                return true;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Close the trap file, and move it to the right place in the trap directory.
+        /// If the file exists already, rename it to allow the new file (ending .trap.gz)
+        /// to sit alongside the old file (except if <paramref name="discardDuplicates"/> is true,
+        /// in which case only the existing file is kept).
+        /// </summary>
+        public void Dispose()
+        {
+            try
+            {
+                if (writerLazy.IsValueCreated)
+                {
+                    writerLazy.Value.Close();
+                    if (TryMove(tmpFile, TrapFile))
+                        return;
+
+                    if (discardDuplicates)
+                    {
+                        FileUtils.TryDelete(tmpFile);
+                        return;
+                    }
+
+                    var existingHash = FileUtils.ComputeFileHash(TrapFile);
+                    var hash = FileUtils.ComputeFileHash(tmpFile);
+                    if (existingHash != hash)
+                    {
+                        var root = TrapFile.Substring(0, TrapFile.Length - 8); // Remove trailing ".trap.gz"
+                        if (TryMove(tmpFile, $"{root}-{hash}.trap{TrapExtension(trapCompression)}"))
+                            return;
+                    }
+                    logger.Log(Severity.Info, "Identical trap file for {0} already exists", TrapFile);
+                    FileUtils.TryDelete(tmpFile);
+                }
+            }
+            catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                logger.Log(Severity.Error, "Failed to move the trap file from {0} to {1} because {2}", tmpFile, TrapFile, ex);
+            }
+        }
+
+        public void Emit(ITrapEmitter emitter)
+        {
+            emitter.EmitTrap(Writer);
+        }
+
+        /// <summary>
+        /// Attempts to archive the specified input file to the normal area of the source archive.
+        /// The file's path must be sufficiently short so as to render the path of its copy in the
+        /// source archive less than the system path limit of 260 characters.
+        /// </summary>
+        /// <param name="fullInputPath">The full path to the input file.</param>
+        /// <param name="transformedPath">The transformed path to the input file.</param>
+        /// <param name="inputEncoding">The encoding used by the input file.</param>
+        /// <exception cref="PathTooLongException">If the output path in the source archive would
+        /// exceed the system path limit of 260 characters.</exception>
+        private void ArchivePath(string fullInputPath, PathTransformer.ITransformedPath transformedPath, Encoding inputEncoding)
+        {
+            var contents = File.ReadAllText(fullInputPath, inputEncoding);
+            ArchiveContents(transformedPath, contents);
+        }
+
+        private void ArchiveContents(PathTransformer.ITransformedPath transformedPath, string contents)
+        {
+            var dest = NestPaths(logger, archive, transformedPath.Value);
+            var tmpSrcFile = Path.GetTempFileName();
+            File.WriteAllText(tmpSrcFile, contents, utf8);
+            try
+            {
+                FileUtils.MoveOrReplace(tmpSrcFile, dest);
+            }
+            catch (IOException ex)
+            {
+                // If this happened, it was probably because the same file was compiled multiple times.
+                // In any case, this is not a fatal error.
+                logger.Log(Severity.Warning, "Problem archiving " + dest + ": " + ex);
+            }
+        }
+
+        public static string NestPaths(ILogger logger, string? outerpath, string innerpath)
+        {
+            var nested = innerpath;
+            if (!string.IsNullOrEmpty(outerpath))
+            {
+                // Remove all leading path separators / or \
+                // For example, UNC paths have two leading \\
+                innerpath = innerpath.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+                if (innerpath.Length > 1 && innerpath[1] == ':')
+                    innerpath = innerpath[0] + "_" + innerpath.Substring(2);
+
+                nested = Path.Combine(outerpath, innerpath);
+            }
+            try
+            {
+                var directoryName = Path.GetDirectoryName(nested);
+                if (directoryName is null)
+                {
+                    logger.Log(Severity.Warning, "Failed to get directory name from path '" + nested + "'.");
+                    throw new InvalidOperationException();
+                }
+                Directory.CreateDirectory(directoryName);
+            }
+            catch (PathTooLongException)
+            {
+                logger.Log(Severity.Warning, "Failed to create parent directory of '" + nested + "': Path too long.");
+                throw;
+            }
+            return nested;
+        }
+
+        private static string TrapExtension(CompressionMode compression)
+        {
+            switch (compression)
+            {
+                case CompressionMode.None: return "";
+                case CompressionMode.Gzip: return ".gz";
+                case CompressionMode.Brotli: return ".br";
+                default: throw new ArgumentOutOfRangeException(nameof(compression), compression, "Unsupported compression type");
+            }
+        }
+
+        public static string TrapPath(ILogger logger, string? folder, PathTransformer.ITransformedPath path, TrapWriter.CompressionMode trapCompression)
+        {
+            var filename = $"{path.Value}.trap{TrapExtension(trapCompression)}";
+            if (string.IsNullOrEmpty(folder))
+                folder = Directory.GetCurrentDirectory();
+
+            return NestPaths(logger, folder, filename);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Tuple.cs
+++ b/powershell/extractor/Semmle.Extraction/Tuple.cs
@@ -1,0 +1,36 @@
+using System.IO;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// A tuple represents a string of the form "a(b,c,d)".
+    /// </summary>
+    public struct Tuple : ITrapEmitter
+    {
+        private readonly string name;
+        private readonly object[] args;
+
+        public Tuple(string name, params object[] args)
+        {
+            this.name = name;
+            this.args = args;
+        }
+
+        /// <summary>
+        /// Constructs a unique string for this tuple.
+        /// </summary>
+        /// <param name="trapFile">The trap file to write to.</param>
+        public void EmitTrap(TextWriter trapFile)
+        {
+            trapFile.WriteTuple(name, args);
+        }
+
+        public override string ToString()
+        {
+            // Only implemented for debugging purposes
+            using var writer = new StringWriter();
+            EmitTrap(writer);
+            return writer.ToString();
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Extraction/Tuples.cs
+++ b/powershell/extractor/Semmle.Extraction/Tuples.cs
@@ -1,0 +1,36 @@
+using Semmle.Extraction.Entities;
+using Semmle.Util;
+
+namespace Semmle.Extraction
+{
+    /// <summary>
+    /// Methods for creating DB tuples.
+    /// </summary>
+    public static class Tuples
+    {
+        public static void containerparent(this System.IO.TextWriter trapFile, Folder parent, IEntity child)
+        {
+            trapFile.WriteTuple("containerparent", parent, child);
+        }
+
+        internal static void extractor_messages(this System.IO.TextWriter trapFile, ExtractionMessage error, Semmle.Util.Logging.Severity severity, string origin, string errorMessage, string entityText, Location location, string stackTrace)
+        {
+            trapFile.WriteTuple("extractor_messages", error, (int)severity, origin, errorMessage, entityText, location, stackTrace);
+        }
+
+        public static void files(this System.IO.TextWriter trapFile, File file, string fullName)
+        {
+            trapFile.WriteTuple("files", file, fullName);
+        }
+
+        internal static void folders(this System.IO.TextWriter trapFile, Folder folder, string path)
+        {
+            trapFile.WriteTuple("folders", folder, path);
+        }
+
+        public static void locations_default(this System.IO.TextWriter trapFile, SourceLocation label, Entities.File file, int startLine, int startCol, int endLine, int endCol)
+        {
+            trapFile.WriteTuple("locations_default", label, file, startLine, startCol, endLine, endCol);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Pipeline.Tests/Program.cs
+++ b/powershell/extractor/Semmle.Pipeline.Tests/Program.cs
@@ -1,0 +1,46 @@
+﻿using Semmle.Pipeline.Tests;
+
+string folder1Path = args[0];
+string folder2Path = args[1];
+string[] folder1Files = Directory.GetFiles(folder1Path);
+string[] folder2Files = Directory.GetFiles(folder2Path);
+
+int numinvalid = 0;
+Console.WriteLine();
+
+foreach (string file1 in folder1Files)
+{
+    string fileName1 = Path.GetFileName(file1);
+
+    foreach (string file2 in folder2Files)
+    {
+        string fileName2 = Path.GetFileName(file2);
+
+        if (fileName1 == fileName2)
+        {
+            string file1Sanitized = TrapSanitizer.SanitizeTrap(File.ReadAllLines(file1));
+            string file2Sanitized = TrapSanitizer.SanitizeTrap(File.ReadAllLines(file2));
+
+            if (!file1Sanitized.Equals(file2Sanitized))
+            {
+                Console.WriteLine("FAILED");
+                Console.WriteLine($"${file1}");
+                Console.WriteLine($"{file1}");
+                numinvalid++;
+            }
+            else
+            {
+                Console.WriteLine("SUCCESS");
+                Console.WriteLine($"{file1}");
+                Console.WriteLine($"{file1}");
+            }
+            break;
+        }
+    }
+}
+Console.WriteLine();
+
+if (numinvalid > 0)
+{
+    throw new Exception("Trap files do not match expected output. See above logs for details.");
+}

--- a/powershell/extractor/Semmle.Pipeline.Tests/Semmle.Pipeline.Tests.csproj
+++ b/powershell/extractor/Semmle.Pipeline.Tests/Semmle.Pipeline.Tests.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/powershell/extractor/Semmle.Pipeline.Tests/TrapSanitizer.cs
+++ b/powershell/extractor/Semmle.Pipeline.Tests/TrapSanitizer.cs
@@ -1,0 +1,92 @@
+﻿using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Semmle.Pipeline.Tests;
+
+/// <summary>
+/// This class provides a method for sanitizing a trap files in tests so they can be validated. 
+///     The resulting trap file will not be valid for making a codeqldb due to missing file metadata,
+///     which is removed to ensure the test case can match the expected trap.
+/// </summary>
+internal class TrapSanitizer
+{
+    // Regex to match the IDs in the file (# followed by digits)
+    private static readonly Regex CaptureId = new Regex($"#([0-9]+)");
+
+    /// <summary>
+    /// Sanitize a Trap file to check equality by removing run specific things like file names and squashing ids
+    ///     to a consistent range
+    /// </summary>
+    /// <param name="TrapContents">The lines of the trap file to sanitize</param>
+    /// <returns>A string containing the sanitized contents</returns>
+    public static string SanitizeTrap(string[] TrapContents)
+    {
+        StringBuilder sb = new();
+        int largestId = 0;
+        // Will be the line on which syntactic extraction information starts
+        int startingLineActual = -1;
+        for (int i = 0; i < TrapContents.Length; i++)
+        {
+            // The first line with actual extracted contents will be after the numlines line
+            if (TrapContents[i].StartsWith("numlines"))
+            {
+                startingLineActual = i + 1;
+                break;
+            }
+            // If a line before numlines has an ID it is a candidate for largest id found
+            if (CaptureId.IsMatch(TrapContents[i]))
+            {
+                largestId = int.Max(largestId, int.Parse(CaptureId.Matches(TrapContents[i])[0].Groups[1].Captures[0].Value));
+            }
+        }
+
+        // Starting from the line after numlines declaration
+        for (int i = startingLineActual; i < TrapContents.Length; i++)
+        {
+            // Replace IDs in each line based on the largest previous ID found
+            // Reserve #1 for the File
+            sb.Append(SanitizeLine(TrapContents[i], largestId - 1));
+            sb.Append(Environment.NewLine);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Sanitize a single line of trap content given the largest previously used id number to ignore,
+    ///     subtracting the offset from those IDs.
+    /// </summary>
+    /// <param name="trapContent">A single line of trap content</param>
+    /// <param name="offset">The offset to apply</param>
+    /// <returns>A sanitized line</returns>
+    private static string SanitizeLine(string trapContent, int offset)
+    {
+        var matches = CaptureId.Matches(trapContent);
+        if (!matches.Any())
+        {
+            return trapContent;
+        }
+        var sb = new StringBuilder();
+        // Tracks how much of the line has been parsed
+        int lastIndex = 0;
+        foreach (Match match in matches)
+        {
+            var capture = match.Groups[1].Captures[0];
+            sb.Append(trapContent[lastIndex..capture.Index]);
+            // Adjust lastIndex to pass over the captured ID's characters in the original string for next iteration
+            lastIndex = capture.Index + capture.Length;
+            int newInt = int.Parse(capture.Value);
+            // We remove all the lines above newlines, but `location`s still reference #1, so we need to reserve ID 1.
+            if (newInt > 1)
+            {
+                sb.Append(newInt - offset);
+            }
+            else
+            {
+                sb.Append(newInt);
+            }
+        }
+        sb.Append(trapContent[lastIndex..]);
+        return sb.ToString();
+    }
+}

--- a/powershell/extractor/Semmle.Util.Tests/ActionMap.cs
+++ b/powershell/extractor/Semmle.Util.Tests/ActionMap.cs
@@ -1,0 +1,53 @@
+using Xunit;
+using Assert = Xunit.Assert;
+using Semmle.Util;
+
+namespace SemmleTests.Semmle.Util
+{
+
+    public class ActionMapTests
+    {
+        [Fact]
+        public void TestAddthenOnAdd()
+        {
+            var am = new ActionMap<int, int>();
+            am.Add(1, 2);
+            int value = 0;
+            am.OnAdd(1, x => value = x);
+            Assert.Equal(2, value);
+        }
+
+        [Fact]
+        public void TestOnAddthenAdd()
+        {
+            var am = new ActionMap<int, int>();
+            int value = 0;
+            am.OnAdd(1, x => value = x);
+            am.Add(1, 2);
+            Assert.Equal(2, value);
+        }
+
+        [Fact]
+        public void TestNotAdded()
+        {
+            var am = new ActionMap<int, int>();
+            int value = 0;
+            am.OnAdd(1, x => value = x);
+            am.Add(2, 2);
+            Assert.Equal(0, value);
+        }
+
+        [Fact]
+        public void TestMultipleActions()
+        {
+            var am = new ActionMap<int, int>();
+            int value1 = 0, value2 = 0;
+            am.OnAdd(1, x => value1 = x);
+            am.OnAdd(1, x => value2 = x);
+            am.Add(1, 2);
+            Assert.Equal(2, value1);
+            Assert.Equal(2, value2);
+        }
+
+    }
+}

--- a/powershell/extractor/Semmle.Util.Tests/CanonicalPathCache.cs
+++ b/powershell/extractor/Semmle.Util.Tests/CanonicalPathCache.cs
@@ -1,0 +1,182 @@
+using Xunit;
+using Semmle.Util;
+using System.IO;
+using Semmle.Util.Logging;
+using System;
+
+namespace SemmleTests.Semmle.Util
+{
+    public sealed class CanonicalPathCacheTest : IDisposable
+    {
+        private readonly ILogger Logger = new LoggerMock();
+        private readonly string root;
+        private CanonicalPathCache cache;
+
+        public CanonicalPathCacheTest()
+        {
+            File.Create("abc").Close();
+            cache = CanonicalPathCache.Create(Logger, 1000, CanonicalPathCache.Symlinks.Follow);
+
+            // Change directories to a directory that is in canonical form.
+            Directory.SetCurrentDirectory(cache.GetCanonicalPath(Path.GetTempPath()));
+
+            root = Win32.IsWindows() ? @"X:\" : "/";
+        }
+
+        public void Dispose()
+        {
+            File.Delete("abc");
+            Logger.Dispose();
+        }
+
+        [Fact]
+        public void CanonicalPathRelativeFile()
+        {
+            var abcPath = Path.GetFullPath("abc");
+
+            Assert.Equal(abcPath, cache.GetCanonicalPath("abc"));
+        }
+
+        [Fact]
+        public void CanonicalPathAbsoluteFile()
+        {
+            var abcPath = Path.GetFullPath("abc");
+
+            Assert.Equal(abcPath, cache.GetCanonicalPath(abcPath));
+        }
+
+        [Fact]
+        public void CanonicalPathDirectory()
+        {
+            var cwd = Directory.GetCurrentDirectory();
+
+            Assert.Equal(cwd, cache.GetCanonicalPath(cwd));
+        }
+
+        [Fact]
+        public void CanonicalPathInvalidRoot()
+        {
+            if (Win32.IsWindows())
+                Assert.Equal(@"X:\", cache.GetCanonicalPath(@"x:\"));
+        }
+
+        [Fact]
+        public void CanonicalPathMissingRoot()
+        {
+            if (Win32.IsWindows())
+                Assert.Equal(@"X:\nosuchfile", cache.GetCanonicalPath(@"X:\nosuchfile"));
+        }
+
+        [Fact]
+        public void CanonicalPathUNCRoot()
+        {
+            CanonicalPathCache cache2 = CanonicalPathCache.Create(Logger, 1000, CanonicalPathCache.Symlinks.Preserve);
+
+            if (Win32.IsWindows())
+            {
+                var windows = cache.GetCanonicalPath(@"\WINDOWS").Replace(":", "$");
+                Assert.Equal($@"\\LOCALHOST\{windows}\bar", cache2.GetCanonicalPath($@"\\localhost\{windows}\bar"));
+            }
+        }
+
+        [Fact]
+        public void CanonicalPathMissingFile()
+        {
+            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), "NOSUCHFILE"), cache.GetCanonicalPath("NOSUCHFILE"));
+        }
+
+        [Fact]
+        public void CanonicalPathMissingAbsolutePath()
+        {
+            Assert.Equal(Path.Combine(root, "no", "such", "file"), cache.GetCanonicalPath(Path.Combine(root, "no", "such", "file")));
+
+            if (Win32.IsWindows())
+                Assert.Equal(@"C:\Windows\no\such\file", cache.GetCanonicalPath(@"C:\windOws\no\such\file"));
+        }
+
+        [Fact]
+        public void CanonicalPathMissingRelativePath()
+        {
+            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), "NO", "SUCH"), cache.GetCanonicalPath(Path.Combine("NO", "SUCH")));
+        }
+
+        [Fact]
+        public void CanonicalPathLowercaseDrive()
+        {
+            if (Win32.IsWindows())
+                Assert.Equal(@"C:\Windows", cache.GetCanonicalPath(@"c:\Windows"));
+        }
+
+        [Fact]
+        public void CanonicalPathCorrectsCase()
+        {
+            if (!Win32.IsWindows())
+                return;
+
+            var abcPath = Path.GetFullPath("abc");
+
+            Assert.Equal(abcPath, cache.GetCanonicalPath("ABC"));
+            Assert.Equal(abcPath, cache.GetCanonicalPath("abc"));
+            Assert.Equal(abcPath, cache.GetCanonicalPath(abcPath.ToUpperInvariant()));
+            Assert.Equal(abcPath, cache.GetCanonicalPath(abcPath.ToLowerInvariant()));
+        }
+
+        [Fact]
+        public void CanonicalPathDots()
+        {
+            var abcPath = Path.GetFullPath("abc");
+            Assert.Equal(abcPath, cache.GetCanonicalPath(Path.Combine("foo", ".", "..", "abc")));
+        }
+
+        [Fact]
+        public void CanonicalPathCacheSize()
+        {
+            cache = CanonicalPathCache.Create(Logger, 2, CanonicalPathCache.Symlinks.Preserve);
+            Assert.Equal(0, cache.CacheSize);
+
+            // The file "ABC" will fill the cache with parent directory info.
+            cache.GetCanonicalPath("ABC");
+            Assert.True(cache.CacheSize == 2);
+
+            string cp = cache.GetCanonicalPath("def");
+            Assert.Equal(2, cache.CacheSize);
+            Assert.Equal(Path.GetFullPath("def"), cp);
+        }
+
+        [Fact]
+        public void CanonicalPathFollowLinksTests()
+        {
+            cache = CanonicalPathCache.Create(Logger, 1000, CanonicalPathCache.Symlinks.Follow);
+            RunAllTests();
+        }
+
+        [Fact]
+        public void CanonicalPathPreserveLinksTests()
+        {
+            cache = CanonicalPathCache.Create(Logger, 1000, CanonicalPathCache.Symlinks.Preserve);
+            RunAllTests();
+        }
+
+        private void RunAllTests()
+        {
+            CanonicalPathRelativeFile();
+            CanonicalPathAbsoluteFile();
+            CanonicalPathDirectory();
+            CanonicalPathInvalidRoot();
+            CanonicalPathMissingRoot();
+            CanonicalPathMissingFile();
+            CanonicalPathMissingAbsolutePath();
+            CanonicalPathMissingRelativePath();
+            CanonicalPathLowercaseDrive();
+            CanonicalPathCorrectsCase();
+            CanonicalPathDots();
+        }
+
+        private sealed class LoggerMock : ILogger
+        {
+            public void Dispose() { }
+
+            public void Log(Severity s, string text) { }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util.Tests/FileUtils.cs
+++ b/powershell/extractor/Semmle.Util.Tests/FileUtils.cs
@@ -1,0 +1,20 @@
+using Xunit;
+using Semmle.Util;
+
+namespace SemmleTests.Semmle.Util
+{
+    public class TestFileUtils
+    {
+        [Fact]
+        public void TestConvertPaths()
+        {
+            Assert.Equal("/tmp/abc.cs", FileUtils.ConvertToUnix(@"\tmp\abc.cs"));
+            Assert.Equal("tmp/abc.cs", FileUtils.ConvertToUnix(@"tmp\abc.cs"));
+
+            Assert.Equal(@"\tmp\abc.cs", FileUtils.ConvertToWindows(@"/tmp/abc.cs"));
+            Assert.Equal(@"tmp\abc.cs", FileUtils.ConvertToWindows(@"tmp/abc.cs"));
+
+            Assert.Equal(Win32.IsWindows() ? @"foo\bar" : "foo/bar", FileUtils.ConvertToNative("foo/bar"));
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util.Tests/LineCounterTest.cs
+++ b/powershell/extractor/Semmle.Util.Tests/LineCounterTest.cs
@@ -1,0 +1,81 @@
+using Xunit;
+
+using Semmle.Util;
+
+namespace SemmleTests
+{
+    public class LineCounterTest
+    {
+        //#################### PRIVATE VARIABLES ####################
+        #region
+
+        #endregion
+
+        //#################### TEST METHODS ####################
+        #region
+
+        [Fact]
+        public void ComputeLineCountsTest1()
+        {
+            var input = "Console.WriteLine();";
+            Assert.Equal(new LineCounts { Total = 1, Code = 1, Comment = 0 }, LineCounter.ComputeLineCounts(input));
+        }
+
+        [Fact]
+        public void ComputeLineCountsTest2()
+        {
+            var input = "Console.WriteLine();   // Wibble";
+            Assert.Equal(new LineCounts { Total = 1, Code = 1, Comment = 1 }, LineCounter.ComputeLineCounts(input));
+        }
+
+        [Fact]
+        public void ComputeLineCountsTest3()
+        {
+            var input = "Console.WriteLine();\n";
+            Assert.Equal(new LineCounts { Total = 2, Code = 1, Comment = 0 }, LineCounter.ComputeLineCounts(input));
+        }
+
+        [Fact]
+        public void ComputeLineCountsTest4()
+        {
+            var input = "\nConsole.WriteLine();";
+            Assert.Equal(new LineCounts { Total = 2, Code = 1, Comment = 0 }, LineCounter.ComputeLineCounts(input));
+        }
+
+        [Fact]
+        public void ComputeLineCountsTest5()
+        {
+            var input = "\nConsole.WriteLine();\nConsole.WriteLine();   // Foo\n";
+            Assert.Equal(new LineCounts { Total = 4, Code = 2, Comment = 1 }, LineCounter.ComputeLineCounts(input));
+        }
+
+        [Fact]
+        public void ComputeLineCountsTest6()
+        {
+            var input =
+@"
+/*
+There once was a counter of lines,
+Which worked (if one trusted the signs) -
+But best to be sure,
+For in old days of yore
+Dodgy coders were sent down the mines.
+*/
+
+using System;   // always useful
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        // Print out something inane.
+        Console.WriteLine(""Something inane!"");
+    }
+}
+";
+            Assert.Equal(new LineCounts { Total = 20, Code = 8, Comment = 9 }, LineCounter.ComputeLineCounts(input));
+        }
+
+        #endregion
+    }
+}

--- a/powershell/extractor/Semmle.Util.Tests/LongPaths.cs
+++ b/powershell/extractor/Semmle.Util.Tests/LongPaths.cs
@@ -1,0 +1,184 @@
+using Xunit;
+using Semmle.Util;
+using System.IO;
+using System.Linq;
+using System;
+
+namespace SemmleTests.Semmle.Util
+{
+    /// <summary>
+    /// Ensure that the Extractor works with long paths.
+    /// These should be handled by .NET Core.
+    /// </summary>
+    public sealed class LongPaths : IDisposable
+    {
+        private static readonly string tmpDir = Path.GetTempPath();
+        private static readonly string shortPath = Path.Combine(tmpDir, "test.txt");
+        private static readonly string longPath = Path.Combine(tmpDir, "aaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "ccccccccccccccccccccccccccccccc", "ddddddddddddddddddddddddddddddddddddd", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "fffffffffffffffffffffffffffffffff",
+            "ggggggggggggggggggggggggggggggggggg", "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh", "iiiiiiiiiiiiiiii.txt");
+
+        public LongPaths()
+        {
+            CleanUp();
+        }
+
+        public void Dispose()
+        {
+            CleanUp();
+        }
+
+        private static void CleanUp()
+        {
+            try
+            {
+                File.Delete(shortPath);
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            try
+            {
+                File.Delete(longPath);
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+        }
+
+        [Fact]
+        public void ParentDirectory()
+        {
+            Assert.Equal("abc", Path.GetDirectoryName(Path.Combine("abc", "def")));
+            Assert.Equal(Win32.IsWindows() ? "\\" : "/", Path.GetDirectoryName($@"{Path.DirectorySeparatorChar}def"));
+            Assert.Equal("", Path.GetDirectoryName(@"def"));
+
+            if (Win32.IsWindows())
+            {
+                Assert.Null(Path.GetDirectoryName(@"C:"));
+                Assert.Null(Path.GetDirectoryName(@"C:\"));
+            }
+        }
+
+        [Fact]
+        public void Delete()
+        {
+            // OK Do not exist.
+            File.Delete(shortPath);
+            File.Delete(longPath);
+        }
+
+        [Fact]
+        public void Move()
+        {
+            File.WriteAllText(shortPath, "abc");
+            Directory.CreateDirectory(Path.GetDirectoryName(longPath)!);
+            File.Delete(longPath);
+            File.Move(shortPath, longPath);
+            File.Move(longPath, shortPath);
+            Assert.Equal("abc", File.ReadAllText(shortPath));
+        }
+
+        [Fact]
+        public void Replace()
+        {
+            File.WriteAllText(shortPath, "abc");
+            File.Delete(longPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(longPath)!);
+            File.Move(shortPath, longPath);
+            File.WriteAllText(shortPath, "def");
+            FileUtils.MoveOrReplace(shortPath, longPath);
+            File.WriteAllText(shortPath, "abc");
+            FileUtils.MoveOrReplace(longPath, shortPath);
+            Assert.Equal("def", File.ReadAllText(shortPath));
+        }
+
+        private readonly byte[] buffer1 = new byte[10] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        [Fact]
+        public void CreateShortStream()
+        {
+            var buffer2 = new byte[10];
+
+            using (var s1 = new FileStream(shortPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                s1.Write(buffer1, 0, 10);
+            }
+
+            using (var s2 = new FileStream(shortPath, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                Assert.Equal(10, s2.Read(buffer2, 0, 10));
+                Assert.True(Enumerable.SequenceEqual(buffer1, buffer2));
+            }
+        }
+
+        [Fact]
+        public void CreateLongStream()
+        {
+            var buffer2 = new byte[10];
+
+            Directory.CreateDirectory(Path.GetDirectoryName(longPath)!);
+
+            using (var s3 = new FileStream(longPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                s3.Write(buffer1, 0, 10);
+            }
+
+            using (var s4 = new FileStream(longPath, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                Assert.Equal(10, s4.Read(buffer2, 0, 10));
+                Assert.True(Enumerable.SequenceEqual(buffer1, buffer2));
+            }
+        }
+
+        [Fact]
+        public void FileDoesNotExist()
+        {
+            // File does not exist
+            Assert.Throws<System.IO.FileNotFoundException>(() =>
+            {
+                using (new FileStream(longPath, FileMode.Open, FileAccess.Read, FileShare.None))
+                {
+                    //
+                }
+            });
+        }
+
+        [Fact]
+        public void OverwriteFile()
+        {
+            using (var s1 = new FileStream(longPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                s1.Write(buffer1, 0, 10);
+            }
+
+            byte[] buffer2 = { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+
+            using (var s2 = new FileStream(longPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                s2.Write(buffer2, 0, 10);
+            }
+
+            byte[] buffer3 = new byte[10];
+
+            using (var s3 = new FileStream(longPath, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                Assert.Equal(10, s3.Read(buffer3, 0, 10));
+            }
+
+            Assert.True(Enumerable.SequenceEqual(buffer2, buffer3));
+        }
+
+        [Fact]
+        public void LongFileExists()
+        {
+            Assert.False(File.Exists("no such file"));
+            Assert.False(File.Exists("\":"));
+            Assert.False(File.Exists(@"C:\"));  // A directory
+
+            Assert.False(File.Exists(longPath));
+            new FileStream(longPath, FileMode.Create, FileAccess.Write, FileShare.None).Close();
+            Assert.True(File.Exists(longPath));
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util.Tests/Properties/AssemblyInfo.cs
+++ b/powershell/extractor/Semmle.Util.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Semmle.Util.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Semmle.Util.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0d16a323-fde2-4231-9c60-4c593e151736")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/powershell/extractor/Semmle.Util.Tests/Semmle.Util.Tests.csproj
+++ b/powershell/extractor/Semmle.Util.Tests/Semmle.Util.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Semmle.Util\Semmle.Util.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/powershell/extractor/Semmle.Util.Tests/TextTest.cs
+++ b/powershell/extractor/Semmle.Util.Tests/TextTest.cs
@@ -1,0 +1,78 @@
+using System;
+using Xunit;
+using Assert = Xunit.Assert;
+
+using Semmle.Util;
+
+namespace SemmleTests
+{
+    public class TextTest
+    {
+        //#################### PRIVATE VARIABLES ####################
+        #region
+
+        /// <summary>
+        /// A shorter way of writing Environment.NewLine (it gets used repeatedly).
+        /// </summary>
+        private static readonly string NL = Environment.NewLine;
+
+        #endregion
+
+        //#################### TEST METHODS ####################
+        #region
+
+        [Fact]
+        public void GetAllTest()
+        {
+            var input = new string[]
+            {
+                "Said once a young coder from Crewe,",
+                "'I like to write tests, so I do!",
+                "They help me confirm",
+                "That I don't need to squirm -",
+                "My code might look nice, but works too!'"
+            };
+
+            var text = new Text(input);
+
+            Assert.Equal(string.Join(NL, input) + NL, text.GetAll());
+        }
+
+        [Fact]
+        public void GetPortionTest()
+        {
+            var input = new string[]
+            {
+                "There once was a jolly young tester",
+                "Who couldn't leave software to fester -",
+                "He'd prod and he'd poke",
+                "Until something bad broke,",
+                "And then he'd find someone to pester."
+            };
+
+            var text = new Text(input);
+
+            // A single-line range (to test the special case).
+            Assert.Equal("jolly" + NL, text.GetPortion(0, 17, 0, 22));
+
+            // A two-line range.
+            Assert.Equal("prod and he'd poke" + NL + "Until" + NL, text.GetPortion(2, 5, 3, 5));
+
+            // A three-line range (to test that the middle line is included in full).
+            Assert.Equal("poke" + NL + "Until something bad broke," + NL + "And then" + NL, text.GetPortion(2, 19, 4, 8));
+
+            // An invalid but recoverable range (to test that a best effort is made rather than crashing).
+            Assert.Equal(NL + "Who couldn't leave software to fester -" + NL, text.GetPortion(0, int.MaxValue, 1, int.MaxValue));
+
+            // Some quite definitely dodgy ranges (to test that exceptions are thrown).
+            Assert.Throws<Exception>(() => text.GetPortion(-1, 0, 0, 0));
+            Assert.Throws<Exception>(() => text.GetPortion(0, -1, 0, 0));
+            Assert.Throws<Exception>(() => text.GetPortion(0, 0, -1, 0));
+            Assert.Throws<Exception>(() => text.GetPortion(0, 0, 0, -1));
+            Assert.Throws<Exception>(() => text.GetPortion(3, 5, 2, 5));
+            Assert.Throws<Exception>(() => text.GetPortion(2, 5, int.MaxValue, 5));
+        }
+
+        #endregion
+    }
+}

--- a/powershell/extractor/Semmle.Util/ActionMap.cs
+++ b/powershell/extractor/Semmle.Util/ActionMap.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// A dictionary which performs an action when items are added to the dictionary.
+    /// The order in which keys and actions are added does not matter.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TValue"></typeparam>
+    public class ActionMap<TKey, TValue> where TKey : notnull
+    {
+        public void Add(TKey key, TValue value)
+        {
+
+            if (actions.TryGetValue(key, out var a))
+                a(value);
+            values[key] = value;
+        }
+
+        public void OnAdd(TKey key, Action<TValue> action)
+        {
+            if (actions.TryGetValue(key, out var a))
+            {
+                actions[key] = a + action;
+            }
+            else
+            {
+                actions.Add(key, action);
+            }
+
+            if (values.TryGetValue(key, out var val))
+            {
+                action(val);
+            }
+        }
+
+        // Action associated with each key.
+        private readonly Dictionary<TKey, Action<TValue>> actions = new Dictionary<TKey, Action<TValue>>();
+
+        // Values associated with each key.
+        private readonly Dictionary<TKey, TValue> values = new Dictionary<TKey, TValue>();
+    }
+}

--- a/powershell/extractor/Semmle.Util/CanonicalPathCache.cs
+++ b/powershell/extractor/Semmle.Util/CanonicalPathCache.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using Semmle.Util.Logging;
+using Mono.Unix;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// Interface for obtaining canonical paths.
+    /// </summary>
+    public interface IPathCache
+    {
+        string GetCanonicalPath(string path);
+    }
+
+    /// <summary>
+    /// Algorithm for determining a canonical path.
+    /// For example some strategies may preserve symlinks
+    /// or only work on certain platforms.
+    /// </summary>
+    public abstract class PathStrategy
+    {
+        /// <summary>
+        /// Obtain a canonical path.
+        /// </summary>
+        /// <param name="path">The path to canonicalise.</param>
+        /// <param name="cache">A cache for making subqueries.</param>
+        /// <returns>The canonical path.</returns>
+        public abstract string GetCanonicalPath(string path, IPathCache cache);
+
+        /// <summary>
+        /// Constructs a canonical path for a file
+        /// which doesn't yet exist.
+        /// </summary>
+        /// <param name="path">Path to canonicalise.</param>
+        /// <param name="cache">The PathCache.</param>
+        /// <returns>A canonical path.</returns>
+        protected static string ConstructCanonicalPath(string path, IPathCache cache)
+        {
+            var parent = Directory.GetParent(path);
+
+            return parent is not null ?
+                Path.Combine(cache.GetCanonicalPath(parent.FullName), Path.GetFileName(path)) :
+                path.ToUpperInvariant();
+        }
+    }
+
+    /// <summary>
+    /// Determine canonical paths using the Win32 function
+    /// GetFinalPathNameByHandle(). Follows symlinks.
+    /// </summary>
+    internal class GetFinalPathNameByHandleStrategy : PathStrategy
+    {
+        /// <summary>
+        /// Call GetFinalPathNameByHandle() to get a canonical filename.
+        /// Follows symlinks.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// GetFinalPathNameByHandle() only works on open file handles,
+        /// so if the path doesn't yet exist, construct the path
+        /// by appending the filename to the canonical parent directory.
+        /// </remarks>
+        ///
+        /// <param name="path">The path to canonicalise.</param>
+        /// <param name="cache">Subquery cache.</param>
+        /// <returns>The canonical path.</returns>
+        public override string GetCanonicalPath(string path, IPathCache cache)
+        {
+            using var hFile = Win32.CreateFile(  // lgtm[cs/call-to-unmanaged-code]
+                path,
+                0,
+                Win32.FILE_SHARE_READ | Win32.FILE_SHARE_WRITE,
+                IntPtr.Zero,
+                Win32.OPEN_EXISTING,
+                Win32.FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+
+            if (hFile.IsInvalid)
+            {
+                // File/directory does not exist.
+                return ConstructCanonicalPath(path, cache);
+            }
+
+            var outPath = new StringBuilder(Win32.MAX_PATH);
+            var length = Win32.GetFinalPathNameByHandle(hFile, outPath, outPath.Capacity, 0);  // lgtm[cs/call-to-unmanaged-code]
+
+            if (length >= outPath.Capacity)
+            {
+                // Path length exceeded MAX_PATH.
+                // Possible if target has a long path.
+                outPath = new StringBuilder(length + 1);
+                length = Win32.GetFinalPathNameByHandle(hFile, outPath, outPath.Capacity, 0);  // lgtm[cs/call-to-unmanaged-code]
+            }
+
+            const int preamble = 4; // outPath always starts \\?\
+
+            if (length <= preamble)
+            {
+                // Failed. GetFinalPathNameByHandle() failed somehow.
+                return ConstructCanonicalPath(path, cache);
+            }
+
+            var result = outPath.ToString(preamble, length - preamble);  // Trim off leading \\?\
+
+            return result.StartsWith("UNC")
+                ? @"\" + result.Substring(3)
+                : result;
+        }
+    }
+
+    /// <summary>
+    /// Determine file case by querying directory contents.
+    /// Preserves symlinks.
+    /// </summary>
+    internal class QueryDirectoryStrategy : PathStrategy
+    {
+        public override string GetCanonicalPath(string path, IPathCache cache)
+        {
+            var parent = Directory.GetParent(path);
+
+            if (parent is null)
+            {
+                // We are at a root of the filesystem.
+                // Convert drive letters, UNC paths etc. to uppercase.
+                // On UNIX, this should be "/" or "".
+                return path.ToUpperInvariant();
+
+            }
+
+            var name = Path.GetFileName(path);
+            var parentPath = cache.GetCanonicalPath(parent.FullName);
+            try
+            {
+                var entries = Directory.GetFileSystemEntries(parentPath, name);
+                return entries.Length == 1
+                    ? entries[0]
+                    : Path.Combine(parentPath, name);
+            }
+            catch  // lgtm[cs/catch-of-all-exceptions]
+            {
+                // IO error or security error querying directory.
+                return Path.Combine(parentPath, name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Uses Mono.Unix.UnixPath to resolve symlinks.
+    /// Not available on Windows.
+    /// </summary>
+    internal class PosixSymlinkStrategy : PathStrategy
+    {
+        public PosixSymlinkStrategy()
+        {
+            GetRealPath(".");   // Test that it works
+        }
+
+        private static string GetRealPath(string path)
+        {
+            path = UnixPath.GetFullPath(path);
+            return UnixPath.GetCompleteRealPath(path);
+        }
+
+        public override string GetCanonicalPath(string path, IPathCache cache)
+        {
+            try
+            {
+                return GetRealPath(path);
+            }
+            catch  // lgtm[cs/catch-of-all-exceptions]
+            {
+                // File does not exist
+                return ConstructCanonicalPath(path, cache);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Class which computes canonical paths.
+    /// Contains a simple thread-safe cache of files and directories.
+    /// </summary>
+    public class CanonicalPathCache : IPathCache
+    {
+        /// <summary>
+        /// The maximum number of items in the cache.
+        /// </summary>
+        private readonly int maxCapacity;
+
+        /// <summary>
+        /// How to handle symlinks.
+        /// </summary>
+        public enum Symlinks
+        {
+            Follow,
+            Preserve
+        }
+
+        /// <summary>
+        /// Algorithm for computing the canonical path.
+        /// </summary>
+        private readonly PathStrategy pathStrategy;
+
+        /// <summary>
+        /// Create cache with a given capacity.
+        /// </summary>
+        /// <param name="pathStrategy">The algorithm for determining the canonical path.</param>
+        /// <param name="capacity">The size of the cache.</param>
+        public CanonicalPathCache(int maxCapacity, PathStrategy pathStrategy)
+        {
+            if (maxCapacity <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxCapacity), maxCapacity, "Invalid cache size specified");
+
+            this.maxCapacity = maxCapacity;
+            this.pathStrategy = pathStrategy;
+        }
+
+
+        /// <summary>
+        /// Create a CanonicalPathCache.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// Creates the appropriate PathStrategy object which encapsulates
+        /// the correct algorithm. Falls back to different implementations
+        /// depending on platform.
+        /// </remarks>
+        ///
+        /// <param name="maxCapacity">Size of the cache.</param>
+        /// <param name="symlinks">Policy for following symlinks.</param>
+        /// <returns>A new CanonicalPathCache.</returns>
+        public static CanonicalPathCache Create(ILogger logger, int maxCapacity)
+        {
+            var preserveSymlinks =
+                Environment.GetEnvironmentVariable("CODEQL_PRESERVE_SYMLINKS") == "true" ||
+                Environment.GetEnvironmentVariable("SEMMLE_PRESERVE_SYMLINKS") == "true";
+            return Create(logger, maxCapacity, preserveSymlinks ? CanonicalPathCache.Symlinks.Preserve : CanonicalPathCache.Symlinks.Follow);
+
+        }
+
+        /// <summary>
+        /// Create a CanonicalPathCache.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// Creates the appropriate PathStrategy object which encapsulates
+        /// the correct algorithm. Falls back to different implementations
+        /// depending on platform.
+        /// </remarks>
+        ///
+        /// <param name="maxCapacity">Size of the cache.</param>
+        /// <param name="symlinks">Policy for following symlinks.</param>
+        /// <returns>A new CanonicalPathCache.</returns>
+        public static CanonicalPathCache Create(ILogger logger, int maxCapacity, Symlinks symlinks)
+        {
+            PathStrategy pathStrategy;
+
+            switch (symlinks)
+            {
+                case Symlinks.Follow:
+                    try
+                    {
+                        pathStrategy = Win32.IsWindows() ?
+                            (PathStrategy)new GetFinalPathNameByHandleStrategy() :
+                            (PathStrategy)new PosixSymlinkStrategy();
+                    }
+                    catch  // lgtm[cs/catch-of-all-exceptions]
+                    {
+                        // Failed to late-bind a suitable library.
+                        logger.Log(Severity.Warning, "Preserving symlinks in canonical paths");
+                        pathStrategy = new QueryDirectoryStrategy();
+                    }
+                    break;
+                case Symlinks.Preserve:
+                    pathStrategy = new QueryDirectoryStrategy();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(symlinks), symlinks, "Invalid symlinks option");
+            }
+
+            return new CanonicalPathCache(maxCapacity, pathStrategy);
+        }
+
+        /// <summary>
+        /// Map of path to canonical path.
+        /// </summary>
+        private readonly IDictionary<string, string> cache = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Used to evict random cache items when the cache is full.
+        /// </summary>
+        private readonly Random random = new Random();
+
+        /// <summary>
+        /// The current number of items in the cache.
+        /// </summary>
+        public int CacheSize
+        {
+            get
+            {
+                lock (cache)
+                    return cache.Count;
+            }
+        }
+
+        /// <summary>
+        /// Adds a path to the cache.
+        /// Removes items from cache as needed.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <param name="canonical">The canonical form of path.</param>
+        private void AddToCache(string path, string canonical)
+        {
+            if (cache.Count >= maxCapacity)
+            {
+                /* A simple strategy for limiting the cache size, given that
+                 * C# doesn't have a convenient dictionary+list data structure.
+                 */
+                cache.Remove(cache.ElementAt(random.Next(maxCapacity)));
+            }
+            cache[path] = canonical;
+        }
+
+        /// <summary>
+        /// Retrieve the canonical path for a given path.
+        /// Caches the result.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <returns>The canonical path.</returns>
+        public string GetCanonicalPath(string path)
+        {
+            lock (cache)
+            {
+                if (!cache.TryGetValue(path, out var canonicalPath))
+                {
+                    canonicalPath = pathStrategy.GetCanonicalPath(path, this);
+                    AddToCache(path, canonicalPath);
+                }
+                return canonicalPath;
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/CommandLineExtensions.cs
+++ b/powershell/extractor/Semmle.Util/CommandLineExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Util
+{
+    public static class CommandLineExtensions
+    {
+        /// <summary>
+        /// Archives the first "@" argument in a list of command line arguments.
+        /// Subsequent "@" arguments are ignored.
+        /// </summary>
+        /// <param name="commandLineArguments">The raw command line arguments.</param>
+        /// <param name="textWriter">The writer to archive to.</param>
+        /// <returns>True iff the file was written.</returns>
+        public static bool WriteCommandLine(this IEnumerable<string> commandLineArguments, TextWriter textWriter)
+        {
+            var found = false;
+            foreach (var arg in commandLineArguments.Where(arg => arg.StartsWith('@')).Select(arg => arg.Substring(1)))
+            {
+                string? line;
+                using var file = new StreamReader(arg);
+                while ((line = file.ReadLine()) is not null)
+                    textWriter.WriteLine(line);
+                found = true;
+            }
+            return found;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/CommandLineOptions.cs
+++ b/powershell/extractor/Semmle.Util/CommandLineOptions.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// Represents a parsed set of command line options.
+    /// </summary>
+    public interface ICommandLineOptions
+    {
+        /// <summary>
+        /// Handle an option of the form "--threads 5" or "--threads:5"
+        /// </summary>
+        /// <param name="key">The name of the key. This is case sensitive.</param>
+        /// <param name="value">The supplied value.</param>
+        /// <returns>True if the option was handled, or false otherwise.</returns>
+        bool HandleOption(string key, string value);
+
+        /// <summary>
+        /// Handle a flag of the form "--cil" or "--nocil"
+        /// </summary>
+        /// <param name="key">The name of the flag. This is case sensitive.</param>
+        /// <param name="value">True if set, or false if prefixed by "--no"</param>
+        /// <returns>True if the flag was handled, or false otherwise.</returns>
+        bool HandleFlag(string key, bool value);
+
+        /// <summary>
+        /// Handle an argument, not prefixed by "--".
+        /// </summary>
+        /// <param name="argument">The command line argument.</param>
+        /// <returns>True if the argument was handled, or false otherwise.</returns>
+        bool HandleArgument(string argument);
+
+        /// <summary>
+        /// Process an unhandled option, or an unhandled argument.
+        /// </summary>
+        /// <param name="argument">The argument.</param>
+        void InvalidArgument(string argument);
+    }
+
+    public static class OptionsExtensions
+    {
+        public static void ParseArguments(this ICommandLineOptions options, IReadOnlyList<string> arguments)
+        {
+            for (var i = 0; i < arguments.Count; ++i)
+            {
+                var arg = arguments[i];
+                if (arg.StartsWith("--"))
+                {
+                    var colon = arg.IndexOf(':');
+                    if (colon > 0 && options.HandleOption(arg.Substring(2, colon - 2), arg.Substring(colon + 1)))
+                    { }
+                    else if (arg.StartsWith("--no") && options.HandleFlag(arg.Substring(4), false))
+                    { }
+                    else if (options.HandleFlag(arg.Substring(2), true))
+                    { }
+                    else if (i + 1 < arguments.Count && options.HandleOption(arg.Substring(2), arguments[i + 1]))
+                    {
+                        ++i;
+                    }
+                    else
+                    {
+                        options.InvalidArgument(arg);
+                    }
+                }
+                else
+                {
+                    if (!options.HandleArgument(arg))
+                    {
+                        options.InvalidArgument(arg);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/DictionaryExtensions.cs
+++ b/powershell/extractor/Semmle.Util/DictionaryExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Semmle.Util
+{
+    public static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Adds another element to the list for the given key in this
+        /// dictionary. If a list does not already exist, a new list is
+        /// created.
+        /// </summary>
+        public static void AddAnother<T1, T2>(this Dictionary<T1, List<T2>> dict, T1 key, T2 element) where T1 : notnull
+        {
+            if (!dict.TryGetValue(key, out var list))
+            {
+                list = new List<T2>();
+                dict[key] = list;
+            }
+            list.Add(element);
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/Enumerators.cs
+++ b/powershell/extractor/Semmle.Util/Enumerators.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Semmle.Util
+{
+    public static class Enumerators
+    {
+        /// <summary>
+        /// Create an enumerable with a single element.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The type of the enumerble/element.</typeparam>
+        /// <param name="t">The element.</param>
+        /// <returns>An enumerable containing a single element.</returns>
+        public static IEnumerable<T> Singleton<T>(T t)
+        {
+            yield return t;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/FileRenamer.cs
+++ b/powershell/extractor/Semmle.Util/FileRenamer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// Utility to temporarily rename a set of files.
+    /// </summary>
+    public sealed class FileRenamer : IDisposable
+    {
+        private readonly string[] files;
+        private const string suffix = ".codeqlhidden";
+
+        public FileRenamer(IEnumerable<FileInfo> oldFiles)
+        {
+            files = oldFiles.Select(f => f.FullName).ToArray();
+
+            foreach (var file in files)
+            {
+                File.Move(file, file + suffix);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var file in files)
+            {
+                File.Move(file + suffix, file);
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/FileUtils.cs
+++ b/powershell/extractor/Semmle.Util/FileUtils.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Semmle.Util
+{
+    public static class FileUtils
+    {
+        public static string ConvertToWindows(string path)
+        {
+            return path.Replace('/', '\\');
+        }
+
+        public static string ConvertToUnix(string path)
+        {
+            return path.Replace('\\', '/');
+        }
+
+        public static string ConvertToNative(string path)
+        {
+            return Path.DirectorySeparatorChar == '/' ?
+                path.Replace('\\', '/') :
+                path.Replace('/', '\\');
+        }
+
+        /// <summary>
+        /// Moves the source file to the destination, overwriting the destination file if
+        /// it exists already.
+        /// </summary>
+        /// <param name="src">Source file.</param>
+        /// <param name="dest">Target file.</param>
+        public static void MoveOrReplace(string src, string dest)
+        {
+            File.Move(src, dest, overwrite: true);
+        }
+
+        /// <summary>
+        /// Attempt to delete the given file (ignoring I/O exceptions).
+        /// </summary>
+        /// <param name="file">The file to delete.</param>
+        public static void TryDelete(string file)
+        {
+            try
+            {
+                File.Delete(file);
+            }
+            catch (IOException)
+            {
+                // Ignore
+            }
+        }
+
+        /// <summary>
+        /// Finds the path for the program <paramref name="prog"/> based on the
+        /// <code>PATH</code> environment variable, and in the case of Windows the
+        /// <code>PATHEXT</code> environment variable.
+        ///
+        /// Returns <code>null</code> of no path can be found.
+        /// </summary>
+        public static string? FindProgramOnPath(string prog)
+        {
+            var paths = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator);
+            string[] exes;
+            if (Win32.IsWindows())
+            {
+                var extensions = Environment.GetEnvironmentVariable("PATHEXT")?.Split(';')?.ToArray();
+                exes = extensions is null || extensions.Any(prog.EndsWith)
+                    ? new[] { prog }
+                    : extensions.Select(ext => prog + ext).ToArray();
+            }
+            else
+            {
+                exes = new[] { prog };
+            }
+            var candidates = paths?.Where(path => exes.Any(exe0 => File.Exists(Path.Combine(path, exe0))));
+            return candidates?.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Computes the hash of <paramref name="filePath"/>.
+        /// </summary>
+        public static string ComputeFileHash(string filePath)
+        {
+            using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var shaAlg = new SHA256Managed();
+            var sha = shaAlg.ComputeHash(fileStream);
+            var hex = new StringBuilder(sha.Length * 2);
+            foreach (var b in sha)
+                hex.AppendFormat("{0:x2}", b);
+            return hex.ToString();
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/FuzzyDictionary.cs
+++ b/powershell/extractor/Semmle.Util/FuzzyDictionary.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// A dictionary from strings to elements of type T.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// This data structure is able to locate items based on an "approximate match"
+    /// of the key. This is used for example when attempting to identify two terms
+    /// in different trap files which are similar but not identical.
+    ///
+    /// The algorithm locates the closest match to a string based on a "distance function".
+    ///
+    /// Whilst many distance functions are possible, a bespoke algorithm is used here,
+    /// for efficiency and suitablility for the domain.
+    ///
+    /// The distance is defined as the Hamming Distance of the numbers in the string.
+    /// Each string is split into the base "form" (stripped of numbers) and a vector of
+    /// numbers. (Numbers are non-negative integers in this context).
+    ///
+    /// Strings with a different "form" are considered different and have a distance
+    /// of infinity.
+    ///
+    /// This distance function is reflexive, symmetric and obeys the triangle inequality.
+    ///
+    /// E.g. foo(bar,1,2) has form "foo(bar,,)" and integers {1,2}
+    ///
+    /// distance(foo(bar,1,2), foo(bar,1,2)) = 0
+    /// distance(foo(bar,1,2), foo(bar,1,3)) = 1
+    /// distance(foo(bar,2,1), foo(bar,1,2)) = 2
+    /// distance(foo(bar,1,2), foo(baz,1,2)) = infinity
+    /// </remarks>
+    ///
+    /// <typeparam name="T">The value type.</typeparam>
+    public class FuzzyDictionary<T> where T : class
+    {
+        // All data items indexed by the "base string" (stripped of numbers)
+        private readonly Dictionary<string, List<KeyValuePair<string, T>>> index = new Dictionary<string, List<KeyValuePair<string, T>>>();
+
+        /// <summary>
+        /// Stores a new KeyValuePair in the data structure.
+        /// </summary>
+        /// <param name="k">The key.</param>
+        /// <param name="v">The value.</param>
+        public void Add(string k, T v)
+        {
+            var kv = new KeyValuePair<string, T>(k, v);
+
+            var root = StripDigits(k);
+            index.AddAnother(root, kv);
+        }
+
+        /// <summary>
+        /// Computes the Hamming Distance between two sequences of the same length.
+        /// </summary>
+        /// <param name="v1">Vector 1</param>
+        /// <param name="v2">Vector 2</param>
+        /// <returns>The Hamming Distance.</returns>
+        private static int HammingDistance<TElement>(IEnumerable<TElement> v1, IEnumerable<TElement> v2) where TElement : notnull
+        {
+            return v1.Zip(v2, (x, y) => x.Equals(y) ? 0 : 1).Sum();
+        }
+
+        /// <summary>
+        /// Locates the value with the smallest Hamming Distance from the query.
+        /// </summary>
+        /// <param name="query">The query string.</param>
+        /// <param name="distance">The distance between the query string and the stored string.</param>
+        /// <returns>The best match, or null (default).</returns>
+        public T? FindMatch(string query, out int distance)
+        {
+            var root = StripDigits(query);
+            if (!index.TryGetValue(root, out var list))
+            {
+                distance = 0;
+                return default(T);
+            }
+
+            return BestMatch(query, list, (a, b) => HammingDistance(ExtractIntegers(a), ExtractIntegers(b)), out distance);
+        }
+
+        /// <summary>
+        /// Returns the best match (with the smallest distance) for a query.
+        /// </summary>
+        /// <param name="query">The query string.</param>
+        /// <param name="candidates">The list of candidate matches.</param>
+        /// <param name="distance">The distance function.</param>
+        /// <param name="bestDistance">The distance between the query and the stored string.</param>
+        /// <returns>The stored value.</returns>
+        private static T? BestMatch(string query, IEnumerable<KeyValuePair<string, T>> candidates, Func<string, string, int> distance, out int bestDistance)
+        {
+            var bestMatch = default(T);
+            bestDistance = 0;
+            var first = true;
+
+            foreach (var candidate in candidates)
+            {
+                var d = distance(query, candidate.Key);
+                if (d == 0)
+                    return candidate.Value;
+
+                if (first || d < bestDistance)
+                {
+                    bestDistance = d;
+                    bestMatch = candidate.Value;
+                    first = false;
+                }
+            }
+
+            return bestMatch;
+        }
+
+        /// <summary>
+        /// Removes all digits from a string.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <returns>String with digits removed.</returns>
+        private static string StripDigits(string input)
+        {
+            var result = new StringBuilder();
+            foreach (var c in input.Where(c => !char.IsDigit(c)))
+                result.Append(c);
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Extracts and enumerates all non-negative integers in a string.
+        /// </summary>
+        /// <param name="input">The string to enumerate.</param>
+        /// <returns>The sequence of integers.</returns>
+        private static IEnumerable<int> ExtractIntegers(string input)
+        {
+            var inNumber = false;
+            var value = 0;
+            foreach (var c in input)
+            {
+                if (char.IsDigit(c))
+                {
+                    if (inNumber)
+                    {
+                        value = value * 10 + (c - '0');
+                    }
+                    else
+                    {
+                        inNumber = true;
+                        value = c - '0';
+                    }
+                }
+                else
+                {
+                    if (inNumber)
+                    {
+                        yield return value;
+                        inNumber = false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/IEnumerableExtensions.cs
+++ b/powershell/extractor/Semmle.Util/IEnumerableExtensions.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Semmle.Util
+{
+    public static class IEnumerableExtensions
+    {
+        /// <summary>
+        /// Find the first element in the sequence, or null if the sequence is empty.
+        /// </summary>
+        /// <typeparam name="T">The type of the sequence.</typeparam>
+        /// <param name="list">The list of items.</param>
+        /// <returns>The first item, or null if the sequence is empty.</returns>
+        public static T? FirstOrNull<T>(this IEnumerable<T> list) where T : struct
+        {
+            return list.Any() ? (T?)list.First() : null;
+        }
+
+        /// <summary>
+        /// Finds the last element a sequence, or null if the sequence is empty.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
+        /// <param name="list">The list of items.</param>
+        /// <returns>The last item, or null if the sequence is empty.</returns>
+        public static T? LastOrNull<T>(this IEnumerable<T> list) where T : struct
+        {
+            return list.Any() ? (T?)list.Last() : null;
+        }
+
+        /// <summary>
+        /// Interleaves the elements from the two sequences.
+        /// </summary>
+        public static IEnumerable<T> Interleave<T>(this IEnumerable<T> first, IEnumerable<T> second)
+        {
+            using var enumerator1 = first.GetEnumerator();
+            using var enumerator2 = second.GetEnumerator();
+            bool moveNext1;
+            while ((moveNext1 = enumerator1.MoveNext()) && enumerator2.MoveNext())
+            {
+                yield return enumerator1.Current;
+                yield return enumerator2.Current;
+            }
+
+            if (moveNext1)
+            {
+                // `first` has more elements than `second`
+                yield return enumerator1.Current;
+                while (enumerator1.MoveNext())
+                {
+                    yield return enumerator1.Current;
+                }
+            }
+
+            while (enumerator2.MoveNext())
+            {
+                // `second` has more elements than `first`
+                yield return enumerator2.Current;
+            }
+        }
+
+        /// <summary>
+        /// Enumerates a possibly null enumerable.
+        /// If the enumerable is null, the list is empty.
+        /// </summary>
+        public static IEnumerable<T> EnumerateNull<T>(this IEnumerable<T>? items)
+        {
+            if (items is null)
+                yield break;
+            foreach (var item in items) yield return item;
+        }
+
+        /// <summary>
+        /// Applies the action <paramref name="a"/> to each item in this collection.
+        /// </summary>
+        public static void ForEach<T>(this IEnumerable<T> items, Action<T> a)
+        {
+            foreach (var item in items)
+                a(item);
+        }
+
+        /// <summary>
+        /// Forces enumeration of this collection and discards the result.
+        /// </summary>
+        public static void Enumerate<T>(this IEnumerable<T> items)
+        {
+            items.ForEach(_ => { });
+        }
+
+        /// <summary>
+        /// Computes a hash of a sequence.
+        /// </summary>
+        /// <typeparam name="T">The type of the item.</typeparam>
+        /// <param name="items">The list of items to hash.</param>
+        /// <returns>The hash code.</returns>
+        public static int SequenceHash<T>(this IEnumerable<T> items) where T : notnull
+        {
+            var h = 0;
+            foreach (var i in items)
+                h = h * 7 + i.GetHashCode();
+            return h;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/LineCounter.cs
+++ b/powershell/extractor/Semmle.Util/LineCounter.cs
@@ -1,0 +1,281 @@
+using System;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// An instance of this class is used to store the computed line count metrics (of
+    /// various different types) for a piece of text.
+    /// </summary>
+    public sealed class LineCounts
+    {
+        //#################### PROPERTIES ####################
+        #region
+
+        /// <summary>
+        /// The number of lines in the text that contain code.
+        /// </summary>
+        public int Code { get; set; }
+
+        /// <summary>
+        /// The number of lines in the text that contain comments.
+        /// </summary>
+        public int Comment { get; set; }
+
+        /// <summary>
+        /// The total number of lines in the text.
+        /// </summary>
+        public int Total { get; set; }
+
+        #endregion
+
+        //#################### PUBLIC METHODS ####################
+        #region
+
+        public override bool Equals(object? other)
+        {
+            return other is LineCounts rhs &&
+                Total == rhs.Total &&
+                Code == rhs.Code &&
+                Comment == rhs.Comment;
+        }
+
+        public override int GetHashCode()
+        {
+            return Total ^ Code ^ Comment;
+        }
+
+        public override string ToString()
+        {
+            return "Total: " + Total + " Code: " + Code + " Comment: " + Comment;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// This class can be used to compute line count metrics of various different types
+    /// (code, comment and total) for a piece of text.
+    /// </summary>
+    public static class LineCounter
+    {
+        //#################### NESTED CLASSES ####################
+        #region
+
+        /// <summary>
+        /// An instance of this class keeps track of the contextual information required during line counting.
+        /// </summary>
+        private class Context
+        {
+            /// <summary>
+            /// The index of the current character under consideration.
+            /// </summary>
+            public int CurIndex { get; set; }
+
+            /// <summary>
+            /// Whether or not the current line under consideration contains any code.
+            /// </summary>
+            public bool HasCode { get; set; }
+
+            /// <summary>
+            /// Whether or not the current line under consideration contains a comment.
+            /// </summary>
+            public bool HasComment { get; set; }
+        }
+
+        #endregion
+
+        //#################### PUBLIC METHODS ####################
+        #region
+
+        /// <summary>
+        /// Computes line count metrics for the specified input text.
+        /// </summary>
+        /// <param name="input">The input text for which to compute line count metrics.</param>
+        /// <returns>The computed metrics.</returns>
+        public static LineCounts ComputeLineCounts(string input)
+        {
+            var counts = new LineCounts();
+            var context = new Context();
+
+            char? cur, prev = null;
+            while ((cur = GetNext(input, context)) is not null)
+            {
+                if (IsNewLine(cur))
+                {
+                    RegisterNewLine(counts, context);
+                    cur = null;
+                }
+                else if (cur == '*' && prev == '/')
+                {
+                    ReadMultiLineComment(input, counts, context);
+                    cur = null;
+                }
+                else if (cur == '/' && prev == '/')
+                {
+                    ReadEOLComment(input, context);
+                    context.HasComment = true;
+                    cur = null;
+                }
+                else if (cur == '"')
+                {
+                    ReadRestOfString(input, context);
+                    context.HasCode = true;
+                    cur = null;
+                }
+                else if (cur == '\'')
+                {
+                    ReadRestOfChar(input, context);
+                    context.HasCode = true;
+                    cur = null;
+                }
+                else if (!IsWhitespace(cur) && cur != '/')  // exclude '/' to avoid counting comments as code
+                {
+                    context.HasCode = true;
+                }
+                prev = cur;
+            }
+
+            // The final line of text should always be counted, even if it's empty.
+            RegisterNewLine(counts, context);
+
+            return counts;
+        }
+
+        #endregion
+
+        //#################### PRIVATE METHODS ####################
+        #region
+
+        /// <summary>
+        /// Gets the next character to be considered from the input text and updates the current character index accordingly.
+        /// </summary>
+        /// <param name="input">The input text for which we are computing line count metrics.</param>
+        /// <param name="context">The contextual information required during line counting.</param>
+        /// <returns></returns>
+        private static char? GetNext(string input, Context context)
+        {
+            return input is null || context.CurIndex >= input.Length ?
+                (char?)null :
+                input[context.CurIndex++];
+        }
+
+        /// <summary>
+        /// Determines whether or not the specified character equals '\n'.
+        /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <returns>true, if the specified character equals '\n', or false otherwise.</returns>
+        private static bool IsNewLine(char? c)
+        {
+            return c == '\n';
+        }
+
+        /// <summary>
+        /// Determines whether or not the specified character should be considered to be whitespace.
+        /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <returns>true, if the specified character should be considered to be whitespace, or false otherwise.</returns>
+        private static bool IsWhitespace(char? c)
+        {
+            return c == ' ' || c == '\t' || c == '\r';
+        }
+
+        /// <summary>
+        /// Consumes the input text up to the end of the current line (not including any '\n').
+        /// This is used to consume an end-of-line comment (i.e. a //-style comment).
+        /// </summary>
+        /// <param name="input">The input text.</param>
+        /// <param name="context">The contextual information required during line counting.</param>
+        private static void ReadEOLComment(string input, Context context)
+        {
+            char? c;
+            do
+            {
+                c = GetNext(input, context);
+            } while (c is not null && !IsNewLine(c));
+
+            // If we reached the end of a line (as opposed to reaching the end of the text),
+            // put the '\n' back so that it can be handled by the normal newline processing
+            // code.
+            if (IsNewLine(c))
+                --context.CurIndex;
+        }
+
+        /// <summary>
+        /// Consumes the input text up to the end of a multi-line comment.
+        /// </summary>
+        /// <param name="input">The input text.</param>
+        /// <param name="counts">The line count metrics for the input text.</param>
+        /// <param name="context">The contextual information required during line counting.</param>
+        private static void ReadMultiLineComment(string input, LineCounts counts, Context context)
+        {
+            char? cur = '\0', prev = null;
+            context.HasComment = true;
+            while (cur is not null && ((cur = GetNext(input, context)) != '/' || prev != '*'))
+            {
+                if (IsNewLine(cur))
+                {
+                    RegisterNewLine(counts, context);
+                    context.HasComment = true;
+                }
+                prev = cur;
+            }
+        }
+
+        /// <summary>
+        /// Consumes the input text up to the end of a character literal, e.g. '\t'.
+        /// </summary>
+        /// <param name="input">The input text.</param>
+        /// <param name="context">The contextual information required during line counting.</param>
+        private static void ReadRestOfChar(string input, Context context)
+        {
+            if (GetNext(input, context) == '\\')
+            {
+                GetNext(input, context);
+            }
+            GetNext(input, context);
+        }
+
+        /// <summary>
+        /// Consumes the input text up to the end of a string literal, e.g. "Wibble".
+        /// </summary>
+        /// <param name="input">The input text.</param>
+        /// <param name="context">The contextual information required during line counting.</param>
+        private static void ReadRestOfString(string input, Context context)
+        {
+            char? cur = '\0';
+            var numSlashes = 0;
+            while (cur is not null && ((cur = GetNext(input, context)) != '"' || (numSlashes % 2 != 0)))
+            {
+                if (cur == '\\')
+                    ++numSlashes;
+                else
+                    numSlashes = 0;
+            }
+        }
+
+        /// <summary>
+        /// Updates the line count metrics when a newline character is seen, and resets
+        /// the code and comment flags in the context ready to process the next line.
+        /// </summary>
+        /// <param name="counts">The line count metrics for the input text.</param>
+        /// <param name="context">The contextual information required during line counting.</param>
+        private static void RegisterNewLine(LineCounts counts, Context context)
+        {
+            ++counts.Total;
+
+            if (context.HasCode)
+            {
+                ++counts.Code;
+                context.HasCode = false;
+            }
+
+            if (context.HasComment)
+            {
+                ++counts.Comment;
+                context.HasComment = false;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/powershell/extractor/Semmle.Util/Logger.cs
+++ b/powershell/extractor/Semmle.Util/Logger.cs
@@ -1,0 +1,195 @@
+using System;
+using System.IO;
+
+namespace Semmle.Util.Logging
+{
+    /// <summary>
+    /// The severity of a log message.
+    /// </summary>
+    public enum Severity
+    {
+        Trace = 1,
+        Debug = 2,
+        Info = 3,
+        Warning = 4,
+        Error = 5
+    }
+
+    /// <summary>
+    /// Log verbosity level.
+    /// </summary>
+    public enum Verbosity
+    {
+        Off = 0,
+        Error = 1,
+        Warning = 2,
+        Info = 3,
+        Debug = 4,
+        Trace = 5,
+        All = 6
+    }
+
+    /// <summary>
+    /// A logger.
+    /// </summary>
+    public interface ILogger : IDisposable
+    {
+        /// <summary>
+        /// Log the given text with the given severity.
+        /// </summary>
+        void Log(Severity s, string text);
+    }
+
+    public static class LoggerExtensions
+    {
+        /// <summary>
+        /// Log the given text with the given severity.
+        /// </summary>
+        public static void Log(this ILogger logger, Severity s, string text, params object?[] args)
+        {
+            logger.Log(s, string.Format(text, args));
+        }
+    }
+
+    /// <summary>
+    /// A logger that outputs to a <code>csharp.log</code>
+    /// file.
+    /// </summary>
+    public sealed class FileLogger : ILogger
+    {
+        private readonly StreamWriter writer;
+        private readonly Verbosity verbosity;
+
+        public FileLogger(Verbosity verbosity, string outputFile)
+        {
+            this.verbosity = verbosity;
+
+            try
+            {
+                var dir = Path.GetDirectoryName(outputFile);
+                if (!string.IsNullOrEmpty(dir) && !System.IO.Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+                writer = new PidStreamWriter(
+                    new FileStream(outputFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite, 8192));
+            }
+            catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                Console.Error.WriteLine("SEMMLE: Couldn't initialise C# extractor output: " + ex.Message + "\n" + ex.StackTrace);
+                Console.Error.Flush();
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            writer.Dispose();
+        }
+
+        private static string GetSeverityPrefix(Severity s)
+        {
+            return "[" + s.ToString().ToUpper() + "] ";
+        }
+
+        public void Log(Severity s, string text)
+        {
+            if (verbosity.Includes(s))
+                writer.WriteLine(GetSeverityPrefix(s) + text);
+        }
+    }
+
+    /// <summary>
+    /// A logger that outputs to stdout/stderr.
+    /// </summary>
+    public sealed class ConsoleLogger : ILogger
+    {
+        private readonly Verbosity verbosity;
+
+        public ConsoleLogger(Verbosity verbosity)
+        {
+            this.verbosity = verbosity;
+        }
+
+        public void Dispose() { }
+
+        private static TextWriter GetConsole(Severity s)
+        {
+            return s == Severity.Error ? Console.Error : Console.Out;
+        }
+
+        private static string GetSeverityPrefix(Severity s)
+        {
+            switch (s)
+            {
+                case Severity.Trace:
+                case Severity.Debug:
+                case Severity.Info:
+                    return "";
+                case Severity.Warning:
+                    return "Warning: ";
+                case Severity.Error:
+                    return "Error: ";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(s));
+            }
+        }
+
+        public void Log(Severity s, string text)
+        {
+            if (verbosity.Includes(s))
+                GetConsole(s).WriteLine(GetSeverityPrefix(s) + text);
+        }
+    }
+
+    /// <summary>
+    /// A combined logger.
+    /// </summary>
+    public sealed class CombinedLogger : ILogger
+    {
+        private readonly ILogger logger1;
+        private readonly ILogger logger2;
+
+        public CombinedLogger(ILogger logger1, ILogger logger2)
+        {
+            this.logger1 = logger1;
+            this.logger2 = logger2;
+        }
+
+        public void Dispose()
+        {
+            logger1.Dispose();
+            logger2.Dispose();
+        }
+
+        public void Log(Severity s, string text)
+        {
+            logger1.Log(s, text);
+            logger2.Log(s, text);
+        }
+    }
+
+    internal static class VerbosityExtensions
+    {
+        /// <summary>
+        /// Whether a message with the given severity must be included
+        /// for this verbosity level.
+        /// </summary>
+        public static bool Includes(this Verbosity v, Severity s)
+        {
+            switch (s)
+            {
+                case Severity.Trace:
+                    return v >= Verbosity.Trace;
+                case Severity.Debug:
+                    return v >= Verbosity.Debug;
+                case Severity.Info:
+                    return v >= Verbosity.Info;
+                case Severity.Warning:
+                    return v >= Verbosity.Warning;
+                case Severity.Error:
+                    return v >= Verbosity.Error;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(s));
+            }
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/LoggerUtils.cs
+++ b/powershell/extractor/Semmle.Util/LoggerUtils.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Diagnostics;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// Utility stream writer that prefixes the current PID to some writes.
+    /// Useful to disambiguate logs belonging to different extractor processes
+    /// that end up in the same place (csharp.log). Does a best-effort attempt
+    /// (i.e. only overrides one of the overloaded methods, calling the others
+    /// may print without a prefix).
+    /// </summary>
+    public sealed class PidStreamWriter : StreamWriter
+    {
+        /// <summary>
+        /// Constructs with output stream.
+        /// </summary>
+        /// <param name="stream">The stream to write to.</param>
+        public PidStreamWriter(Stream stream) : base(stream) { }
+
+        private readonly string prefix = "[" + Process.GetCurrentProcess().Id + "] ";
+
+        public override void WriteLine(string? value)
+        {
+            lock (mutex)
+            {
+                base.WriteLine(prefix + value);
+            }
+        }
+
+        public override void WriteLine(string? format, params object?[] args)
+        {
+            WriteLine(format is null ? format : string.Format(format, args));
+        }
+
+        private readonly object mutex = new object();
+    }
+}

--- a/powershell/extractor/Semmle.Util/ProcessStartInfoExtensions.cs
+++ b/powershell/extractor/Semmle.Util/ProcessStartInfoExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Semmle.Util
+{
+    public static class ProcessStartInfoExtensions
+    {
+        /// <summary>
+        /// Runs this process, and returns the exit code, as well as the contents
+        /// of stdout in <paramref name="stdout"/>.
+        /// </summary>
+        public static int ReadOutput(this ProcessStartInfo pi, out IList<string> stdout)
+        {
+            stdout = new List<string>();
+            using var process = Process.Start(pi);
+
+            if (process is null)
+            {
+                return -1;
+            }
+
+            string? s;
+            do
+            {
+                s = process.StandardOutput.ReadLine();
+                if (s is not null)
+                    stdout.Add(s);
+            }
+            while (s is not null);
+            process.WaitForExit();
+            return process.ExitCode;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/Properties/AssemblyInfo.cs
+++ b/powershell/extractor/Semmle.Util/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Semmle.Util")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Semmle.Util")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bafbef7d-b40e-4b6c-a7fc-c8add8413c56")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/powershell/extractor/Semmle.Util/Semmle.Util.csproj
+++ b/powershell/extractor/Semmle.Util/Semmle.Util.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <AssemblyName>Semmle.Util</AssemblyName>
+    <RootNamespace>Semmle.Util</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/powershell/extractor/Semmle.Util/SharedReference.cs
+++ b/powershell/extractor/Semmle.Util/SharedReference.cs
@@ -1,0 +1,18 @@
+namespace Semmle.Util
+{
+    /// <summary>
+    /// An instance of this class maintains a shared reference to an object.
+    /// This makes it possible for several different parts of the code to
+    /// share access to an object that can change (that is, they all want
+    /// to refer to the same object, but the object to which they jointly
+    /// refer may vary over time).
+    /// </summary>
+    /// <typeparam name="T">The type of the shared object.</typeparam>
+    public sealed class SharedReference<T> where T : class
+    {
+        /// <summary>
+        /// The shared object to which different parts of the code want to refer.
+        /// </summary>
+        public T? Obj { get; set; }
+    }
+}

--- a/powershell/extractor/Semmle.Util/StringBuilder.cs
+++ b/powershell/extractor/Semmle.Util/StringBuilder.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Semmle.Util
+{
+    public static class StringBuilderExtensions
+    {
+        /// <summary>
+        /// Appends a [comma] separated list to a StringBuilder.
+        /// </summary>
+        /// <typeparam name="T">The type of the list.</typeparam>
+        /// <param name="builder">The StringBuilder to append to.</param>
+        /// <param name="separator">The separator string (e.g. ",")</param>
+        /// <param name="items">The list of items.</param>
+        /// <returns>The original StringBuilder (fluent interface).</returns>
+        public static StringBuilder AppendList<T>(this StringBuilder builder, string separator, IEnumerable<T> items)
+        {
+            return builder.BuildList(separator, items, (x, sb) => { sb.Append(x); });
+        }
+
+        /// <summary>
+        /// Builds a string using a separator and an action for each item in the list.
+        /// </summary>
+        /// <typeparam name="T">The type of the items.</typeparam>
+        /// <param name="builder">The string builder.</param>
+        /// <param name="separator">The separator string (e.g. ", ")</param>
+        /// <param name="items">The list of items.</param>
+        /// <param name="action">The action on each item.</param>
+        /// <returns>The original StringBuilder (fluent interface).</returns>
+        public static StringBuilder BuildList<T>(this StringBuilder builder, string separator, IEnumerable<T> items, Action<T, StringBuilder> action)
+        {
+            var first = true;
+            foreach (var item in items)
+            {
+                if (first)
+                    first = false;
+                else
+                    builder.Append(separator);
+
+                action(item, builder);
+            }
+            return builder;
+        }
+
+    }
+}

--- a/powershell/extractor/Semmle.Util/StringExtensions.cs
+++ b/powershell/extractor/Semmle.Util/StringExtensions.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Semmle.Util
+{
+    public static class StringExtensions
+    {
+        public static (string, string) Split(this string self, int index0)
+        {
+            var split = self.Split(new[] { index0 });
+            return (split[0], split[1]);
+        }
+
+        public static (string, string, string) Split(this string self, int index0, int index1)
+        {
+            var split = self.Split(new[] { index0, index1 });
+            return (split[0], split[1], split[2]);
+        }
+
+        public static (string, string, string, string) Split(this string self, int index0, int index1, int index2)
+        {
+            var split = self.Split(new[] { index0, index1, index2 });
+            return (split[0], split[1], split[2], split[3]);
+        }
+
+        private static List<string> Split(this string self, params int[] indices)
+        {
+            var ret = new List<string>();
+            var previousIndex = 0;
+            foreach (var index in indices.OrderBy(i => i))
+            {
+                ret.Add(self.Substring(previousIndex, index - previousIndex));
+                previousIndex = index;
+            }
+
+            ret.Add(self.Substring(previousIndex));
+
+            return ret;
+        }
+    }
+}

--- a/powershell/extractor/Semmle.Util/TemporaryDirectory.cs
+++ b/powershell/extractor/Semmle.Util/TemporaryDirectory.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.IO;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// A temporary directory that is created within the system temp directory.
+    /// When this object is disposed, the directory is deleted.
+    /// </summary>
+    public sealed class TemporaryDirectory : IDisposable
+    {
+        public DirectoryInfo DirInfo { get; }
+
+        public TemporaryDirectory(string name)
+        {
+            DirInfo = new DirectoryInfo(name);
+            DirInfo.Create();
+        }
+
+        public void Dispose()
+        {
+            DirInfo.Delete(true);
+        }
+
+        public override string ToString() => DirInfo.FullName.ToString();
+    }
+}

--- a/powershell/extractor/Semmle.Util/Text.cs
+++ b/powershell/extractor/Semmle.Util/Text.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// An instance of this class represents a piece of text, e.g. the text of a C# source file.
+    /// </summary>
+    public sealed class Text
+    {
+        //#################### PRIVATE VARIABLES ####################
+        #region
+
+        /// <summary>
+        /// The text, stored line-by-line.
+        /// </summary>
+        private readonly string[] lines;
+
+        #endregion
+
+        //#################### CONSTRUCTORS ####################
+        #region
+
+        /// <summary>
+        /// Constructs a text object from an array of lines.
+        /// </summary>
+        /// <param name="lines">The lines of text.</param>
+        public Text(string[] lines)
+        {
+            this.lines = lines;
+        }
+
+        #endregion
+
+        //#################### PUBLIC METHODS ####################
+        #region
+
+        /// <summary>
+        /// Gets the whole text.
+        /// </summary>
+        /// <returns>The whole text.</returns>
+        public string GetAll()
+        {
+            using var sw = new StringWriter();
+            foreach (var s in lines)
+            {
+                sw.WriteLine(s);
+            }
+            return sw.ToString();
+        }
+
+        /// <summary>
+        /// Gets the portion of text that lies in the specified location range.
+        /// </summary>
+        /// <param name="startRow">The row at which the portion starts.</param>
+        /// <param name="startColumn">The column in the start row at which the portion starts.</param>
+        /// <param name="endRow">The row at which the portion ends.</param>
+        /// <param name="endColumn">The column in the end row at which the portion ends.</param>
+        /// <returns>The portion of text that lies in the specified location range.</returns>
+        public string GetPortion(int startRow, int startColumn, int endRow, int endColumn)
+        {
+            // Perform some basic validation on the range bounds.
+            if (startRow < 0 || endRow < 0 || startColumn < 0 || endColumn < 0 || endRow >= lines.Length || startRow > endRow)
+            {
+                throw new Exception
+                (
+                    string.Format("Bad range ({0},{1}):({2},{3}) in a piece of text with {4} lines", startRow, startColumn, endRow, endColumn, lines.Length)
+                );
+            }
+
+            using var sw = new StringWriter();
+            string line;
+
+            for (var i = startRow; i <= endRow; ++i)
+            {
+                if (i == startRow && i == endRow)
+                {
+                    // This is a single-line range, so take the bit between "startColumn" and "endColumn".
+                    line = startColumn <= lines[i].Length ? lines[i].Substring(startColumn, endColumn - startColumn) : "";
+                }
+                else if (i == startRow)
+                {
+                    // This is the first line of a multi-line range, so take the bit from "startColumn" onwards.
+                    line = startColumn <= lines[i].Length ? lines[i].Substring(startColumn) : "";
+                }
+                else if (i == endRow)
+                {
+                    // This is the last line of a multi-line range, so take the bit up to "endColumn".
+                    line = endColumn <= lines[i].Length ? lines[i].Substring(0, endColumn) : lines[i];
+                }
+                else
+                {
+                    // This is a line in the middle of a multi-line range, so take the whole line.
+                    line = lines[i];
+                }
+
+                sw.WriteLine(line);
+            }
+
+            return sw.ToString();
+        }
+
+        #endregion
+    }
+}

--- a/powershell/extractor/Semmle.Util/Win32.cs
+++ b/powershell/extractor/Semmle.Util/Win32.cs
@@ -1,0 +1,78 @@
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// Holder for various Win32 functions.
+    /// </summary>
+    public static class Win32
+    {
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern int GetFinalPathNameByHandle(  // lgtm[cs/unmanaged-code]
+            SafeHandle handle,
+            [In, Out] StringBuilder path,
+            int bufLen,
+            int flags);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern SafeFileHandle CreateFile(  // lgtm[cs/unmanaged-code]
+            string filename,
+            uint desiredAccess,
+            uint shareMode,
+            IntPtr securityAttributes,
+            uint creationDisposition,
+            uint flags,
+            IntPtr hTemplateFile);
+
+        /// <summary>
+        /// Is the system Windows, and should we use kernel32.dll?
+        /// </summary>
+        /// <returns>If it's Windows.</returns>
+        public static bool IsWindows()
+        {
+            switch ((int)Environment.OSVersion.Platform)
+            {
+                // See: http://www.mono-project.com/docs/faq/technical/#how-to-detect-the-execution-platform
+
+                case 4:
+                case 6:
+                case 128:
+                    // Running on Unix
+                    return false;
+                default:
+                    // Running on Windows
+                    return true;
+            }
+        }
+
+        public const int ERROR_FILE_NOT_FOUND = 0x02;
+        public const int ERROR_PATH_NOT_FOUND = 0x03;
+        public const int ERROR_ALREADY_EXISTS = 0xb7;
+
+        public const uint FILE_SHARE_READ = 1;
+        public const uint FILE_SHARE_WRITE = 2;
+        public const uint FILE_SHARE_DELETE = 4;
+
+        public const uint FILE_ATTRIBUTE_READONLY = 1;
+        public const uint FILE_ATTRIBUTE_NORMAL = 128;
+        public const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+        public const int INVALID_HANDLE_VALUE = -1;
+        public const int MAX_PATH = 260;
+
+        public const uint GENERIC_READ = 0x80000000;
+        public const uint GENERIC_WRITE = 0x40000000;
+
+        public const uint CREATE_ALWAYS = 2;
+        public const uint CREATE_NEW = 1;
+        public const uint OPEN_ALWAYS = 4;
+        public const uint OPEN_EXISTING = 3;
+        public const uint TRUNCATE_EXISTING = 5;
+
+        public const int MOVEFILE_REPLACE_EXISTING = 1;
+        public const int MOVEFILE_COPY_ALLOWED = 2;
+        public const uint INVALID_FILE_ATTRIBUTES = 0xffffffff;
+    }
+}

--- a/powershell/extractor/Semmle.Util/Worklist.cs
+++ b/powershell/extractor/Semmle.Util/Worklist.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+
+namespace Semmle.Util
+{
+    /// <summary>
+    /// A worklist of items, providing the operations of adding an item, checking
+    /// whether there are new items and iterating a chunk of unprocessed items.
+    /// Any one item will only be accepted into the worklist once.
+    /// </summary>
+    public class Worklist<T>
+    {
+        private readonly HashSet<T> internalSet = new HashSet<T>();
+        private LinkedList<T> internalList = new LinkedList<T>();
+        private bool hasNewElements = false;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has had any new elements added
+        /// since the last time <c>GetUnprocessedElements()</c> was called.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has new elements; otherwise, <c>false</c>.
+        /// </value>
+        public bool HasNewElements => hasNewElements;
+
+        /// <summary>
+        /// Add the specified element to the worklist.
+        /// </summary>
+        /// <param name='element'>
+        /// If set to <c>true</c> element.
+        /// </param>
+        public bool Add(T element)
+        {
+            if (internalSet.Contains(element))
+                return false;
+            internalSet.Add(element);
+            internalList.AddLast(element);
+            hasNewElements = true;
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the unprocessed elements that have been accumulated since the last time
+        /// this method was called. If <c>HasNewElements == true</c>, the resulting list
+        /// will be non-empty.
+        /// </summary>
+        /// <returns>
+        /// The unprocessed elements.
+        /// </returns>
+        public LinkedList<T> GetUnprocessedElements()
+        {
+            var result = internalList;
+            internalList = new LinkedList<T>();
+            hasNewElements = false;
+            return result;
+        }
+    }
+}

--- a/powershell/extractor/powershell.sln
+++ b/powershell/extractor/powershell.sln
@@ -1,0 +1,49 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33424.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Semmle.Extraction", "Semmle.Extraction\Semmle.Extraction.csproj", "{7BF4FD7F-2295-4A62-9603-99F765CAE816}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Semmle.Extraction.PowerShell.Standalone", "Semmle.Extraction.PowerShell.Standalone\Semmle.Extraction.PowerShell.Standalone.csproj", "{CD73A353-CDA4-4B65-B860-A02036CC505D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Semmle.Util", "Semmle.Util\Semmle.Util.csproj", "{D9DF0626-492A-4F34-AA61-16F28685EEEA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Semmle.Extraction.PowerShell", "Semmle.Extraction.PowerShell\Semmle.Extraction.PowerShell.csproj", "{C0E3BE64-2F6D-4998-B094-8722D2854E23}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extractor.Tests", "Microsoft.Extractor.Tests\Microsoft.Extractor.Tests.csproj", "{EC0710DB-754A-43F8-B7D3-706872BD4BDD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7BF4FD7F-2295-4A62-9603-99F765CAE816}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BF4FD7F-2295-4A62-9603-99F765CAE816}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BF4FD7F-2295-4A62-9603-99F765CAE816}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BF4FD7F-2295-4A62-9603-99F765CAE816}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD73A353-CDA4-4B65-B860-A02036CC505D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD73A353-CDA4-4B65-B860-A02036CC505D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD73A353-CDA4-4B65-B860-A02036CC505D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD73A353-CDA4-4B65-B860-A02036CC505D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9DF0626-492A-4F34-AA61-16F28685EEEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9DF0626-492A-4F34-AA61-16F28685EEEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9DF0626-492A-4F34-AA61-16F28685EEEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9DF0626-492A-4F34-AA61-16F28685EEEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0E3BE64-2F6D-4998-B094-8722D2854E23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0E3BE64-2F6D-4998-B094-8722D2854E23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0E3BE64-2F6D-4998-B094-8722D2854E23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0E3BE64-2F6D-4998-B094-8722D2854E23}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC0710DB-754A-43F8-B7D3-706872BD4BDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC0710DB-754A-43F8-B7D3-706872BD4BDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC0710DB-754A-43F8-B7D3-706872BD4BDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC0710DB-754A-43F8-B7D3-706872BD4BDD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B3147091-BA1A-4358-94B1-6A1B2CED62FF}
+	EndGlobalSection
+EndGlobal

--- a/powershell/ql/lib/semmlecode.powershell.dbscheme
+++ b/powershell/ql/lib/semmlecode.powershell.dbscheme
@@ -1,0 +1,1648 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int parent: @ast ref,
+  int child: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @ast ref,
+  int item2: @ast ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @ast ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @ast ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @ast ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @ast ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @ast ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @ast ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @ast ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @ast ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @ast ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @ast ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @ast ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @ast ref,
+  int condition: @ast ref,
+  int body: @ast ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @ast ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @ast ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @ast ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @ast ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @ast ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @ast ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @ast ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @ast ref,
+  int configurationType: int ref,
+  int name: @ast ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @ast ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/ql/lib/semmlecode.powershell.dbscheme.stats
+++ b/powershell/ql/lib/semmlecode.powershell.dbscheme.stats
@@ -1,0 +1,1 @@
+<dbstats><typesizes /><stats /></dbstats>

--- a/powershell/tools/autobuild.cmd
+++ b/powershell/tools/autobuild.cmd
@@ -1,0 +1,8 @@
+@echo off
+
+if not defined CODEQL_POWERSHELL_EXTRACTOR (
+    set CODEQL_POWERSHELL_EXTRACTOR=Semmle.Extraction.PowerShell.Standalone.exe
+)
+
+type NUL && "%CODEQL_EXTRACTOR_POWERSHELL_ROOT%/tools/%CODEQL_PLATFORM%/%CODEQL_POWERSHELL_EXTRACTOR%"
+exit /b %ERRORLEVEL%

--- a/powershell/tools/autobuild.sh
+++ b/powershell/tools/autobuild.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -z "${CODEQL_EXTRACTOR_POWERSHELL_ROOT}" ]]; then
+  export CODEQL_EXTRACTOR_POWERSHELL_ROOT="Semmle.Extraction.PowerShell.Standalone.exe"
+fi
+
+"$CODEQL_EXTRACTOR_POWERSHELL_ROOT/tools/$CODEQL_PLATFORM/$CODEQL_POWERSHELL_EXTRACTOR"

--- a/powershell/tools/index.cmd
+++ b/powershell/tools/index.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+if not defined CODEQL_POWERSHELL_EXTRACTOR (
+    set CODEQL_POWERSHELL_EXTRACTOR=Semmle.Extraction.PowerShell.Standalone.exe
+)
+
+type NUL && "%CODEQL_EXTRACTOR_POWERSHELL_ROOT%/tools/%CODEQL_PLATFORM%/%CODEQL_POWERSHELL_EXTRACTOR%"
+
+exit /b %ERRORLEVEL%

--- a/powershell/tools/index.sh
+++ b/powershell/tools/index.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -z "${CODEQL_EXTRACTOR_POWERSHELL_ROOT}" ]]; then
+  export CODEQL_EXTRACTOR_POWERSHELL_ROOT="Semmle.Extraction.PowerShell.Standalone.exe"
+fi
+
+"$CODEQL_EXTRACTOR_POWERSHELL_ROOT/tools/$CODEQL_PLATFORM/$CODEQL_POWERSHELL_EXTRACTOR"

--- a/powershell/tools/qltest.cmd
+++ b/powershell/tools/qltest.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+if not defined CODEQL_POWERSHELL_EXTRACTOR (
+    set CODEQL_POWERSHELL_EXTRACTOR=Semmle.Extraction.PowerShell.Standalone.exe
+)
+
+type NUL && "%CODEQL_EXTRACTOR_POWERSHELL_ROOT%/tools/%CODEQL_PLATFORM%/%CODEQL_POWERSHELL_EXTRACTOR%"
+
+exit /b %ERRORLEVEL%

--- a/powershell/tools/qltest.sh
+++ b/powershell/tools/qltest.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -z "${CODEQL_EXTRACTOR_POWERSHELL_ROOT}" ]]; then
+  export CODEQL_EXTRACTOR_POWERSHELL_ROOT="Semmle.Extraction.PowerShell.Standalone.exe"
+fi
+
+"$CODEQL_EXTRACTOR_POWERSHELL_ROOT/tools/$CODEQL_PLATFORM/$CODEQL_POWERSHELL_EXTRACTOR"


### PR DESCRIPTION
This PR moves the powershell extractor and the related script files to the public repo. Once this PR has gone in we can properly start on the QL work for powershell support.

I haven't made any changes to the extractor code itself. I _have_ however done the following:
- Modified the folder structure to match existing CodeQL supported languages
- Added a build script to make it easier to build the extractor and hook it up to the CodeQL CLI.
- Modified the `README.md` to reflect the above changes.

@dilanbhalla I noticed that the original README file had a line that said:
> structure must remain unchanged for NuGet package creation to run successfully

which I've totally ignored (🙈) since I don't know anything about this NuGet package creation. Do you know if I've broken anything by this restructuring (and how I can test this)?