### PR TITLE
PS: Remove spurious `Pipeline`s in the DB

### DIFF
--- a/misc/scripts/prepare-db-upgrade.sh
+++ b/misc/scripts/prepare-db-upgrade.sh
@@ -80,7 +80,7 @@ case "${lang}" in
   java)
     scheme_file="${lang}/ql/lib/config/semmlecode.dbscheme"
     ;;
-  csharp | cpp | javascript | python)
+  csharp | cpp | javascript | python | powershell)
     scheme_file="${lang}/ql/lib/semmlecode.${lang}.dbscheme"
     ;;
   go | ruby | swift)

--- a/powershell/downgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/old.dbscheme
+++ b/powershell/downgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/old.dbscheme
@@ -1,0 +1,1648 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @command_base | @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/downgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/semmlecode.powershell.dbscheme
+++ b/powershell/downgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/semmlecode.powershell.dbscheme
@@ -1,0 +1,1648 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/downgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/upgrade.properties
+++ b/powershell/downgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/upgrade.properties
@@ -1,0 +1,2 @@
+description: Remove Pipelines with one element.
+compatibility: partial

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayExpressionEntity.cs
@@ -19,7 +19,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             var subExpression = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.SubExpression);
             trapFile.array_expression(this, subExpression);
             trapFile.array_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayLiteralEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ArrayLiteralEntity.cs
@@ -23,7 +23,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Elements[index]);
                 trapFile.array_literal_element(this, index, entity);
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AssignmentStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AssignmentStatementEntity.cs
@@ -19,7 +19,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             var right = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Right);
             trapFile.assignment_statement(this, Fragment.Operator, left, right);
             trapFile.assignment_statement_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributeEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributeEntity.cs
@@ -28,7 +28,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.attribute_positional_argument(this, i,
                     EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.PositionalArguments[i]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributedExpression.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/AttributedExpression.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             trapFile.attributed_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Attribute), 
                 EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Child));
             trapFile.attributed_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BinaryExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BinaryExpressionEntity.cs
@@ -18,7 +18,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             var right = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Right);
             trapFile.binary_expression(this, Fragment.Operator, left, right);
             trapFile.binary_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BlockStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BlockStatementEntity.cs
@@ -16,7 +16,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.block_statement(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), TokenEntity.Create(PowerShellContext, Fragment.Kind));
             trapFile.block_statement_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BreakStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/BreakStatementEntity.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             }
 
             trapFile.break_statement_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CatchClauseEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CatchClauseEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.catch_clause_catch_type(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CatchTypes[index]));
             }
             trapFile.catch_clause_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandEntity.cs
@@ -31,7 +31,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Redirections[index]);
                 trapFile.command_redirection(this, index, entity);
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandExpressionEntity.cs
@@ -23,7 +23,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.command_expression_redirection(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Redirections[index]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandParameterEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/CommandParameterEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.command_parameter_argument(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext,Fragment.Argument));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConfigurationDefinitionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConfigurationDefinitionEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.configuration_definition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Body), Fragment.ConfigurationType, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.InstanceName));
             trapFile.configuration_definition_location(this, TrapSuitableLocation); 
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConstantExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConstantExpressionEntity.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.constant_expression_value(this,
                     StringLiteralEntity.Create(PowerShellContext, ReportingLocation, strVal));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
             trapFile.constant_expression_location(this, TrapSuitableLocation);
         }
 

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ContinueStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ContinueStatementEntity.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             }
 
             trapFile.continue_statement_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConvertExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ConvertExpressionEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             var type = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Type);
             trapFile.convert_expression(this, attribute, child, type, Fragment.StaticType.Name);
             trapFile.convert_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DataStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DataStatementEntity.cs
@@ -25,7 +25,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.data_statement_commands_allowed(this, i, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CommandsAllowed[i]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoUntilStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoUntilStatementEntity.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.do_until_statement_condition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoWhileStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DoWhileStatementEntity.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.do_while_statement_condition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DynamicKeywordStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/DynamicKeywordStatementEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.dynamic_keyword_statement_command_elements(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.CommandElements[index]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorExpressionEntity.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                     trapFile.error_expression_nested_ast(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.NestedAst[index]));
                 }
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ErrorStatementEntity.cs
@@ -39,7 +39,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.error_statement_bodies(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Bodies[index]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
             trapFile.error_statement_location(this, TrapSuitableLocation);
         }
 

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExitStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExitStatementEntity.cs
@@ -20,7 +20,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.exit_statement_pipeline(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
             }    
             trapFile.exit_statement(this);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
             trapFile.exit_statement_location(this, TrapSuitableLocation);
         }
 

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExpandableStringExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ExpandableStringExpressionEntity.cs
@@ -25,7 +25,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.expandable_string_expression_nested_expression(this, index,
                     EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.NestedExpressions[index]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FileRedirectionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FileRedirectionEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             trapFile.file_redirection(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Location),
                 Fragment.Append, Fragment.FromStream);
             trapFile.file_redirection_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForEachStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForEachStatementEntity.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.label(this, Fragment.Label);
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ForStatementEntity.cs
@@ -37,7 +37,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.for_statement_iterator(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Iterator));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionDefinitionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionDefinitionEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.function_definition_parameter(this, i, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parameters[i]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionMemberEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/FunctionMemberEntity.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.function_member_return_type(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.ReturnType));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/HashTableEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/HashTableEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.hash_table_key_value_pairs(this, index++, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, pair.Item1), EntityConstructor.ConstructAppropriateEntity(PowerShellContext, pair.Item2));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IfStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IfStatementEntity.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.if_statement_else(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.ElseClause));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IndexExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/IndexExpressionEntity.cs
@@ -19,7 +19,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             var target = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Target);
             trapFile.index_expression(this, index, target, Fragment.NullConditional);
             trapFile.index_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/InvokeMemberExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/InvokeMemberExpressionEntity.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                     trapFile.invoke_member_expression_argument(this, index, entity);
                 }
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MemberExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MemberExpressionEntity.cs
@@ -20,7 +20,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             var member = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Member);
             trapFile.member_expression(this, expression, member, Fragment.NullConditional, Fragment.Static);
             trapFile.member_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MergingRedirectionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/MergingRedirectionEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.merging_redirection(this, Fragment.FromStream, Fragment.ToStream);
             trapFile.merging_redirection_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedAttributeArgumentEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedAttributeArgumentEntity.cs
@@ -18,7 +18,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             trapFile.named_attribute_argument(this, Fragment.ArgumentName,
                 EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Argument));
             trapFile.named_attribute_argument_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NamedBlockEntity.cs
@@ -25,7 +25,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.named_block_trap(this, index, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Traps[index]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NotImplementedEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/NotImplementedEntity.cs
@@ -18,7 +18,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.not_implemented(this, type.FullName ?? type.Name);
             trapFile.not_implemented_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParamBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParamBlockEntity.cs
@@ -28,7 +28,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.param_block_parameter(this, i,
                     EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parameters[i]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParameterEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParameterEntity.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 var entity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.DefaultValue);
                 trapFile.parameter_default_value(this, entity);
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParenExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ParenExpressionEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.paren_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
             trapFile.paren_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineChainEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineChainEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.pipeline_chain(this, Fragment.Background, Fragment.Operator, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.LhsPipelineChain), EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.RhsPipeline));
             trapFile.pipeline_chain_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PipelineEntity.cs
@@ -15,6 +15,11 @@ namespace Semmle.Extraction.PowerShell.Entities
         public PipelineAst Fragment => Symbol.Item1;
         public override void Populate(TextWriter trapFile)
         {
+            // If there is just one element we don't want to include it in the database.
+            if (Fragment.PipelineElements.Count == 1)
+            {
+                return;
+            }
             trapFile.pipeline(this, Fragment.PipelineElements.Count);
             trapFile.pipeline_location(this, TrapSuitableLocation);
             for (var index = 0; index < Fragment.PipelineElements.Count; index++)
@@ -22,13 +27,17 @@ namespace Semmle.Extraction.PowerShell.Entities
                 var subEntity = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.PipelineElements[index]);
                 trapFile.pipeline_component(this, index, subEntity);
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);   
         }
 
         public override bool NeedsPopulation => true;
 
         public override void WriteId(EscapingTextWriter trapFile)
         {
+            if(Fragment.PipelineElements.Count == 1)
+            {
+                return;
+            }
             trapFile.WriteSubId(TrapSuitableLocation);
             trapFile.Write(";pipeline");
         }

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PropertyMemberEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/PropertyMemberEntity.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.property_member_initial_value(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.InitialValue));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ReturnStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ReturnStatementEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.return_statement_pipeline(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
             }
             trapFile.return_statement_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockEntity.cs
@@ -91,7 +91,7 @@ namespace Semmle.Extraction.PowerShell.Entities
 
             if (Fragment.Parent is not null)
             {
-                trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+                trapFile.parent(PowerShellContext, this, Fragment.Parent);
             }
         }
 

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockExpressionEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.script_block_expression(this, ScriptBlockEntity.Create(PowerShellContext, Fragment.ScriptBlock));
             trapFile.script_block_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StatementBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StatementBlockEntity.cs
@@ -33,7 +33,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 }
             }
             
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StringConstantExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/StringConstantExpressionEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.string_constant_expression(this, StringLiteralEntity.Create(PowerShellContext, ReportingLocation, Fragment.Value));
             trapFile.string_constant_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SubExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SubExpressionEntity.cs
