### PR TITLE
PS: Integrate SSA computations into dataflow

### DIFF
--- a/powershell/ql/lib/powershell.qll
+++ b/powershell/ql/lib/powershell.qll
@@ -70,7 +70,9 @@ import semmle.code.powershell.Pipeline
 import semmle.code.powershell.StringConstantExpression
 import semmle.code.powershell.MemberExpr
 import semmle.code.powershell.InvokeMemberExpression
+import semmle.code.powershell.Call
 import semmle.code.powershell.SubExpression
+import semmle.code.powershell.ErrorExpr
 import semmle.code.powershell.ConvertExpr
 import semmle.code.powershell.IndexExpr
 import semmle.code.powershell.HashTable

--- a/powershell/ql/lib/semmle/code/powershell/Call.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Call.qll
@@ -1,0 +1,29 @@
+import powershell
+
+abstract private class AbstractCall extends Ast {
+  abstract Expr getCommand();
+
+  abstract Expr getArgument(int i);
+
+  Expr getNamedArgument(string name) { none() }
+
+  Expr getQualifier() { none() }
+}
+
+private class CmdCall extends AbstractCall instanceof Cmd {
+  final override Expr getCommand() { result = Cmd.super.getCommand() }
+
+  final override Expr getArgument(int i) { result = Cmd.super.getArgument(i) }
+
+  final override Expr getNamedArgument(string name) { result = Cmd.super.getNamedArgument(name) }
+}
+
+private class InvokeMemberCall extends AbstractCall instanceof InvokeMemberExpr {
+  final override Expr getCommand() { result = super.getMember() }
+
+  final override Expr getArgument(int i) { result = InvokeMemberExpr.super.getArgument(i) }
+
+  final override Expr getQualifier() { result = InvokeMemberExpr.super.getQualifier() }
+}
+
+final class Call = AbstractCall;

