### PR TITLE
PS: Add SSA consistency queries and include parameter read/writes as SSA read/writes

### DIFF
--- a/powershell/ql/consistency-queries/SsaConsistency.ql
+++ b/powershell/ql/consistency-queries/SsaConsistency.ql
@@ -1,0 +1,1 @@
+import semmle.code.powershell.dataflow.internal.SsaImpl::Consistency

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -111,7 +111,13 @@ private class AbstractVariable extends TVariable {
   }
 }
 
-class LocalVariable extends AbstractVariable, TLocalVariable {
+final class Variable = AbstractVariable;
+
+abstract class AbstractLocalScopeVariable extends AbstractVariable { }
+
+final class LocalScopeVariable = AbstractLocalScopeVariable;
+
+class LocalVariable extends AbstractLocalScopeVariable, TLocalVariable {
   string name;
   Scope scope;
 
@@ -135,7 +141,7 @@ class LocalVariable extends AbstractVariable, TLocalVariable {
   final override Scope getDeclaringScope() { result = scope }
 }
 
-class Parameter extends AbstractVariable, TParameter {
+class Parameter extends AbstractLocalScopeVariable, TParameter {
   ParameterImpl p;
 
   Parameter() { this = TParameter(p) }
@@ -156,5 +162,3 @@ class Parameter extends AbstractVariable, TParameter {
 
   int getIndex() { this.isFunctionParameter(_, result) }
 }
-
-final class Variable = AbstractVariable;

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -151,7 +151,7 @@ module ExprNodes {
 
   private class VarWriteAccessChildMapping extends VarAccessChildMapping, VarWriteAccess { }
 
-  class VariableWriteAccessCfgNode extends VarAccessCfgNode {
+  class VarWriteAccessCfgNode extends VarAccessCfgNode {
     override string getAPrimaryQlClass() { result = "VarWriteAccessCfgNode" }
 
     override VarWriteAccessChildMapping e;

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
@@ -75,7 +75,7 @@ module Ssa {
    * An SSA definition that corresponds to a write.
    */
   class WriteDefinition extends Definition, SsaImpl::WriteDefinition {
-    private VariableWriteAccessCfgNode write;
+    private VarWriteAccessCfgNode write;
 
     WriteDefinition() {
       exists(BasicBlock bb, int i, Variable v |
@@ -85,7 +85,7 @@ module Ssa {
     }
 
     /** Gets the underlying write access. */
-    final VariableWriteAccessCfgNode getWriteAccess() { result = write }
+    final VarWriteAccessCfgNode getWriteAccess() { result = write }
 
     /**
      * Holds if this SSA definition assigns `value` to the underlying variable.

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
@@ -19,7 +19,7 @@ module SsaInput implements SsaImplCommon::InputSig<Location> {
 
   class ExitBasicBlock extends BasicBlock, BasicBlocks::ExitBasicBlock { }
 
-  class SourceVariable = LocalVariable;
+  class SourceVariable = LocalScopeVariable;
 
   /**
    * Holds if the statement at index `i` of basic block `bb` contains a write to variable `v`.
@@ -34,7 +34,7 @@ module SsaInput implements SsaImplCommon::InputSig<Location> {
     certain = true
   }
 
-  predicate variableRead(BasicBlock bb, int i, LocalVariable v, boolean certain) {
+  predicate variableRead(BasicBlock bb, int i, SourceVariable v, boolean certain) {
     variableReadActual(bb, i, v) and
     certain = true
   }
@@ -59,7 +59,7 @@ predicate uninitializedWrite(Cfg::EntryBasicBlock bb, int i, LocalVariable v) {
 }
 
 /** Holds if `v` is read at index `i` in basic block `bb`. */
-private predicate variableReadActual(Cfg::BasicBlock bb, int i, LocalVariable v) {
+private predicate variableReadActual(Cfg::BasicBlock bb, int i, LocalScopeVariable v) {
   exists(VarReadAccess read |
     read.getVariable() = v and
     read = bb.getNode(i).getAstNode()
@@ -152,7 +152,7 @@ private module Cached {
    */
   cached
   predicate variableWriteActual(
-    Cfg::BasicBlock bb, int i, LocalVariable v, VariableWriteAccessCfgNode write
+    Cfg::BasicBlock bb, int i, LocalScopeVariable v, VarWriteAccessCfgNode write
   ) {
     exists(Cfg::CfgNode n |
       write.getVariable() = v and
@@ -164,7 +164,7 @@ private module Cached {
 
   cached
   VarReadAccessCfgNode getARead(Definition def) {
-    exists(LocalVariable v, Cfg::BasicBlock bb, int i |
+    exists(SsaInput::SourceVariable v, Cfg::BasicBlock bb, int i |
       Impl::ssaDefReachesRead(v, def, bb, i) and
       variableReadActual(bb, i, v) and
       result = bb.getNode(i)


### PR DESCRIPTION
Just like the shared CFG library that we introduced for Powershell has a useful set of consistency queries, the shared SSA library also comes with a set of consistency queries. This PR exposes these consistency queries.

In addition, this PR also includes the set of SSA reads/writes to be reads and writes to parameters.