### PR TITLE
PS: Port `powershell/command-injection` from the internal repo

### DIFF
--- a/powershell/ql/src/experimental/CommandInjection.ql
+++ b/powershell/ql/src/experimental/CommandInjection.ql
@@ -2,7 +2,7 @@
  * @name Command Injection
  * @description Variable expression executed as command
  * @kind problem
- * @id powershell/command-injection
+ * @id powershell/tainted-command
  * @problem.severity warning
  * @precision low
  * @tags security

--- a/powershell/ql/src/experimental/CommandInjection.ql
+++ b/powershell/ql/src/experimental/CommandInjection.ql
@@ -1,0 +1,74 @@
+/**
+ * @name Command Injection
+ * @description Variable expression executed as command
+ * @kind problem
+ * @id powershell/command-injection
+ * @problem.severity warning
+ * @precision low
+ * @tags security
+ */
+
+import powershell
+
+predicate containsScope(VariableExpression outer, VariableExpression inner) {
+  outer.getUserPath() = inner.getUserPath() and
+  outer != inner
+}
+
+predicate constantTernaryExpression(TernaryExpression ternary) {
+  onlyConstantExpressions(ternary.getIfTrue()) and onlyConstantExpressions(ternary.getIfFalse())
+}
+
+predicate constantBinaryExpression(BinaryExpression binary) {
+  onlyConstantExpressions(binary.getLeftHandSide()) and onlyConstantExpressions(binary.getRightHandSide())
+}
+
+predicate onlyConstantExpressions(Expression expr){
+  expr instanceof StringConstantExpression or constantBinaryExpression(expr) or constantTernaryExpression(expr)
+}
+
+VariableExpression getNonConstantVariableAssignment(VariableExpression varexpr) {
+  (
+    exists(AssignmentStatement assignment |
+      not onlyConstantExpressions(assignment.getRightHandSide().(CommandExpression).getExpression()) and
+      result = assignment.getLeftHandSide()
+    )
+  ) and
+  containsScope(result, varexpr)
+}
+
+VariableExpression getParameterWithVariableScope(VariableExpression varexpr) {
+  exists(Parameter parameter |
+    result = parameter.getName() and
+    containsScope(result, varexpr)
+  )
+}
+
+Expression getAllSubExpressions(Expression expr)
+{
+  result = expr or
+  result = getAllSubExpressions(expr.(ArrayLiteral).getAnElement()) or
+  result = getAllSubExpressions(expr.(ArrayExpression).getStatementBlock().getAStatement().(Pipeline).getAComponent().(CommandExpression).getExpression())
+}
+
+Expression dangerousCommandElement(Command command)
+{
+  (
+    command.getKind() = 28 or
+    command.getName() = "Invoke-Expression"
+  ) and
+  result = getAllSubExpressions(command.getAnElement())
+}
+
+from Expression commandarg, VariableExpression unknownDeclaration
+where
+  exists(Command command |
+    (
+      unknownDeclaration = getNonConstantVariableAssignment(commandarg) or
+      unknownDeclaration = getParameterWithVariableScope(commandarg)
+    )
+    and
+    commandarg = dangerousCommandElement(command)
+  )
+select commandarg.(VariableExpression).getLocation(), "Unsafe flow to command argument from $@.",
+  unknownDeclaration, unknownDeclaration.getUserPath()

--- a/powershell/ql/src/experimental/CommandInjection.ql
+++ b/powershell/ql/src/experimental/CommandInjection.ql
@@ -10,48 +10,48 @@
 
 import powershell
 