--- a/powershell/ql/lib/semmle/code/powershell/Command.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Command.qll
@@ -15,6 +15,8 @@ class Cmd extends @command, CmdBase {
 
   CmdElement getElement(int i) { command_command_element(this, i, result) }
 
+  Expr getCommand() { result = this.getElement(0) }
+
   StringConstExpr getCmdName() { result = this.getElement(0) }
 
   Expr getArgument(int i) {
@@ -43,7 +45,7 @@ class Cmd extends @command, CmdBase {
 
 /**
  * An argument to a command.
- * 
+ *
  * The argument may be named or positional.
  */
 class Argument extends Expr {

--- a/powershell/ql/lib/semmle/code/powershell/Command.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Command.qll
@@ -40,3 +40,20 @@ class Cmd extends @command, CmdBase {
 
   Redirection getARedirection() { result = this.getRedirection(_) }
 }
+
+/**
+ * An argument to a command.
+ * 
+ * The argument may be named or positional.
+ */
+class Argument extends Expr {
+  Cmd cmd;
+
+  Argument() { cmd.getArgument(_) = this or cmd.getNamedArgument(_) = this }
+
+  Cmd getCmd() { result = cmd }
+
+  int getIndex() { cmd.getArgument(result) = this }
+
+  string getName() { cmd.getNamedArgument(result) = this }
+}

--- a/powershell/ql/lib/semmle/code/powershell/ErrorExpr.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ErrorExpr.qll
@@ -1,0 +1,7 @@
+import powershell
+
+class ErrorExpr extends @error_expression, Expr {
+  final override SourceLocation getLocation() { error_expression_location(this, result) }
+
+  final override string toString() { result = "error" }
+}

--- a/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
@@ -3,7 +3,7 @@ import powershell
 class InvokeMemberExpr extends @invoke_member_expression, MemberExprBase {
   override SourceLocation getLocation() { invoke_member_expression_location(this, result) }
 
-  Expr getBase() { invoke_member_expression(this, result, _) }
+  Expr getQualifier() { invoke_member_expression(this, result, _) }
 
   CmdElement getMember() { invoke_member_expression(this, _, result) }
 

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -166,6 +166,37 @@ module ExprNodes {
 
     predicate isImplicitWrite() { e.isImplicit() }
   }
+
+  /** A control-flow node that wraps an argument expression. */
+  class ArgumentCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "ArgumentCfgNode" }
+
+    override Argument e;
+
+    final override Argument getExpr() { result = super.getExpr() }
+  }
+
+  private class InvokeMemberChildMapping extends ExprChildMapping, InvokeMemberExpr {
+    override predicate relevantChild(Ast n) { n = this.getQualifier() or n = this.getAnArgument() }
+  }
+
+  /** A control-flow node that wraps an `InvokeMemberExpr` expression. */
+  class InvokeMemberCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "InvokeMemberCfgNode" }
+
+    override InvokeMemberChildMapping e;
+
+    final override InvokeMemberExpr getExpr() { result = super.getExpr() }
+
+    final ExprCfgNode getQualifier() { e.hasCfgChild(e.getQualifier(), this, result) }
+  }
+
+    /** A control-flow node that wraps a qualifier expression. */
+  class QualifierCfgNode extends ExprCfgNode {
+    QualifierCfgNode() { this = any(InvokeMemberCfgNode invoke).getQualifier() }
+
+    InvokeMemberCfgNode getInvokeMember() { this = result.getQualifier() }
+  }
 }
 
 module StmtNodes {

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/Scope.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/Scope.qll
@@ -17,4 +17,23 @@ Scope scopeOf(Ast n) {
 class Scope extends Ast, @script_block {
   /** Gets the outer scope, if any. */
   Scope getOuterScope() { result = scopeOf(this) }
+
+  /**
+   * Gets the `i`'th paramter in this scope.
+   *
+   * This may be both function paramters and parameter block parameters.
+   */
+  Parameter getParameter(int i) {
+    exists(Function func |
+      func.getBody() = this and
+      result = func.getParameter(i)
+    )
+  }
+
+  /**
+   * Gets a paramter in this scope.
+   *
+   * This may be both function paramters and parameter block parameters.
+   */
+  Parameter getAParameter() { result = this.getParameter(_) }
 }

--- a/powershell/ql/test/library-tests/ast/Expressions/expressions.ql
+++ b/powershell/ql/test/library-tests/ast/Expressions/expressions.ql
@@ -10,7 +10,7 @@ query predicate cmdExpr(CmdExpr cmd, Expr e) {
 }
 
 query predicate invokeMemoryExpression(InvokeMemberExpr invoke, Expr e, int i, Expr arg) {
-    e = invoke.getBase() and
+    e = invoke.getQualifier() and
     arg = invoke.getArgument(i)
 }
 

--- a/powershell/ql/test/library-tests/dataflow/local/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/local/test.ps1
@@ -1,0 +1,8 @@
+$a1 = Source()
+Sink($a1)
+
+$b = GetBool()
+if($b) {
+    $a2 = Source()
+}
+Sink($a2)

--- a/powershell/ql/test/library-tests/dataflow/local/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/local/test.ps1
@@ -1,8 +1,8 @@
-$a1 = Source()
-Sink($a1)
+$a1 = Source
+Sink $a1
 
-$b = GetBool()
+$b = GetBool
 if($b) {
-    $a2 = Source()
+    $a2 = Source
 }
-Sink($a2)
+Sink $a2

--- a/powershell/ql/test/library-tests/dataflow/local/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/local/test.ql
@@ -1,0 +1,6 @@
+import powershell
+import semmle.code.powershell.dataflow.DataFlow
+
+from DataFlow::Node pred, DataFlow::Node succ
+where DataFlow::localFlowStep(pred, succ)
+select pred, succ


### PR DESCRIPTION
This PR plugs in the SSA library we added [here](https://github.com/microsoft/codeql/pull/93) into the dataflow library that we added [here](https://github.com/microsoft/codeql/pull/92).

It's all a fairly straightforward copy/paste from Ruby. In the process I also added a new AST class for `ErrorExpr` and created a convenience class for "function calls" that includes both member function calls and non-member function calls.