### PR TITLE
PS: Place parameter definitions in the SSA graph

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/Function.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Function.qll
@@ -1,4 +1,5 @@
 import powershell
+import semmle.code.powershell.controlflow.BasicBlocks
 
 abstract private class AbstractFunction extends Ast {
   abstract string getName();
@@ -20,6 +21,8 @@ abstract private class AbstractFunction extends Ast {
   }
 
   final Parameter getAParameter() { result = this.getParameter(_) }
+
+  EntryBasicBlock getEntryBasicBlock() { result.getScope() = this.getBody() }
 }
 
 class NonMemberFunction extends @function_definition, Stmt, AbstractFunction {

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -2,10 +2,40 @@ private import powershell
 private import semmle.code.powershell.controlflow.internal.Scope
 private import internal.Internal as Internal
 
+private predicate isFunctionParameterImpl(Internal::Parameter p, Function f, int i) {
+  function_definition_parameter(f, i, p)
+  or
+  function_member_parameter(f, i, p)
+}
+
+private predicate hasParameterBlockImpl(Internal::Parameter p, ParamBlock block, int i) {
+  param_block_parameter(block, i, p)
+}
+
+/**
+ * Gets the enclosing scope of `p`.
+ * 
+ * For a function parameter, this is the function body. For a parameter from a
+ * parameter block, this is the enclosing scope of the parameter block.
+ * 
+ * In both of the above cases, the enclosing scope is the function body.
+ */
+private Scope getEnclosingScopeImpl(Internal::Parameter p) {
+  exists(Function f |
+    isFunctionParameterImpl(p, f, _) and
+    result = f.getBody()
+  )
+  or
+  exists(ParamBlock b |
+    hasParameterBlockImpl(p, b, _) and
+    result = b.getEnclosingScope()
+  )
+}
+
 bindingset[scope]
 pragma[inline_late]
 private predicate isParameterImpl(string name, Scope scope) {
-  exists(Internal::Parameter p | p.getName() = name and p.getEnclosingScope() = scope)
+  exists(Internal::Parameter p | p.getName() = name and getEnclosingScopeImpl(p) = scope)
   or
   name = "_"
 }
@@ -47,17 +77,13 @@ private class InternalParameter extends ParameterImpl, TInternalParameter {
 
   override string getName() { result = p.getName() }
 
-  final override Scope getEnclosingScope() { result = p.getEnclosingScope() }
+  final override Scope getEnclosingScope() { result = getEnclosingScopeImpl(p) }
 
   override predicate hasParameterBlock(ParamBlock block, int i) {
-    param_block_parameter(block, i, p)
+    hasParameterBlockImpl(p, block, i)
   }
 
-  override predicate isFunctionParameter(Function f, int i) {
-    function_definition_parameter(f, i, p)
-    or
-    function_member_parameter(f, i, p)
-  }
+  override predicate isFunctionParameter(Function f, int i) { isFunctionParameterImpl(p, f, i) }
 
   override Expr getDefaultValue() { result = p.getDefaultValue() }
 }
@@ -161,4 +187,6 @@ class Parameter extends AbstractLocalScopeVariable, TParameter {
   predicate hasDefaultValue() { exists(this.getDefaultValue()) }
 
   int getIndex() { this.isFunctionParameter(_, result) }
+
+  Function getFunction() { result.getBody() = this.getDeclaringScope() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/VariableExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/VariableExpression.qll
@@ -34,18 +34,24 @@ class VarAccess extends @variable_expression, Expr {
   Variable getVariable() { result.getAnAccess() = this }
 }
 
-private predicate isVariableWriteAccess(Expr e) {
-  e = any(AssignStmt assign).getLeftHandSide()
+private predicate isExplicitVariableWriteAccess(Expr e, AssignStmt assign) {
+  e = assign.getLeftHandSide()
   or
-  e = any(ConvertExpr convert | isVariableWriteAccess(convert)).getExpr()
+  e = any(ConvertExpr convert | isExplicitVariableWriteAccess(convert, assign)).getExpr()
   or
-  e = any(ArrayLiteral array | isVariableWriteAccess(array)).getAnElement()
+  e = any(ArrayLiteral array | isExplicitVariableWriteAccess(array, assign)).getAnElement()
 }
+
+private predicate isImplicitVariableWriteAccess(Expr e) { none() }
 
 class VarReadAccess extends VarAccess {
   VarReadAccess() { not this instanceof VarWriteAccess }
 }
 
 class VarWriteAccess extends VarAccess {
-  VarWriteAccess() { isVariableWriteAccess(this) }
+  VarWriteAccess() { isExplicitVariableWriteAccess(this, _) or isImplicitVariableWriteAccess(this) }
+
+  predicate isExplicit(AssignStmt assign) { isExplicitVariableWriteAccess(this, assign) }
+
+  predicate isImplicit() { isImplicitVariableWriteAccess(this) }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -163,6 +163,8 @@ module ExprNodes {
     predicate isExplicitWrite(StmtNodes::AssignStmtCfgNode assignment) {
       this = assignment.getLeftHandSide()
     }
+
+    predicate isImplicitWrite() { e.isImplicit() }
   }
 }
 

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
@@ -103,6 +103,21 @@ module Ssa {
     final override Location getLocation() { result = write.getLocation() }
   }
 
+  class ParameterDefinition extends Definition, SsaImpl::WriteDefinition {
+    private Variable v;
+
+    ParameterDefinition() {
+      exists(BasicBlock bb, int i |
+        this.definesAt(v, bb, i) and
+        SsaImpl::parameterWrite(bb, i, v)
+      )
+    }
+
+    final override string toString() { result = "<parameter> " + v }
+
+    final override Location getLocation() { result = v.getLocation() }
+  }
+
   /**
    * An SSA definition inserted at the beginning of a scope to represent an
    * uninitialized local variable.

--- a/powershell/ql/test/library-tests/ssa/explicit.ps1
+++ b/powershell/ql/test/library-tests/ssa/explicit.ps1
@@ -1,0 +1,8 @@
+$glo_a = 42
+$glob_b = $glob_a
+
+function f() {
+    $a = 43
+    $b = $a
+    return $b
+}

--- a/powershell/ql/test/library-tests/ssa/parameters.ps1
+++ b/powershell/ql/test/library-tests/ssa/parameters.ps1
@@ -1,0 +1,11 @@
+function function-param([int]$n1, [int]$n2) {
+    return $n1 + $n2
+}
+
+function param-block {
+    param(
+        [int]$a,
+        [int]$b
+    )
+    return $a + $b
+}

--- a/powershell/ql/test/library-tests/ssa/ssa.expected
+++ b/powershell/ql/test/library-tests/ssa/ssa.expected
@@ -1,0 +1,2 @@
+| explicit.ps1:1:1:8:2 | <uninitialized> glob_a | explicit.ps1:2:11:2:18 | glob_a |
+| explicit.ps1:5:5:5:7 | a | explicit.ps1:5:5:5:7 | a |

--- a/powershell/ql/test/library-tests/ssa/ssa.ql
+++ b/powershell/ql/test/library-tests/ssa/ssa.ql
@@ -1,0 +1,4 @@
+import powershell
+import semmle.code.powershell.dataflow.Ssa
+
+query predicate definition(Ssa::Definition def, Variable v) { def.getSourceVariable() = v }


### PR DESCRIPTION
An SSA definition needs to live at some index in a basic block. For a standard write to a local variable this is quite easy: just place the write at the index of the `AssignStmt` that writes to the variable.

In general, every read of an SSA variable needs to have a corresponding (unique) write. And that also includes parameters! So we need to have an initial definition of every parameter.

This PR adds such an initial definition of parameters. Since definition needs to happen before anything else in the function, I've placed the definitions at negative indices in the basic block. So a function such as:
```ps
function f($a, $b, $c) { ... }
```
has the following SSA definitions of the parameters:
- `$a` at index `-3`
- `$b` at index `-2`
- `$c` at index `-1`

this ensures that they're initialized in the right order (i.e., left-to-right) and that the definitions happen before any reads in the body.