@@ -19,7 +19,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             var subExpression = EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.SubExpression);
             trapFile.sub_expression(this, subExpression);
             trapFile.sub_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SwitchStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/SwitchStatementEntity.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.label(this, Fragment.Label);
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TernaryExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TernaryExpressionEntity.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.PowerShell.Entities
 
             trapFile.ternary_expression(this, condition, ifFalse, ifTrue);
             trapFile.ternary_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ThrowStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ThrowStatementEntity.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.throw_statement_pipeline(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Pipeline));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TrapStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TrapStatementEntity.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             }
 
             trapFile.trap_statement_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TryStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TryStatementEntity.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 trapFile.try_statement_finally(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Finally));
             }
             trapFile.try_statement_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeConstraintEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeConstraintEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.type_constraint(this, Fragment.TypeName.Name ?? string.Empty, Fragment.TypeName.FullName ?? string.Empty);
             trapFile.type_constraint_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeDefinitionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeDefinitionEntity.cs
@@ -30,7 +30,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.type_definition_base_type(this, index, TypeConstraintEntity.Create(PowerShellContext, Fragment.BaseTypes[index]));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/TypeExpressionEntity.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.type_expression(this, Fragment.TypeName.Name, Fragment.TypeName.FullName);
             trapFile.type_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UnaryExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UnaryExpressionEntity.cs
@@ -16,7 +16,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.unary_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Child), Fragment.TokenKind, Fragment.StaticType.Name);
             trapFile.unary_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingExpressionEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingExpressionEntity.cs
@@ -16,7 +16,7 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
             trapFile.using_expression(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.SubExpression));
             trapFile.using_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/UsingStatementEntity.cs
@@ -28,7 +28,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.using_statement_module_specification(this, HashtableEntity.Create(PowerShellContext, Fragment.ModuleSpecification));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/VariableExpressionAst.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/VariableExpressionAst.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.PowerShell.Entities
                 Fragment.VariablePath.IsUnscopedVariable, Fragment.VariablePath.IsVariable,
                 Fragment.VariablePath.IsDriveQualified);
             trapFile.variable_expression_location(this, TrapSuitableLocation);
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/WhileStatementEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/WhileStatementEntity.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.PowerShell.Entities
             {
                 trapFile.while_statement_condition(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Condition));
             }
-            trapFile.parent(this, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, Fragment.Parent));
+            trapFile.parent(PowerShellContext, this, Fragment.Parent);
         }
 
         public override bool NeedsPopulation => true;