-predicate containsScope(VariableExpression outer, VariableExpression inner) {
+predicate containsScope(VarAccess outer, VarAccess inner) {
   outer.getUserPath() = inner.getUserPath() and
   outer != inner
 }
 
-predicate constantTernaryExpression(TernaryExpression ternary) {
+predicate constantTernaryExpression(ConditionalExpr ternary) {
   onlyConstantExpressions(ternary.getIfTrue()) and onlyConstantExpressions(ternary.getIfFalse())
 }
 
-predicate constantBinaryExpression(BinaryExpression binary) {
-  onlyConstantExpressions(binary.getLeftHandSide()) and onlyConstantExpressions(binary.getRightHandSide())
+predicate constantBinaryExpression(BinaryExpr binary) {
+  onlyConstantExpressions(binary.getLeft()) and onlyConstantExpressions(binary.getRight())
 }
 
-predicate onlyConstantExpressions(Expression expr){
-  expr instanceof StringConstantExpression or constantBinaryExpression(expr) or constantTernaryExpression(expr)
+predicate onlyConstantExpressions(Expr expr){
+  expr instanceof StringConstExpression or constantBinaryExpression(expr) or constantTernaryExpression(expr)
 }
 
-VariableExpression getNonConstantVariableAssignment(VariableExpression varexpr) {
+VarAccess getNonConstantVariableAssignment(VarAccess varexpr) {
   (
-    exists(AssignmentStatement assignment |
-      not onlyConstantExpressions(assignment.getRightHandSide().(CommandExpression).getExpression()) and
+    exists(AssignStmt assignment |
+      not onlyConstantExpressions(assignment.getRightHandSide().(CmdExpr).getExpr()) and
       result = assignment.getLeftHandSide()
     )
   ) and
   containsScope(result, varexpr)
 }
 
-VariableExpression getParameterWithVariableScope(VariableExpression varexpr) {
+VarAccess getParameterWithVariableScope(VarAccess varexpr) {
   exists(Parameter parameter |
     result = parameter.getName() and
     containsScope(result, varexpr)
   )
 }
 
-Expression getAllSubExpressions(Expression expr)
+Expr getAllSubExpressions(Expr expr)
 {
   result = expr or
   result = getAllSubExpressions(expr.(ArrayLiteral).getAnElement()) or
-  result = getAllSubExpressions(expr.(ArrayExpression).getStatementBlock().getAStatement().(Pipeline).getAComponent().(CommandExpression).getExpression())
+  result = getAllSubExpressions(expr.(ArrayExpr).getStatementBlock().getAStatement().(Pipeline).getAComponent().(CmdExpr).getExpr())
 }
 
-Expression dangerousCommandElement(Command command)
+Expr dangerousCommandElement(Cmd command)
 {
   (
     command.getKind() = 28 or
@@ -60,9 +60,9 @@ Expression dangerousCommandElement(Command command)
   result = getAllSubExpressions(command.getAnElement())
 }
 
-from Expression commandarg, VariableExpression unknownDeclaration
+from Expr commandarg, VarAccess unknownDeclaration
 where
-  exists(Command command |
+  exists(Cmd command |
     (
       unknownDeclaration = getNonConstantVariableAssignment(commandarg) or
       unknownDeclaration = getParameterWithVariableScope(commandarg)
@@ -70,5 +70,5 @@ where
     and
     commandarg = dangerousCommandElement(command)
   )
-select commandarg.(VariableExpression).getLocation(), "Unsafe flow to command argument from $@.",
+select commandarg.(VarAccess).getLocation(), "Unsafe flow to command argument from $@.",
   unknownDeclaration, unknownDeclaration.getUserPath()

--- a/powershell/ql/src/qlpack.yml
+++ b/powershell/ql/src/qlpack.yml
@@ -1,0 +1,11 @@
+name: microsoft-sdl/powershell-queries
+version: 0.0.1
+groups:
+  - powershell
+  - microsoft-all
+  - queries
+extractor: powershell
+dependencies:
+  microsoft-sdl/powershell-all: ${workspace}
+  codeql/suite-helpers: ${workspace}
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR moves the final piece of QL-for-Powershell code from the internal repo to the public one: an experimental query.

Once this is merged we should be able to get rid of the internal stuff