--- a/powershell/extractor/Semmle.Extraction.PowerShell/EntityConstructor.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/EntityConstructor.cs
@@ -6,6 +6,18 @@ namespace Semmle.Extraction.PowerShell;
 
 public static class EntityConstructor
 {
+    private static Entity CreatePipelineEntity(PowerShellContext powerShellContext, PipelineAst pipelineAst)
+    {
+        if (pipelineAst.PipelineElements.Count == 1)
+        {
+            return ConstructAppropriateEntity(powerShellContext, pipelineAst.PipelineElements[0]);
+        }
+        else
+        {
+            return PipelineEntity.Create(powerShellContext, pipelineAst);
+        }
+    }
+    
     public static Entity ConstructAppropriateEntity(PowerShellContext powerShellContext, Ast ast)
     {
         return ast switch
@@ -24,7 +36,7 @@ public static class EntityConstructor
             MemberExpressionAst memberExpressionAst => MemberExpressionEntity.Create(powerShellContext, memberExpressionAst),
             NamedBlockAst namedBlockAst => NamedBlockEntity.Create(powerShellContext, namedBlockAst),
             ParenExpressionAst parenExpressionAst => ParenExpressionEntity.Create(powerShellContext, parenExpressionAst),
-            PipelineAst pipelineAst => PipelineEntity.Create(powerShellContext, pipelineAst),
+            PipelineAst pipelineAst => CreatePipelineEntity(powerShellContext, pipelineAst),
             ScriptBlockAst scriptBlockAst => ScriptBlockEntity.Create(powerShellContext, scriptBlockAst),
             StatementBlockAst statementBlockAst => StatementBlockEntity.Create(powerShellContext, statementBlockAst),
             StringConstantExpressionAst stringConstantExpressionAst => StringConstantExpressionEntity.Create(powerShellContext, stringConstantExpressionAst),

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Tuples.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Tuples.cs
@@ -411,9 +411,17 @@ namespace Semmle.Extraction.PowerShell
             trapFile.WriteTuple("command_parameter_location", commandParameterEntity, location);
         }
         
-        internal static void parent(this TextWriter trapFile, Entity parent, Entity child)
+        internal static void parent(this TextWriter trapFile, PowerShellContext PowerShellContext, Entity child, Ast parent)
         {
-            trapFile.WriteTuple("parent", parent, child);
+            switch(parent)
+            {
+                case PipelineAst pipelineAst when pipelineAst.PipelineElements.Count == 1:
+                    trapFile.parent(PowerShellContext, child, parent.Parent);
+                    break;
+                default:
+                    trapFile.WriteTuple("parent", child, EntityConstructor.ConstructAppropriateEntity(PowerShellContext, parent));
+                    break;
+            }
         }
         internal static void binary_expression(this TextWriter trapFile, BinaryExpressionEntity binaryExpressionEntity, TokenKind operation, Entity left, Entity right)
         {

--- a/powershell/ql/lib/semmle/code/powershell/ThrowStmt.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ThrowStmt.qll
@@ -7,7 +7,7 @@ class ThrowStmt extends @throw_statement, Stmt {
     if this.hasPipeline() then result = "throw ..." else result = "throw"
   }
 
-  Pipeline getPipeline() { throw_statement_pipeline(this, result) }
+  PipelineBase getPipeline() { throw_statement_pipeline(this, result) }
 
   predicate hasPipeline() { exists(this.getPipeline()) }
 }

--- a/powershell/ql/lib/semmlecode.powershell.dbscheme
+++ b/powershell/ql/lib/semmlecode.powershell.dbscheme
@@ -82,7 +82,7 @@ parent(
 // https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
 @command_base = @command | @command_expression;
 // https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
-@chainable = @pipeline | @pipeline_chain;
+@chainable = @command_base | @pipeline | @pipeline_chain;
 //https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
 @pipeline_base = @chainable | @error_statement | @assignment_statement;
 // https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0

--- a/powershell/ql/lib/upgrades/d8eb95bd91979583b569cdd50de46c59210f2aa9/old.dbscheme
+++ b/powershell/ql/lib/upgrades/d8eb95bd91979583b569cdd50de46c59210f2aa9/old.dbscheme
@@ -1,0 +1,1648 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/ql/lib/upgrades/d8eb95bd91979583b569cdd50de46c59210f2aa9/semmlecode.powershell.dbscheme
+++ b/powershell/ql/lib/upgrades/d8eb95bd91979583b569cdd50de46c59210f2aa9/semmlecode.powershell.dbscheme
@@ -1,0 +1,1648 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @command_base | @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/ql/lib/upgrades/d8eb95bd91979583b569cdd50de46c59210f2aa9/upgrade.properties
+++ b/powershell/ql/lib/upgrades/d8eb95bd91979583b569cdd50de46c59210f2aa9/upgrade.properties
@@ -1,0 +1,2 @@
+description: Remove Pipelines with one element.
+compatibility: partial

--- a/powershell/ql/test/library-tests/ast/Statements/statements.expected
+++ b/powershell/ql/test/library-tests/ast/Statements/statements.expected
@@ -1,38 +1,24 @@
 | ExitStatement.ps1:1:1:1:8 | exit ... |
 | ExitStatement.ps1:1:6:1:8 | -1 |
-| ExitStatement.ps1:1:6:1:8 | -1 |
 | IfStatement.ps1:1:1:1:7 | ...=... |
 | IfStatement.ps1:1:6:1:7 | 4 |
 | IfStatement.ps1:3:1:8:2 | if (...) {...} else {...} |
 | IfStatement.ps1:3:5:3:13 | ... -ge ... |
-| IfStatement.ps1:3:5:3:13 | ... -ge ... |
 | IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 |
-| IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 |
-| IfStatement.ps1:7:2:7:21 | $x is less than 3 |
 | IfStatement.ps1:7:2:7:21 | $x is less than 3 |
 | TrapStatement.ps1:1:1:4:2 | TrapTest |
 | TrapStatement.ps1:2:5:2:26 | TrapStatement at: TrapStatement.ps1:2:5:2:26 |
 | TrapStatement.ps1:2:11:2:25 | Error found. |
-| TrapStatement.ps1:2:11:2:25 | Error found. |
 | TrapStatement.ps1:3:5:3:19 | nonsenseString |
-| TrapStatement.ps1:3:5:3:19 | nonsenseString |
-| TrapStatement.ps1:6:1:6:9 | TrapTest |
 | TrapStatement.ps1:6:1:6:9 | TrapTest |
 | Try.ps1:1:1:13:2 | try {...} |
 | Try.ps1:2:4:2:95 | ...=... |
 | Try.ps1:2:17:2:95 | New-Object |
-| Try.ps1:2:17:2:95 | New-Object |
-| Try.ps1:2:69:2:94 | ...,... |
 | Try.ps1:2:69:2:94 | ...,... |
 | Try.ps1:3:5:3:21 | throw ... |
 | Try.ps1:3:11:3:21 | Exception |
-| Try.ps1:3:11:3:21 | Exception |
-| Try.ps1:6:5:6:64 | Unable to download MyDoc.doc from http://www.contoso.com. |
 | Try.ps1:6:5:6:64 | Unable to download MyDoc.doc from http://www.contoso.com. |
 | Try.ps1:9:5:9:52 | An error occurred that could not be resolved. |
-| Try.ps1:9:5:9:52 | An error occurred that could not be resolved. |
-| Try.ps1:12:5:12:37 | The finally block is executed. |
 | Try.ps1:12:5:12:37 | The finally block is executed. |
 | UseProcessBlockForPipelineCommand.ps1:1:1:11:2 | Get-Number |
-| UseProcessBlockForPipelineCommand.ps1:10:5:10:12 | Number |
 | UseProcessBlockForPipelineCommand.ps1:10:5:10:12 | Number |

--- a/powershell/ql/test/library-tests/ast/parent.expected
+++ b/powershell/ql/test/library-tests/ast/parent.expected
@@ -26,7 +26,6 @@
 | Arrays/Arrays.ps1:5:1:5:37 | ...=... | Arrays/Arrays.ps1:1:1:15:15 | {...} |
 | Arrays/Arrays.ps1:5:11:5:21 | New-Object | Arrays/Arrays.ps1:5:11:5:37 | New-Object |
 | Arrays/Arrays.ps1:5:11:5:37 | New-Object | Arrays/Arrays.ps1:5:1:5:37 | ...=... |
-| Arrays/Arrays.ps1:5:11:5:37 | New-Object | Arrays/Arrays.ps1:5:11:5:37 | New-Object |
 | Arrays/Arrays.ps1:5:22:5:33 | object[,] | Arrays/Arrays.ps1:5:11:5:37 | New-Object |
 | Arrays/Arrays.ps1:5:34:5:35 | 2 | Arrays/Arrays.ps1:5:34:5:37 | ...,... |
 | Arrays/Arrays.ps1:5:34:5:37 | ...,... | Arrays/Arrays.ps1:5:11:5:37 | New-Object |
@@ -69,14 +68,12 @@
 | Arrays/Arrays.ps1:11:11:11:25 | @(...) | Arrays/Arrays.ps1:11:11:11:25 | @(...) |
 | Arrays/Arrays.ps1:11:13:11:16 | a | Arrays/Arrays.ps1:11:13:11:24 | ...,... |
 | Arrays/Arrays.ps1:11:13:11:24 | ...,... | Arrays/Arrays.ps1:11:13:11:24 | ...,... |
-| Arrays/Arrays.ps1:11:13:11:24 | ...,... | Arrays/Arrays.ps1:11:13:11:24 | ...,... |
 | Arrays/Arrays.ps1:11:13:11:24 | ...,... | Arrays/Arrays.ps1:11:13:11:24 | {...} |
 | Arrays/Arrays.ps1:11:13:11:24 | {...} | Arrays/Arrays.ps1:11:11:11:25 | @(...) |
 | Arrays/Arrays.ps1:11:17:11:20 | b | Arrays/Arrays.ps1:11:13:11:24 | ...,... |
 | Arrays/Arrays.ps1:11:21:11:24 | c | Arrays/Arrays.ps1:11:13:11:24 | ...,... |
 | Arrays/Arrays.ps1:12:1:12:8 | array3 | Arrays/Arrays.ps1:12:1:12:14 | count |
 | Arrays/Arrays.ps1:12:1:12:14 | count | Arrays/Arrays.ps1:1:1:15:15 | {...} |
-| Arrays/Arrays.ps1:12:1:12:14 | count | Arrays/Arrays.ps1:12:1:12:14 | count |
 | Arrays/Arrays.ps1:12:1:12:14 | count | Arrays/Arrays.ps1:12:1:12:14 | count |
 | Arrays/Arrays.ps1:12:9:12:14 | count | Arrays/Arrays.ps1:12:1:12:14 | count |
 | Arrays/Arrays.ps1:14:1:14:8 | array4 | Arrays/Arrays.ps1:14:1:14:44 | ...=... |
@@ -87,7 +84,6 @@
 | Arrays/Arrays.ps1:14:41:14:44 | @(...) | Arrays/Arrays.ps1:14:11:14:44 | [...]... |
 | Arrays/Arrays.ps1:15:1:15:8 | array4 | Arrays/Arrays.ps1:15:1:15:15 | call to Add |
 | Arrays/Arrays.ps1:15:1:15:15 | call to Add | Arrays/Arrays.ps1:1:1:15:15 | {...} |
-| Arrays/Arrays.ps1:15:1:15:15 | call to Add | Arrays/Arrays.ps1:15:1:15:15 | call to Add |
 | Arrays/Arrays.ps1:15:1:15:15 | call to Add | Arrays/Arrays.ps1:15:1:15:15 | call to Add |
 | Arrays/Arrays.ps1:15:9:15:12 | Add | Arrays/Arrays.ps1:15:1:15:15 | call to Add |
 | Arrays/Arrays.ps1:15:13:15:14 | 1 | Arrays/Arrays.ps1:15:1:15:15 | call to Add |
@@ -104,25 +100,20 @@
 | Dynamic/DynamicExecution.ps1:1:8:1:17 | cmd.exe | Dynamic/DynamicExecution.ps1:1:8:1:17 | cmd.exe |
 | Dynamic/DynamicExecution.ps1:2:1:2:18 | Invoke-Expression | Dynamic/DynamicExecution.ps1:2:1:2:23 | Invoke-Expression |
 | Dynamic/DynamicExecution.ps1:2:1:2:23 | Invoke-Expression | Dynamic/DynamicExecution.ps1:1:1:5:8 | {...} |
-| Dynamic/DynamicExecution.ps1:2:1:2:23 | Invoke-Expression | Dynamic/DynamicExecution.ps1:2:1:2:23 | Invoke-Expression |
 | Dynamic/DynamicExecution.ps1:2:19:2:23 | foo | Dynamic/DynamicExecution.ps1:2:1:2:23 | Invoke-Expression |
 | Dynamic/DynamicExecution.ps1:3:1:3:14 | scriptblock | Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create |
 | Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create | Dynamic/DynamicExecution.ps1:1:1:5:8 | {...} |
 | Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create | Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create |
-| Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create | Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create |
 | Dynamic/DynamicExecution.ps1:3:16:3:22 | Create | Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create |
 | Dynamic/DynamicExecution.ps1:3:23:3:27 | foo | Dynamic/DynamicExecution.ps1:3:1:3:28 | call to Create |
 | Dynamic/DynamicExecution.ps1:4:1:4:32 |  | Dynamic/DynamicExecution.ps1:1:1:5:8 | {...} |
-| Dynamic/DynamicExecution.ps1:4:1:4:32 |  | Dynamic/DynamicExecution.ps1:4:1:4:32 |  |
 | Dynamic/DynamicExecution.ps1:4:3:4:32 | (...) | Dynamic/DynamicExecution.ps1:4:1:4:32 |  |
 | Dynamic/DynamicExecution.ps1:4:4:4:17 | scriptblock | Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create |
 | Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create | Dynamic/DynamicExecution.ps1:4:3:4:32 | (...) |
 | Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create | Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create |
-| Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create | Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create |
 | Dynamic/DynamicExecution.ps1:4:19:4:25 | Create | Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create |
 | Dynamic/DynamicExecution.ps1:4:26:4:30 | foo | Dynamic/DynamicExecution.ps1:4:4:4:31 | call to Create |
 | Dynamic/DynamicExecution.ps1:5:1:5:8 |  | Dynamic/DynamicExecution.ps1:1:1:5:8 | {...} |
-| Dynamic/DynamicExecution.ps1:5:1:5:8 |  | Dynamic/DynamicExecution.ps1:5:1:5:8 |  |
 | Dynamic/DynamicExecution.ps1:5:2:5:8 | $foo | Dynamic/DynamicExecution.ps1:5:1:5:8 |  |
 | Dynamic/DynamicExecution.ps1:5:3:5:7 | foo | Dynamic/DynamicExecution.ps1:5:2:5:8 | $foo |
 | Dynamic/DynamicExecutionWithFunc.ps1:1:1:11:2 | ExecuteAThing | Dynamic/DynamicExecutionWithFunc.ps1:1:1:11:2 | {...} |
@@ -139,32 +130,25 @@
 | Dynamic/DynamicExecutionWithFunc.ps1:5:24:5:34 | userInput | Dynamic/DynamicExecutionWithFunc.ps1:5:12:5:34 | ...+... |
 | Dynamic/DynamicExecutionWithFunc.ps1:6:5:6:22 | Invoke-Expression | Dynamic/DynamicExecutionWithFunc.ps1:6:5:6:27 | Invoke-Expression |
 | Dynamic/DynamicExecutionWithFunc.ps1:6:5:6:27 | Invoke-Expression | Dynamic/DynamicExecutionWithFunc.ps1:2:5:10:30 | {...} |
-| Dynamic/DynamicExecutionWithFunc.ps1:6:5:6:27 | Invoke-Expression | Dynamic/DynamicExecutionWithFunc.ps1:6:5:6:27 | Invoke-Expression |
 | Dynamic/DynamicExecutionWithFunc.ps1:6:23:6:27 | foo | Dynamic/DynamicExecutionWithFunc.ps1:6:5:6:27 | Invoke-Expression |
 | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:18 | scriptblock | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create | Dynamic/DynamicExecutionWithFunc.ps1:2:5:10:30 | {...} |
 | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create |
-| Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:7:20:7:26 | Create | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:7:27:7:31 | foo | Dynamic/DynamicExecutionWithFunc.ps1:7:5:7:32 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:8:5:8:36 |  | Dynamic/DynamicExecutionWithFunc.ps1:2:5:10:30 | {...} |
-| Dynamic/DynamicExecutionWithFunc.ps1:8:5:8:36 |  | Dynamic/DynamicExecutionWithFunc.ps1:8:5:8:36 |  |
 | Dynamic/DynamicExecutionWithFunc.ps1:8:7:8:36 | (...) | Dynamic/DynamicExecutionWithFunc.ps1:8:5:8:36 |  |
 | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:21 | scriptblock | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create | Dynamic/DynamicExecutionWithFunc.ps1:8:7:8:36 | (...) |
 | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create |
-| Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:8:23:8:29 | Create | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:8:30:8:34 | foo | Dynamic/DynamicExecutionWithFunc.ps1:8:8:8:35 | call to Create |
 | Dynamic/DynamicExecutionWithFunc.ps1:9:5:9:12 |  | Dynamic/DynamicExecutionWithFunc.ps1:2:5:10:30 | {...} |
-| Dynamic/DynamicExecutionWithFunc.ps1:9:5:9:12 |  | Dynamic/DynamicExecutionWithFunc.ps1:9:5:9:12 |  |
 | Dynamic/DynamicExecutionWithFunc.ps1:9:6:9:12 | $foo | Dynamic/DynamicExecutionWithFunc.ps1:9:5:9:12 |  |
 | Dynamic/DynamicExecutionWithFunc.ps1:9:7:9:11 | foo | Dynamic/DynamicExecutionWithFunc.ps1:9:6:9:12 | $foo |
 | Dynamic/DynamicExecutionWithFunc.ps1:10:5:10:30 | cmd.exe | Dynamic/DynamicExecutionWithFunc.ps1:2:5:10:30 | {...} |
-| Dynamic/DynamicExecutionWithFunc.ps1:10:5:10:30 | cmd.exe | Dynamic/DynamicExecutionWithFunc.ps1:10:5:10:30 | cmd.exe |
 | Dynamic/DynamicExecutionWithFunc.ps1:10:7:10:16 | cmd.exe | Dynamic/DynamicExecutionWithFunc.ps1:10:5:10:30 | cmd.exe |
 | Dynamic/DynamicExecutionWithFunc.ps1:10:17:10:30 | @(...) | Dynamic/DynamicExecutionWithFunc.ps1:10:5:10:30 | cmd.exe |
-| Dynamic/DynamicExecutionWithFunc.ps1:10:19:10:29 | userInput | Dynamic/DynamicExecutionWithFunc.ps1:10:19:10:29 | userInput |
 | Dynamic/DynamicExecutionWithFunc.ps1:10:19:10:29 | userInput | Dynamic/DynamicExecutionWithFunc.ps1:10:19:10:29 | userInput |
 | Dynamic/DynamicExecutionWithFunc.ps1:10:19:10:29 | userInput | Dynamic/DynamicExecutionWithFunc.ps1:10:19:10:29 | {...} |
 | Dynamic/DynamicExecutionWithFunc.ps1:10:19:10:29 | {...} | Dynamic/DynamicExecutionWithFunc.ps1:10:17:10:30 | @(...) |
@@ -185,24 +169,20 @@
 | Expressions/BinaryExpression.ps1:3:19:3:24 | val2 | Expressions/BinaryExpression.ps1:3:11:3:24 | ...+... |
 | Expressions/BinaryExpression.ps1:4:1:4:8 | result | Expressions/BinaryExpression.ps1:1:1:4:8 | {...} |
 | Expressions/BinaryExpression.ps1:4:1:4:8 | result | Expressions/BinaryExpression.ps1:4:1:4:8 | result |
-| Expressions/BinaryExpression.ps1:4:1:4:8 | result | Expressions/BinaryExpression.ps1:4:1:4:8 | result |
 | Expressions/ConvertWithSecureString.ps1:1:1:1:11 | UserInput | Expressions/ConvertWithSecureString.ps1:1:1:1:55 | ...=... |
 | Expressions/ConvertWithSecureString.ps1:1:1:1:55 | ...=... | Expressions/ConvertWithSecureString.ps1:1:1:2:80 | {...} |
 | Expressions/ConvertWithSecureString.ps1:1:1:2:80 | {...} | Expressions/ConvertWithSecureString.ps1:1:1:2:80 | ConvertWithSecureString.ps1 |
 | Expressions/ConvertWithSecureString.ps1:1:14:1:23 | Read-Host | Expressions/ConvertWithSecureString.ps1:1:14:1:55 | Read-Host |
 | Expressions/ConvertWithSecureString.ps1:1:14:1:55 | Read-Host | Expressions/ConvertWithSecureString.ps1:1:1:1:55 | ...=... |
-| Expressions/ConvertWithSecureString.ps1:1:14:1:55 | Read-Host | Expressions/ConvertWithSecureString.ps1:1:14:1:55 | Read-Host |
 | Expressions/ConvertWithSecureString.ps1:1:24:1:55 | Please enter your secure code | Expressions/ConvertWithSecureString.ps1:1:14:1:55 | Read-Host |
 | Expressions/ConvertWithSecureString.ps1:2:1:2:16 | EncryptedInput | Expressions/ConvertWithSecureString.ps1:2:1:2:80 | ...=... |
 | Expressions/ConvertWithSecureString.ps1:2:1:2:80 | ...=... | Expressions/ConvertWithSecureString.ps1:1:1:2:80 | {...} |
 | Expressions/ConvertWithSecureString.ps1:2:19:2:41 | ConvertTo-SecureString | Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString |
 | Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString | Expressions/ConvertWithSecureString.ps1:2:1:2:80 | ...=... |
-| Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString | Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString |
 | Expressions/ConvertWithSecureString.ps1:2:42:2:49 | String | Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString |
 | Expressions/ConvertWithSecureString.ps1:2:50:2:60 | UserInput | Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString |
 | Expressions/ConvertWithSecureString.ps1:2:61:2:73 | AsPlainText | Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString |
 | Expressions/ConvertWithSecureString.ps1:2:74:2:80 | Force | Expressions/ConvertWithSecureString.ps1:2:19:2:80 | ConvertTo-SecureString |
-| Expressions/ExpandableString.ps1:1:1:1:40 | Date: $([DateTime]::Now)\nName: $name | Expressions/ExpandableString.ps1:1:1:1:40 | Date: $([DateTime]::Now)\nName: $name |
 | Expressions/ExpandableString.ps1:1:1:1:40 | Date: $([DateTime]::Now)\nName: $name | Expressions/ExpandableString.ps1:1:1:1:40 | Date: $([DateTime]::Now)\nName: $name |
 | Expressions/ExpandableString.ps1:1:1:1:40 | Date: $([DateTime]::Now)\nName: $name | Expressions/ExpandableString.ps1:1:1:1:40 | {...} |
 | Expressions/ExpandableString.ps1:1:1:1:40 | {...} | Expressions/ExpandableString.ps1:1:1:1:40 | ExpandableString.ps1 |
@@ -210,16 +190,13 @@
 | Expressions/ExpandableString.ps1:1:21:1:39 | $(...) | Expressions/ExpandableString.ps1:1:1:1:40 | Date: $([DateTime]::Now)\nName: $name |
 | Expressions/ExpandableString.ps1:1:23:1:33 | DateTime | Expressions/ExpandableString.ps1:1:23:1:38 | Now |
 | Expressions/ExpandableString.ps1:1:23:1:38 | Now | Expressions/ExpandableString.ps1:1:23:1:38 | Now |
-| Expressions/ExpandableString.ps1:1:23:1:38 | Now | Expressions/ExpandableString.ps1:1:23:1:38 | Now |
 | Expressions/ExpandableString.ps1:1:23:1:38 | Now | Expressions/ExpandableString.ps1:1:23:1:38 | {...} |
 | Expressions/ExpandableString.ps1:1:23:1:38 | {...} | Expressions/ExpandableString.ps1:1:21:1:39 | $(...) |
 | Expressions/ExpandableString.ps1:1:35:1:38 | Now | Expressions/ExpandableString.ps1:1:23:1:38 | Now |
 | Expressions/SubExpression.ps1:1:1:1:12 | $(...) | Expressions/SubExpression.ps1:1:1:1:24 | call to AddDays |
 | Expressions/SubExpression.ps1:1:1:1:24 | call to AddDays | Expressions/SubExpression.ps1:1:1:1:24 | call to AddDays |
-| Expressions/SubExpression.ps1:1:1:1:24 | call to AddDays | Expressions/SubExpression.ps1:1:1:1:24 | call to AddDays |
 | Expressions/SubExpression.ps1:1:1:1:24 | call to AddDays | Expressions/SubExpression.ps1:1:1:2:22 | {...} |
 | Expressions/SubExpression.ps1:1:1:2:22 | {...} | Expressions/SubExpression.ps1:1:1:2:22 | SubExpression.ps1 |
-| Expressions/SubExpression.ps1:1:3:1:11 | Get-Date | Expressions/SubExpression.ps1:1:3:1:11 | Get-Date |
 | Expressions/SubExpression.ps1:1:3:1:11 | Get-Date | Expressions/SubExpression.ps1:1:3:1:11 | Get-Date |
 | Expressions/SubExpression.ps1:1:3:1:11 | Get-Date | Expressions/SubExpression.ps1:1:3:1:11 | {...} |
 | Expressions/SubExpression.ps1:1:3:1:11 | {...} | Expressions/SubExpression.ps1:1:1:1:12 | $(...) |
@@ -228,8 +205,6 @@
 | Expressions/SubExpression.ps1:2:1:2:12 | $(...) | Expressions/SubExpression.ps1:2:1:2:22 | call to AddDays |
 | Expressions/SubExpression.ps1:2:1:2:22 | call to AddDays | Expressions/SubExpression.ps1:1:1:2:22 | {...} |
 | Expressions/SubExpression.ps1:2:1:2:22 | call to AddDays | Expressions/SubExpression.ps1:2:1:2:22 | call to AddDays |
-| Expressions/SubExpression.ps1:2:1:2:22 | call to AddDays | Expressions/SubExpression.ps1:2:1:2:22 | call to AddDays |
-| Expressions/SubExpression.ps1:2:3:2:11 | Get-Date | Expressions/SubExpression.ps1:2:3:2:11 | Get-Date |
 | Expressions/SubExpression.ps1:2:3:2:11 | Get-Date | Expressions/SubExpression.ps1:2:3:2:11 | Get-Date |
 | Expressions/SubExpression.ps1:2:3:2:11 | Get-Date | Expressions/SubExpression.ps1:2:3:2:11 | {...} |
 | Expressions/SubExpression.ps1:2:3:2:11 | {...} | Expressions/SubExpression.ps1:2:1:2:12 | $(...) |
@@ -243,7 +218,6 @@
 | Expressions/TernaryExpression.ps1:1:9:1:10 | 6 | Expressions/TernaryExpression.ps1:1:9:1:16 | ... -gt ... |
 | Expressions/TernaryExpression.ps1:1:9:1:16 | ... -gt ... | Expressions/TernaryExpression.ps1:1:8:1:17 | (...) |
 | Expressions/TernaryExpression.ps1:1:9:1:16 | ... -gt ... | Expressions/TernaryExpression.ps1:1:9:1:16 | ... -gt ... |
-| Expressions/TernaryExpression.ps1:1:9:1:16 | ... -gt ... | Expressions/TernaryExpression.ps1:1:9:1:16 | ... -gt ... |
 | Expressions/TernaryExpression.ps1:1:15:1:16 | 7 | Expressions/TernaryExpression.ps1:1:9:1:16 | ... -gt ... |
 | Expressions/TernaryExpression.ps1:1:20:1:21 | 1 | Expressions/TernaryExpression.ps1:1:8:1:23 | ...?...:... |
 | Expressions/TernaryExpression.ps1:1:22:1:23 | 2 | Expressions/TernaryExpression.ps1:1:8:1:23 | ...?...:... |
@@ -252,22 +226,17 @@
 | Loops/DoUntil.ps1:2:1:7:2 | {...} | Loops/DoUntil.ps1:1:1:7:19 | DoUntil |
 | Loops/DoUntil.ps1:3:2:3:20 | Starting Loop $a | Loops/DoUntil.ps1:2:1:7:2 | {...} |
 | Loops/DoUntil.ps1:3:2:3:20 | Starting Loop $a | Loops/DoUntil.ps1:3:2:3:20 | Starting Loop $a |
-| Loops/DoUntil.ps1:3:2:3:20 | Starting Loop $a | Loops/DoUntil.ps1:3:2:3:20 | Starting Loop $a |
 | Loops/DoUntil.ps1:3:17:3:19 | a | Loops/DoUntil.ps1:3:2:3:20 | Starting Loop $a |
 | Loops/DoUntil.ps1:4:2:4:4 | a | Loops/DoUntil.ps1:2:1:7:2 | {...} |
-| Loops/DoUntil.ps1:4:2:4:4 | a | Loops/DoUntil.ps1:4:2:4:4 | a |
 | Loops/DoUntil.ps1:4:2:4:4 | a | Loops/DoUntil.ps1:4:2:4:4 | a |
 | Loops/DoUntil.ps1:5:2:5:4 | a | Loops/DoUntil.ps1:5:2:5:6 | ...++ |
 | Loops/DoUntil.ps1:5:2:5:6 | ...++ | Loops/DoUntil.ps1:2:1:7:2 | {...} |
 | Loops/DoUntil.ps1:5:2:5:6 | ...++ | Loops/DoUntil.ps1:5:2:5:6 | ...++ |
-| Loops/DoUntil.ps1:5:2:5:6 | ...++ | Loops/DoUntil.ps1:5:2:5:6 | ...++ |
 | Loops/DoUntil.ps1:6:2:6:17 | Now $a is $a | Loops/DoUntil.ps1:2:1:7:2 | {...} |
-| Loops/DoUntil.ps1:6:2:6:17 | Now $a is $a | Loops/DoUntil.ps1:6:2:6:17 | Now $a is $a |
 | Loops/DoUntil.ps1:6:2:6:17 | Now $a is $a | Loops/DoUntil.ps1:6:2:6:17 | Now $a is $a |
 | Loops/DoUntil.ps1:6:14:6:16 | a | Loops/DoUntil.ps1:6:2:6:17 | Now $a is $a |
 | Loops/DoUntil.ps1:7:10:7:12 | a | Loops/DoUntil.ps1:7:10:7:18 | ... -le ... |
 | Loops/DoUntil.ps1:7:10:7:18 | ... -le ... | Loops/DoUntil.ps1:1:1:7:19 | DoUntil |
-| Loops/DoUntil.ps1:7:10:7:18 | ... -le ... | Loops/DoUntil.ps1:7:10:7:18 | ... -le ... |
 | Loops/DoUntil.ps1:7:10:7:18 | ... -le ... | Loops/DoUntil.ps1:7:10:7:18 | ... -le ... |
 | Loops/DoUntil.ps1:7:17:7:18 | 5 | Loops/DoUntil.ps1:7:10:7:18 | ... -le ... |
 | Loops/DoWhile.ps1:1:1:7:19 | DoWhile | Loops/DoWhile.ps1:1:1:7:19 | {...} |
@@ -275,22 +244,17 @@
 | Loops/DoWhile.ps1:2:1:7:2 | {...} | Loops/DoWhile.ps1:1:1:7:19 | DoWhile |
 | Loops/DoWhile.ps1:3:2:3:20 | Starting Loop $a | Loops/DoWhile.ps1:2:1:7:2 | {...} |
 | Loops/DoWhile.ps1:3:2:3:20 | Starting Loop $a | Loops/DoWhile.ps1:3:2:3:20 | Starting Loop $a |
-| Loops/DoWhile.ps1:3:2:3:20 | Starting Loop $a | Loops/DoWhile.ps1:3:2:3:20 | Starting Loop $a |
 | Loops/DoWhile.ps1:3:17:3:19 | a | Loops/DoWhile.ps1:3:2:3:20 | Starting Loop $a |
 | Loops/DoWhile.ps1:4:2:4:4 | a | Loops/DoWhile.ps1:2:1:7:2 | {...} |
-| Loops/DoWhile.ps1:4:2:4:4 | a | Loops/DoWhile.ps1:4:2:4:4 | a |
 | Loops/DoWhile.ps1:4:2:4:4 | a | Loops/DoWhile.ps1:4:2:4:4 | a |
 | Loops/DoWhile.ps1:5:2:5:4 | a | Loops/DoWhile.ps1:5:2:5:6 | ...++ |
 | Loops/DoWhile.ps1:5:2:5:6 | ...++ | Loops/DoWhile.ps1:2:1:7:2 | {...} |
 | Loops/DoWhile.ps1:5:2:5:6 | ...++ | Loops/DoWhile.ps1:5:2:5:6 | ...++ |
-| Loops/DoWhile.ps1:5:2:5:6 | ...++ | Loops/DoWhile.ps1:5:2:5:6 | ...++ |
 | Loops/DoWhile.ps1:6:2:6:17 | Now $a is $a | Loops/DoWhile.ps1:2:1:7:2 | {...} |
-| Loops/DoWhile.ps1:6:2:6:17 | Now $a is $a | Loops/DoWhile.ps1:6:2:6:17 | Now $a is $a |
 | Loops/DoWhile.ps1:6:2:6:17 | Now $a is $a | Loops/DoWhile.ps1:6:2:6:17 | Now $a is $a |
 | Loops/DoWhile.ps1:6:14:6:16 | a | Loops/DoWhile.ps1:6:2:6:17 | Now $a is $a |
 | Loops/DoWhile.ps1:7:10:7:12 | a | Loops/DoWhile.ps1:7:10:7:18 | ... -le ... |
 | Loops/DoWhile.ps1:7:10:7:18 | ... -le ... | Loops/DoWhile.ps1:1:1:7:19 | DoWhile |
-| Loops/DoWhile.ps1:7:10:7:18 | ... -le ... | Loops/DoWhile.ps1:7:10:7:18 | ... -le ... |
 | Loops/DoWhile.ps1:7:10:7:18 | ... -le ... | Loops/DoWhile.ps1:7:10:7:18 | ... -le ... |
 | Loops/DoWhile.ps1:7:17:7:18 | 5 | Loops/DoWhile.ps1:7:10:7:18 | ... -le ... |
 | Loops/While.ps1:1:1:1:5 | var | Loops/While.ps1:1:1:1:9 | ...=... |
@@ -302,12 +266,10 @@
 | Loops/While.ps1:2:8:2:12 | var | Loops/While.ps1:2:8:2:18 | ... -le ... |
 | Loops/While.ps1:2:8:2:18 | ... -le ... | Loops/While.ps1:2:1:13:2 | while(...) {...} |
 | Loops/While.ps1:2:8:2:18 | ... -le ... | Loops/While.ps1:2:8:2:18 | ... -le ... |
-| Loops/While.ps1:2:8:2:18 | ... -le ... | Loops/While.ps1:2:8:2:18 | ... -le ... |
 | Loops/While.ps1:2:17:2:18 | 5 | Loops/While.ps1:2:8:2:18 | ... -le ... |
 | Loops/While.ps1:3:1:13:2 | {...} | Loops/While.ps1:2:1:13:2 | while(...) {...} |
 | Loops/While.ps1:4:5:4:15 | Write-Host | Loops/While.ps1:4:5:4:41 | Write-Host |
 | Loops/While.ps1:4:5:4:41 | Write-Host | Loops/While.ps1:3:1:13:2 | {...} |
-| Loops/While.ps1:4:5:4:41 | Write-Host | Loops/While.ps1:4:5:4:41 | Write-Host |
 | Loops/While.ps1:4:16:4:19 | The | Loops/While.ps1:4:5:4:41 | Write-Host |
 | Loops/While.ps1:4:20:4:25 | value | Loops/While.ps1:4:5:4:41 | Write-Host |
 | Loops/While.ps1:4:26:4:28 | of | Loops/While.ps1:4:5:4:41 | Write-Host |
@@ -317,11 +279,9 @@
 | Loops/While.ps1:5:5:5:9 | var | Loops/While.ps1:5:5:5:11 | ...++ |
 | Loops/While.ps1:5:5:5:11 | ...++ | Loops/While.ps1:3:1:13:2 | {...} |
 | Loops/While.ps1:5:5:5:11 | ...++ | Loops/While.ps1:5:5:5:11 | ...++ |
-| Loops/While.ps1:5:5:5:11 | ...++ | Loops/While.ps1:5:5:5:11 | ...++ |
 | Loops/While.ps1:6:5:12:6 | if (...) {...} else {...} | Loops/While.ps1:3:1:13:2 | {...} |
 | Loops/While.ps1:6:9:6:13 | var | Loops/While.ps1:6:9:6:19 | ... -le ... |
 | Loops/While.ps1:6:9:6:19 | ... -le ... | Loops/While.ps1:6:5:12:6 | if (...) {...} else {...} |
-| Loops/While.ps1:6:9:6:19 | ... -le ... | Loops/While.ps1:6:9:6:19 | ... -le ... |
 | Loops/While.ps1:6:9:6:19 | ... -le ... | Loops/While.ps1:6:9:6:19 | ... -le ... |
 | Loops/While.ps1:6:18:6:19 | 3 | Loops/While.ps1:6:9:6:19 | ... -le ... |
 | Loops/While.ps1:6:20:8:6 | {...} | Loops/While.ps1:6:5:12:6 | if (...) {...} else {...} |
@@ -329,11 +289,9 @@
 | Loops/While.ps1:10:5:12:6 | {...} | Loops/While.ps1:6:5:12:6 | if (...) {...} else {...} |
 | Loops/While.ps1:11:9:11:14 | break | Loops/While.ps1:10:5:12:6 | {...} |
 | Redirections/FileRedirection.ps1:1:1:3:2 | $(...) | Redirections/FileRedirection.ps1:1:1:3:20 | $(...) |
-| Redirections/FileRedirection.ps1:1:1:3:20 | $(...) | Redirections/FileRedirection.ps1:1:1:3:20 | $(...) |
 | Redirections/FileRedirection.ps1:1:1:3:20 | $(...) | Redirections/FileRedirection.ps1:1:1:3:20 | {...} |
 | Redirections/FileRedirection.ps1:1:1:3:20 | {...} | Redirections/FileRedirection.ps1:1:1:3:20 | FileRedirection.ps1 |
 | Redirections/FileRedirection.ps1:2:5:2:9 | Here | Redirections/FileRedirection.ps1:2:5:2:32 | Here |
-| Redirections/FileRedirection.ps1:2:5:2:32 | Here | Redirections/FileRedirection.ps1:2:5:2:32 | Here |
 | Redirections/FileRedirection.ps1:2:5:2:32 | Here | Redirections/FileRedirection.ps1:2:5:2:32 | {...} |
 | Redirections/FileRedirection.ps1:2:5:2:32 | {...} | Redirections/FileRedirection.ps1:1:1:3:2 | $(...) |
 | Redirections/FileRedirection.ps1:2:10:2:12 | is | Redirections/FileRedirection.ps1:2:5:2:32 | Here |
@@ -347,7 +305,6 @@
 | Statements/ExitStatement.ps1:1:1:1:8 | {...} | Statements/ExitStatement.ps1:1:1:1:8 | ExitStatement.ps1 |
 | Statements/ExitStatement.ps1:1:6:1:8 | -1 | Statements/ExitStatement.ps1:1:1:1:8 | exit ... |
 | Statements/ExitStatement.ps1:1:6:1:8 | -1 | Statements/ExitStatement.ps1:1:6:1:8 | -1 |
-| Statements/ExitStatement.ps1:1:6:1:8 | -1 | Statements/ExitStatement.ps1:1:6:1:8 | -1 |
 | Statements/IfStatement.ps1:1:1:1:3 | x | Statements/IfStatement.ps1:1:1:1:7 | ...=... |
 | Statements/IfStatement.ps1:1:1:1:7 | ...=... | Statements/IfStatement.ps1:1:1:8:2 | {...} |
 | Statements/IfStatement.ps1:1:1:8:2 | {...} | Statements/IfStatement.ps1:1:1:8:2 | IfStatement.ps1 |
@@ -357,16 +314,13 @@
 | Statements/IfStatement.ps1:3:5:3:7 | x | Statements/IfStatement.ps1:3:5:3:13 | ... -ge ... |
 | Statements/IfStatement.ps1:3:5:3:13 | ... -ge ... | Statements/IfStatement.ps1:3:1:8:2 | if (...) {...} else {...} |
 | Statements/IfStatement.ps1:3:5:3:13 | ... -ge ... | Statements/IfStatement.ps1:3:5:3:13 | ... -ge ... |
-| Statements/IfStatement.ps1:3:5:3:13 | ... -ge ... | Statements/IfStatement.ps1:3:5:3:13 | ... -ge ... |
 | Statements/IfStatement.ps1:3:12:3:13 | 3 | Statements/IfStatement.ps1:3:5:3:13 | ... -ge ... |
 | Statements/IfStatement.ps1:3:15:5:2 | {...} | Statements/IfStatement.ps1:3:1:8:2 | if (...) {...} else {...} |
 | Statements/IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 | Statements/IfStatement.ps1:3:15:5:2 | {...} |
 | Statements/IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 | Statements/IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 |
-| Statements/IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 | Statements/IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 |
 | Statements/IfStatement.ps1:4:3:4:5 | x | Statements/IfStatement.ps1:4:2:4:36 | $x is greater than or equal to 3 |
 | Statements/IfStatement.ps1:6:6:8:2 | {...} | Statements/IfStatement.ps1:3:1:8:2 | if (...) {...} else {...} |
 | Statements/IfStatement.ps1:7:2:7:21 | $x is less than 3 | Statements/IfStatement.ps1:6:6:8:2 | {...} |
-| Statements/IfStatement.ps1:7:2:7:21 | $x is less than 3 | Statements/IfStatement.ps1:7:2:7:21 | $x is less than 3 |
 | Statements/IfStatement.ps1:7:2:7:21 | $x is less than 3 | Statements/IfStatement.ps1:7:2:7:21 | $x is less than 3 |
 | Statements/IfStatement.ps1:7:3:7:5 | x | Statements/IfStatement.ps1:7:2:7:21 | $x is less than 3 |
 | Statements/TrapStatement.ps1:1:1:4:2 | TrapTest | Statements/TrapStatement.ps1:1:1:6:9 | {...} |
@@ -377,12 +331,9 @@
 | Statements/TrapStatement.ps1:2:10:2:26 | {...} | Statements/TrapStatement.ps1:2:5:2:26 | TrapStatement at: Statements/TrapStatement.ps1:2:5:2:26 |
 | Statements/TrapStatement.ps1:2:11:2:25 | Error found. | Statements/TrapStatement.ps1:2:10:2:26 | {...} |
 | Statements/TrapStatement.ps1:2:11:2:25 | Error found. | Statements/TrapStatement.ps1:2:11:2:25 | Error found. |
-| Statements/TrapStatement.ps1:2:11:2:25 | Error found. | Statements/TrapStatement.ps1:2:11:2:25 | Error found. |
 | Statements/TrapStatement.ps1:3:5:3:19 | nonsenseString | Statements/TrapStatement.ps1:2:5:3:19 | {...} |
 | Statements/TrapStatement.ps1:3:5:3:19 | nonsenseString | Statements/TrapStatement.ps1:3:5:3:19 | nonsenseString |
-| Statements/TrapStatement.ps1:3:5:3:19 | nonsenseString | Statements/TrapStatement.ps1:3:5:3:19 | nonsenseString |
 | Statements/TrapStatement.ps1:6:1:6:9 | TrapTest | Statements/TrapStatement.ps1:1:1:6:9 | {...} |
-| Statements/TrapStatement.ps1:6:1:6:9 | TrapTest | Statements/TrapStatement.ps1:6:1:6:9 | TrapTest |
 | Statements/TrapStatement.ps1:6:1:6:9 | TrapTest | Statements/TrapStatement.ps1:6:1:6:9 | TrapTest |
 | Statements/Try.ps1:1:1:13:2 | try {...} | Statements/Try.ps1:1:1:13:2 | {...} |
 | Statements/Try.ps1:1:1:13:2 | {...} | Statements/Try.ps1:1:1:13:2 | Try.ps1 |
@@ -391,13 +342,11 @@
 | Statements/Try.ps1:2:4:2:95 | ...=... | Statements/Try.ps1:1:5:4:2 | {...} |
 | Statements/Try.ps1:2:17:2:27 | New-Object | Statements/Try.ps1:2:17:2:95 | New-Object |
 | Statements/Try.ps1:2:17:2:95 | New-Object | Statements/Try.ps1:2:4:2:95 | ...=... |
-| Statements/Try.ps1:2:17:2:95 | New-Object | Statements/Try.ps1:2:17:2:95 | New-Object |
 | Statements/Try.ps1:2:28:2:53 | System.Xaml.XamlException | Statements/Try.ps1:2:17:2:95 | New-Object |
 | Statements/Try.ps1:2:54:2:67 | ArgumentList | Statements/Try.ps1:2:17:2:95 | New-Object |
 | Statements/Try.ps1:2:68:2:95 | (...) | Statements/Try.ps1:2:17:2:95 | New-Object |
 | Statements/Try.ps1:2:69:2:80 | Bad XAML! | Statements/Try.ps1:2:69:2:94 | ...,... |
 | Statements/Try.ps1:2:69:2:94 | ...,... | Statements/Try.ps1:2:68:2:95 | (...) |
-| Statements/Try.ps1:2:69:2:94 | ...,... | Statements/Try.ps1:2:69:2:94 | ...,... |
 | Statements/Try.ps1:2:69:2:94 | ...,... | Statements/Try.ps1:2:69:2:94 | ...,... |
 | Statements/Try.ps1:2:82:2:87 | null | Statements/Try.ps1:2:69:2:94 | ...,... |
 | Statements/Try.ps1:2:89:2:91 | 10 | Statements/Try.ps1:2:69:2:94 | ...,... |
@@ -405,22 +354,18 @@
 | Statements/Try.ps1:3:5:3:21 | throw ... | Statements/Try.ps1:1:5:4:2 | {...} |
 | Statements/Try.ps1:3:11:3:21 | Exception | Statements/Try.ps1:3:5:3:21 | throw ... |
 | Statements/Try.ps1:3:11:3:21 | Exception | Statements/Try.ps1:3:11:3:21 | Exception |
-| Statements/Try.ps1:3:11:3:21 | Exception | Statements/Try.ps1:3:11:3:21 | Exception |
 | Statements/Try.ps1:5:1:7:2 | catch[...] {...} | Statements/Try.ps1:1:1:13:2 | try {...} |
 | Statements/Try.ps1:5:7:5:32 | System.Net.WebException | Statements/Try.ps1:5:1:7:2 | catch[...] {...} |
 | Statements/Try.ps1:5:33:5:56 | System.IO.IOException | Statements/Try.ps1:5:1:7:2 | catch[...] {...} |
 | Statements/Try.ps1:5:57:7:2 | {...} | Statements/Try.ps1:5:1:7:2 | catch[...] {...} |
 | Statements/Try.ps1:6:5:6:64 | Unable to download MyDoc.doc from http://www.contoso.com. | Statements/Try.ps1:5:57:7:2 | {...} |
 | Statements/Try.ps1:6:5:6:64 | Unable to download MyDoc.doc from http://www.contoso.com. | Statements/Try.ps1:6:5:6:64 | Unable to download MyDoc.doc from http://www.contoso.com. |
-| Statements/Try.ps1:6:5:6:64 | Unable to download MyDoc.doc from http://www.contoso.com. | Statements/Try.ps1:6:5:6:64 | Unable to download MyDoc.doc from http://www.contoso.com. |
 | Statements/Try.ps1:8:1:10:2 | catch {...} | Statements/Try.ps1:1:1:13:2 | try {...} |
 | Statements/Try.ps1:8:7:10:2 | {...} | Statements/Try.ps1:8:1:10:2 | catch {...} |
 | Statements/Try.ps1:9:5:9:52 | An error occurred that could not be resolved. | Statements/Try.ps1:8:7:10:2 | {...} |
 | Statements/Try.ps1:9:5:9:52 | An error occurred that could not be resolved. | Statements/Try.ps1:9:5:9:52 | An error occurred that could not be resolved. |
-| Statements/Try.ps1:9:5:9:52 | An error occurred that could not be resolved. | Statements/Try.ps1:9:5:9:52 | An error occurred that could not be resolved. |
 | Statements/Try.ps1:11:9:13:2 | {...} | Statements/Try.ps1:1:1:13:2 | try {...} |
 | Statements/Try.ps1:12:5:12:37 | The finally block is executed. | Statements/Try.ps1:11:9:13:2 | {...} |
-| Statements/Try.ps1:12:5:12:37 | The finally block is executed. | Statements/Try.ps1:12:5:12:37 | The finally block is executed. |
 | Statements/Try.ps1:12:5:12:37 | The finally block is executed. | Statements/Try.ps1:12:5:12:37 | The finally block is executed. |
 | Statements/UseProcessBlockForPipelineCommand.ps1:1:1:11:2 | Get-Number | Statements/UseProcessBlockForPipelineCommand.ps1:1:1:11:2 | {...} |
 | Statements/UseProcessBlockForPipelineCommand.ps1:1:1:11:2 | {...} | Statements/UseProcessBlockForPipelineCommand.ps1:1:1:11:2 | UseProcessBlockForPipelineCommand.ps1 |
@@ -434,7 +379,6 @@
 | Statements/UseProcessBlockForPipelineCommand.ps1:5:20:5:37 | True | Statements/UseProcessBlockForPipelineCommand.ps1:5:20:5:37 | True |
 | Statements/UseProcessBlockForPipelineCommand.ps1:6:9:6:14 | int | Statements/UseProcessBlockForPipelineCommand.ps1:5:9:7:16 | Number |
 | Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:12 | Number | Statements/UseProcessBlockForPipelineCommand.ps1:4:5:10:12 | {...} |
-| Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:12 | Number | Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:12 | Number |
 | Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:12 | Number | Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:12 | Number |
 | file://:0:0:0:0 | (no string representation) | Blocks/ParamBlock.ps1:3:5:4:23 | Parameter |
 | file://:0:0:0:0 | (no string representation) | Dynamic/DynamicExecutionWithFunc.ps1:3:9:3:19 | userInput |

--- a/powershell/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/powershell/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -32,9 +32,6 @@ conditionals.ps1:
 #-----|  -> myBool
 
 #    4| myBool
-#-----|  -> myBool
-
-#    4| myBool
 #-----| true -> {...}
 
 #    4| myBool
@@ -58,9 +55,6 @@ conditionals.ps1:
 #-----|  -> if (...) {...} else {...}
 
 #   14| if (...) {...} else {...}
-#-----|  -> myBool
-
-#   14| myBool
 #-----|  -> myBool
 
 #   14| myBool
@@ -96,13 +90,10 @@ conditionals.ps1:
 #-----| false, true -> myBool2
 
 #   27| ... -and ...
-#-----|  -> myBool1
-
-#   27| ... -and ...
 #-----| true -> {...}
 
 #   27| ... -and ...
-#-----|  -> ... -and ...
+#-----|  -> myBool1
 
 #   27| myBool2
 #-----| false, true -> ... -and ...
@@ -131,14 +122,11 @@ conditionals.ps1:
 #-----| false, true -> myBool2
 
 #   37| ... -and ...
-#-----|  -> myBool1
-
-#   37| ... -and ...
 #-----| true -> {...}
 #-----| false -> {...}
 
 #   37| ... -and ...
-#-----|  -> ... -and ...
+#-----|  -> myBool1
 
 #   37| myBool2
 #-----| false, true -> ... -and ...
@@ -169,13 +157,10 @@ conditionals.ps1:
 #-----| false, true -> myBool2
 
 #   50| ... -or ...
-#-----|  -> myBool1
-
-#   50| ... -or ...
 #-----| true -> {...}
 
 #   50| ... -or ...
-#-----|  -> ... -or ...
+#-----|  -> myBool1
 
 #   50| myBool2
 #-----| false, true -> ... -or ...
@@ -204,14 +189,11 @@ conditionals.ps1:
 #-----| false, true -> myBool2
 
 #   60| ... -or ...
-#-----|  -> myBool1
-
-#   60| ... -or ...
 #-----| true -> {...}
 #-----| false -> {...}
 
 #   60| ... -or ...
-#-----|  -> ... -or ...
+#-----|  -> myBool1
 
 #   60| myBool2
 #-----| false, true -> ... -or ...
@@ -236,9 +218,6 @@ conditionals.ps1:
 #-----|  -> if (...) {...}
 
 #   73| if (...) {...}
-#-----|  -> myBool1
-
-#   73| myBool1
 #-----|  -> myBool1
 
 #   73| myBool1
@@ -268,9 +247,6 @@ conditionals.ps1:
 #-----|  -> myBool1
 
 #   87| myBool1
-#-----|  -> myBool1
-
-#   87| myBool1
 #-----| true -> {...}
 #-----| false -> {...}
 
@@ -297,9 +273,6 @@ conditionals.ps1:
 #-----|  -> switch(...) {...}
 
 #  102| n
-#-----|  -> n
-
-#  102| n
 
 #  102| n
 #-----|  -> n
@@ -318,9 +291,6 @@ conditionals.ps1:
 
 #  111| {...}
 #-----|  -> switch(...) {...}
-
-#  111| n
-#-----|  -> n
 
 #  111| n
 
@@ -346,9 +316,6 @@ conditionals.ps1:
 #-----|  -> ...=...
 
 #  124| switch(...) {...}
-#-----|  -> n
-
-#  124| n
 #-----|  -> n
 
 #  124| n
@@ -395,13 +362,10 @@ functions.ps1:
 #-----|  -> number2
 
 #    8| ...+...
-#-----|  -> number1
-
-#    8| ...+...
 #-----|  -> exit {...} (normal)
 
 #    8| ...+...
-#-----|  -> ...+...
+#-----|  -> number1
 
 #    8| number2
 #-----|  -> ...+...
@@ -462,13 +426,10 @@ functions.ps1:
 #-----|  -> name2
 
 #   19| ...+...
-#-----|  -> name
-
-#   19| ...+...
 #-----|  -> exit {...} (normal)
 
 #   19| ...+...
-#-----|  -> ...+...
+#-----|  -> name
 
 #   19| name2
 #-----|  -> ...+...
@@ -513,9 +474,6 @@ functions.ps1:
 #-----|  -> {...}
 
 #   29| numbers
-#-----|  -> numbers
-
-#   29| numbers
 #-----|  -> forach(... in ...)
 
 #   29| numbers
@@ -535,9 +493,6 @@ functions.ps1:
 
 #   31| number
 #-----|  -> number
-
-#   33| sum
-#-----|  -> sum
 
 #   33| sum
 #-----|  -> exit {...} (normal)
@@ -594,9 +549,6 @@ functions.ps1:
 #-----|  -> _
 
 #   48| {...}
-#-----|  -> sum
-
-#   50| sum
 #-----|  -> sum
 
 #   50| sum
@@ -716,14 +668,11 @@ loops.ps1:
 #-----|  -> 10
 
 #    4| ... -le ...
-#-----|  -> a
-
-#    4| ... -le ...
 #-----| false -> exit {...} (normal)
 #-----| true -> {...}
 
 #    4| ... -le ...
-#-----|  -> ... -le ...
+#-----|  -> a
 
 #    4| 10
 #-----|  -> ... -le ...
@@ -785,14 +734,11 @@ loops.ps1:
 #-----|  -> 10
 
 #   11| ... -le ...
-#-----|  -> a
-
-#   11| ... -le ...
 #-----| false -> exit {...} (normal)
 #-----| true -> {...}
 
 #   11| ... -le ...
-#-----|  -> ... -le ...
+#-----|  -> a
 
 #   11| 10
 #-----|  -> ... -le ...
@@ -839,14 +785,11 @@ loops.ps1:
 #-----|  -> 10
 
 #   19| ... -le ...
-#-----|  -> a
-
-#   19| ... -le ...
 #-----| false -> exit {...} (normal)
 #-----| true -> {...}
 
 #   19| ... -le ...
-#-----|  -> ... -le ...
+#-----|  -> a
 
 #   19| 10
 #-----|  -> ... -le ...
@@ -914,14 +857,11 @@ loops.ps1:
 #-----|  -> 10
 
 #   30| ... -le ...
-#-----|  -> a
-
-#   30| ... -le ...
 #-----| false -> exit {...} (normal)
 #-----| true -> {...}
 
 #   30| ... -le ...
-#-----|  -> ... -le ...
+#-----|  -> a
 
 #   30| 10
 #-----|  -> ... -le ...
@@ -983,14 +923,11 @@ loops.ps1:
 #-----|  -> 10
 
 #   38| ... -ge ...
-#-----|  -> a
-
-#   38| ... -ge ...
 #-----| true -> exit {...} (normal)
 #-----| false -> {...}
 
 #   38| ... -ge ...
-#-----|  -> ... -ge ...
+#-----|  -> a
 
 #   38| 10
 #-----|  -> ... -ge ...
@@ -1043,14 +980,11 @@ loops.ps1:
 #-----|  -> 10
 
 #   44| ... -le ...
-#-----|  -> i
-
-#   44| ... -le ...
 #-----| false -> exit {...} (normal)
 #-----| true -> {...}
 
 #   44| ... -le ...
-#-----|  -> ... -le ...
+#-----|  -> i
 
 #   44| 10
 #-----|  -> ... -le ...
@@ -1171,9 +1105,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #    2| {...}
-#-----|  -> Write-Output
-
-#    3| Write-Output
 
 #   10| test-try-with-throw-catch
 #-----|  -> test-try-with-throw-catch-with-throw
@@ -1197,9 +1128,6 @@ try.ps1:
 #-----|  -> b
 
 #   12| b
-#-----|  -> b
-
-#   12| b
 #-----| true -> {...}
 
 #   12| b
@@ -1209,9 +1137,6 @@ try.ps1:
 #-----|  -> throw ...
 
 #   13| throw ...
-#-----|  -> 42
-
-#   13| 42
 #-----|  -> 42
 
 #   13| 42
@@ -1241,9 +1166,6 @@ try.ps1:
 #-----|  -> b
 
 #   23| b
-#-----|  -> b
-
-#   23| b
 #-----| true -> {...}
 
 #   23| b
@@ -1253,9 +1175,6 @@ try.ps1:
 #-----|  -> throw ...
 
 #   24| throw ...
-#-----|  -> 42
-
-#   24| 42
 #-----|  -> 42
 
 #   24| 42
@@ -1285,9 +1204,6 @@ try.ps1:
 #-----|  -> b
 
 #   34| b
-#-----|  -> b
-
-#   34| b
 #-----| true -> {...}
 
 #   34| b
@@ -1297,9 +1213,6 @@ try.ps1:
 #-----|  -> throw ...
 
 #   35| throw ...
-#-----|  -> 42
-
-#   35| 42
 #-----|  -> 42
 
 #   35| 42
@@ -1323,9 +1236,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #   44| {...}
-#-----|  -> Write-Output
-
-#   45| Write-Output
 
 #   52| test-try-catch-specific-1
 #-----|  -> test-try-two-catch-specific-1
@@ -1343,9 +1253,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #   53| {...}
-#-----|  -> Write-Output
-
-#   54| Write-Output
 
 #   61| test-try-two-catch-specific-1
 #-----|  -> test-try-catch-specific-2
@@ -1363,9 +1270,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #   62| {...}
-#-----|  -> Write-Output
-
-#   63| Write-Output
 
 #   72| test-try-catch-specific-2
 #-----|  -> test-try-two-catch-specific-2
@@ -1383,9 +1287,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #   73| {...}
-#-----|  -> Write-Output
-
-#   74| Write-Output
 
 #   81| test-try-two-catch-specific-2
 #-----|  -> test-try-three-catch-specific-2
@@ -1403,9 +1304,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #   82| {...}
-#-----|  -> Write-Output
-
-#   83| Write-Output
 
 #   92| test-try-three-catch-specific-2
 #-----|  -> test-try-catch-finally
@@ -1423,9 +1321,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #   93| {...}
-#-----|  -> Write-Output
-
-#   94| Write-Output
 
 #  105| test-try-catch-finally
 #-----|  -> test-try-finally
@@ -1443,9 +1338,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #  106| {...}
-#-----|  -> Write-Output
-
-#  107| Write-Output
 
 #  116| test-try-finally
 #-----|  -> test-try-finally-catch-specific-1
@@ -1463,9 +1355,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #  117| {...}
-#-----|  -> Write-Output
-
-#  118| Write-Output
 
 #  125| test-try-finally-catch-specific-1
 #-----|  -> test-nested-try-inner-finally
@@ -1483,9 +1372,6 @@ try.ps1:
 #-----|  -> try {...}
 
 #  126| {...}
-#-----|  -> Write-Output
-
-#  127| Write-Output
 
 #  136| test-nested-try-inner-finally
 #-----|  -> test-nested-try-inner-finally
@@ -1509,9 +1395,6 @@ try.ps1:
 #-----|  -> {...}
 
 #  138| {...}
-#-----|  -> Write-Output
-
-#  139| Write-Output
 
 #  149| test-nested-try-inner-finally
 #-----|  -> test-nested-try-outer-finally
@@ -1535,9 +1418,6 @@ try.ps1:
 #-----|  -> {...}
 
 #  151| {...}
-#-----|  -> Write-Output
-
-#  152| Write-Output
 
 #  164| test-nested-try-outer-finally
 #-----|  -> test-nested-try-inner-outer-finally
@@ -1561,9 +1441,6 @@ try.ps1:
 #-----|  -> {...}
 
 #  166| {...}
-#-----|  -> Write-Output
-
-#  167| Write-Output
 
 #  179| test-nested-try-inner-outer-finally
 #-----|  -> exit try.ps1 (normal)
@@ -1587,6 +1464,3 @@ try.ps1:
 #-----|  -> {...}
 
 #  181| {...}
-#-----|  -> Write-Output
-
-#  182| Write-Output


### PR DESCRIPTION
`Pipeline` elements appear implicitly in a lot of places in Powershell. For example, in something like:
```ps
$a = My-Foo 42
```
This looks like an assignment where the right-hand side is a `Cmd`, but it's actually an assignment where the right-hand side is a `Pipeline` containing a single element: A `Cmd`.

This is an artifact from the Powershell parser, and from a query-writing perspective is very confusing. So this PR removes `Pipeline`s containing only a single element. This means that the right-hand of `$a = MyFoo-42` actually _is_ a `Cmd`. However, if one were to write something like `$a = My-Foo 42 | MyBar "abc"` then we'd have a `Pipeline` on the right-hand side as expected.

The first commit updates the extractor to skip `Pipeline`s when they wrap a single element. Most of the touched files are because we had to change the way we generate the `parent` relation such that it skips single-element `Pipelines`. For example, the parent of `My-Foo 42 in `$a = My-Foo 42` isn't the `Pipeline` (since we don't extract single-element `Pipelines` anymore), but rather the parent of that `Pipeline`.

The next commit fixes up the GitHub script for generating up- and down-grade scripts to also work on Powershell, and the next commit runs the script to generate the up- and down-grade scripts. It's probably possible to generate a better up- and down-grade script pair that improves analyses on old databases, but I don't think it's really worth it since we don't actually run a lot of Powershell analysis yet.

The final commit accepts the test changes. This is simple removal of elements that are no longer in the database.