### PR TITLE
PS: Add `InineExpectationsTest` library for dataflow tests

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/AssignmentStatement.qll
+++ b/powershell/ql/lib/semmle/code/powershell/AssignmentStatement.qll
@@ -1,6 +1,6 @@
 import powershell
 
-class AssignStmt extends @assignment_statement, Stmt {
+class AssignStmt extends @assignment_statement, PipelineBase {
   override SourceLocation getLocation() { assignment_statement_location(this, result) }
 
   int getKind() { assignment_statement(this, result, _, _) }

--- a/powershell/ql/lib/semmle/code/powershell/Call.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Call.qll
@@ -7,6 +7,8 @@ abstract private class AbstractCall extends Ast {
 
   Expr getNamedArgument(string name) { none() }
 
+  Expr getAnArgument() { result = this.getArgument(_) or result = this.getNamedArgument(_) }
+
   Expr getQualifier() { none() }
 }
 

--- a/powershell/ql/lib/semmle/code/powershell/Command.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Command.qll
@@ -1,11 +1,11 @@
 import powershell
 
 class Cmd extends @command, CmdBase {
-  override string toString() { result = this.getName() }
+  override string toString() { result = this.getCommandName() }
 
   override SourceLocation getLocation() { command_location(this, result) }
 
-  string getName() { command(this, result, _, _, _) }
+  string getCommandName() { command(this, result, _, _, _) }
 
   int getKind() { command(this, _, result, _, _) }
 
@@ -18,6 +18,8 @@ class Cmd extends @command, CmdBase {
   Expr getCommand() { result = this.getElement(0) }
 
   StringConstExpr getCmdName() { result = this.getElement(0) }
+
+  Expr getAnArgument() { result = this.getArgument(_) or result = this.getNamedArgument(_) }
 
   Expr getArgument(int i) {
     result =

--- a/powershell/ql/lib/semmle/code/powershell/CommandBase.qll
+++ b/powershell/ql/lib/semmle/code/powershell/CommandBase.qll
@@ -1,3 +1,3 @@
 import powershell
 
-class CmdBase extends @command_base, Stmt { }
+class CmdBase extends @command_base, Chainable { }

--- a/powershell/ql/lib/semmle/code/powershell/CommentEntity.qll
+++ b/powershell/ql/lib/semmle/code/powershell/CommentEntity.qll
@@ -1,9 +1,17 @@
 import powershell
 
 class Comment extends @comment_entity {
-  SourceLocation getLocation() { comment_entity_location(this, result) }
+  Location getLocation() { comment_entity_location(this, result) }
 
   StringLiteral getCommentContents() { comment_entity(this, result) }
 
-  string toString() { result = "Comment at: " + this.getLocation().toString() }
+  string toString() { result = this.getCommentContents().toString() }
+}
+
+class SingleLineComment extends Comment {
+  SingleLineComment() { this.getCommentContents().getNumContinuations() = 1 }
+}
+
+class MultiLineComment extends Comment {
+  MultiLineComment() { this.getCommentContents().getNumContinuations() > 1 }
 }

--- a/powershell/ql/lib/semmle/code/powershell/StringLiteral.qll
+++ b/powershell/ql/lib/semmle/code/powershell/StringLiteral.qll
@@ -1,14 +1,12 @@
 import powershell
 
 class StringLiteral extends @string_literal {
-  int getNumContinuations() { string_literal_line(this, result, _) }
+  int getNumContinuations() { result = strictcount(int i | exists(this.getContinuation(i))) }
 
   string getContinuation(int index) { string_literal_line(this, index, result) }
 
   /** Get the full string literal with all its parts concatenated */
-  string toString() {
-    result = this.getValue()
-  }
+  string toString() { result = this.getValue() }
 
   string getValue() {
     result = concat(int i | i = [0 .. this.getNumContinuations()] | this.getContinuation(i), "\n")

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/Completion.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/Completion.qll
@@ -23,7 +23,7 @@ private newtype TCompletion =
 
 private predicate commandThrows(Cmd c, boolean unconditional) {
   c.getNamedArgument("ErrorAction").(StringConstExpr).getValue().getValue() = "Stop" and
-  if c.getName() = "Write-Error" then unconditional = true else unconditional = false
+  if c.getCommandName() = "Write-Error" then unconditional = true else unconditional = false
 }
 
 pragma[noinline]

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
@@ -184,7 +184,7 @@ module Trees {
       )
     }
 
-  int getNumberOfDefaultValues() { result = count(int i | exists(this.getDefaultValue(i))) }
+    int getNumberOfDefaultValues() { result = count(int i | exists(this.getDefaultValue(i))) }
 
     override predicate succ(AstNode pred, AstNode succ, Completion c) {
       // Step to the first parameter

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -41,6 +41,14 @@ private class ExprNodeImpl extends ExprNode, NodeImpl {
   override string toStringImpl() { result = this.getExprNode().toString() }
 }
 
+private class StmtNodeImpl extends StmtNode, NodeImpl {
+  override CfgScope getCfgScope() { none() /* TODO */ }
+
+  override Location getLocationImpl() { result = this.getStmtNode().getLocation() }
+
+  override string toStringImpl() { result = this.getStmtNode().toString() }
+}
+
 /** Gets the SSA definition node corresponding to parameter `p`. */
 pragma[nomagic]
 SsaImpl::DefinitionExt getParameterDef(Parameter p) {
@@ -61,7 +69,7 @@ module SsaFlow {
   Impl::Node asNode(Node n) {
     n = TSsaNode(result)
     or
-    result.(Impl::ExprNode).getExpr() = n.asExpr()
+    result.(Impl::ExprNode).getExpr() = n.asExpr() // TODO: Statement nodes?
     or
     result.(Impl::ExprPostUpdateNode).getExpr() = n.(PostUpdateNode).getPreUpdateNode().asExpr()
     or
@@ -98,6 +106,7 @@ private module Cached {
   cached
   newtype TNode =
     TExprNode(CfgNodes::ExprCfgNode n) or
+    TStmtNode(CfgNodes::StmtCfgNode n) or
     TSsaNode(SsaImpl::DataFlowIntegration::SsaNode node) or
     TNormalParameterNode(Parameter p) or
     TExprPostUpdateNode(CfgNodes::ExprCfgNode n) {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
@@ -11,6 +11,8 @@ class Node extends TNode {
   /** Gets the expression corresponding to this node, if any. */
   CfgNodes::ExprCfgNode asExpr() { result = this.(ExprNode).getExprNode() }
 
+  CfgNodes::StmtCfgNode asStmt() { result = this.(StmtNode).getStmtNode() }
+
   /** Gets the parameter corresponding to this node, if any. */
   Parameter asParameter() { result = this.(ParameterNode).getParameter() }
 
@@ -45,6 +47,22 @@ class ExprNode extends Node, TExprNode {
 
   /** Gets the expression corresponding to this node. */
   CfgNodes::ExprCfgNode getExprNode() { result = n }
+}
+
+/**
+ * A statement, viewed as a node in a data flow graph.
+ *
+ * Note that because of control-flow splitting, one `Stmt` may correspond
+ * to multiple `StmtNode`s, just like it may correspond to multiple
+ * `ControlFlow::Node`s.
+ */
+class StmtNode extends Node, TStmtNode {
+  private CfgNodes::StmtCfgNode n;
+
+  StmtNode() { this = TStmtNode(n) }
+
+  /** Gets the expression corresponding to this node. */
+  CfgNodes::StmtCfgNode getStmtNode() { result = n }
 }
 
 /**
@@ -102,6 +120,9 @@ private import Cached
 
 /** Gets a node corresponding to expression `e`. */
 ExprNode exprNode(CfgNodes::ExprCfgNode e) { result.getExprNode() = e }
+
+/** Gets a node corresponding to statement `s`. */
+StmtNode stmtNode(CfgNodes::StmtCfgNode e) { result.getStmtNode() = e }
 
 /**
  * Gets the node corresponding to the value of parameter `p` at function entry.

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingImplSpecific.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingImplSpecific.qll
@@ -2,7 +2,7 @@
  * Provides Powershell-specific definitions for use in the taint tracking library.
  */
 
-private import codeql.Locations
+private import powershell
 private import codeql.dataflow.TaintTracking
 private import DataFlowImplSpecific
 

--- a/powershell/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/powershell/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -1,0 +1,8 @@
+/**
+ * Inline expectation tests for Powershell.
+ * See `shared/util/codeql/util/test/InlineExpectationsTest.qll`
+ */
+
+private import codeql.util.test.InlineExpectationsTest
+private import internal.InlineExpectationsTestImpl
+import Make<Impl>

--- a/powershell/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/powershell/ql/test/TestUtilities/InlineFlowTest.qll
@@ -1,0 +1,24 @@
+/**
+ * Inline flow tests for Powershell.
+ * See `shared/util/codeql/dataflow/test/InlineFlowTest.qll`
+ */
+
+import powershell
+private import codeql.dataflow.test.InlineFlowTest
+private import semmle.code.powershell.dataflow.internal.DataFlowImplSpecific
+private import semmle.code.powershell.dataflow.internal.TaintTrackingImplSpecific
+private import internal.InlineExpectationsTestImpl
+
+private module FlowTestImpl implements InputSig<Location, PowershellDataFlow> {
+  import TestUtilities.InlineFlowTestUtil
+
+  bindingset[src, sink]
+  string getArgString(DataFlow::Node src, DataFlow::Node sink) {
+    (if exists(getSourceArgString(src)) then result = getSourceArgString(src) else result = "") and
+    exists(sink)
+  }
+
+  predicate interpretModelForTest(QlBuiltins::ExtensionId madId, string model) { none() }
+}
+
+import InlineFlowTestMake<Location, PowershellDataFlow, PowershellTaintTracking, Impl, FlowTestImpl>

--- a/powershell/ql/test/TestUtilities/InlineFlowTestUtil.qll
+++ b/powershell/ql/test/TestUtilities/InlineFlowTestUtil.qll
@@ -1,0 +1,19 @@
+/**
+ * Defines the default source and sink recognition for `InlineFlowTest.qll`.
+ */
+
+import powershell
+import semmle.code.powershell.dataflow.DataFlow
+
+predicate defaultSource(DataFlow::Node src) {
+  src.asStmt().getStmt().(Cmd).getCommandName() = ["Source", "Taint"]
+}
+
+predicate defaultSink(DataFlow::Node sink) {
+  exists(Cmd cmd | cmd.getCommandName() = "Sink" | sink.asExpr().getExpr() = cmd.getAnArgument())
+}
+
+string getSourceArgString(DataFlow::Node src) {
+  defaultSource(src) and
+  src.asStmt().getStmt().(Cmd).getAnArgument().(StringConstExpr).getValue().getValue() = result
+}

--- a/powershell/ql/test/TestUtilities/internal/InlineExpectationsTestImpl.qll
+++ b/powershell/ql/test/TestUtilities/internal/InlineExpectationsTestImpl.qll
@@ -1,0 +1,13 @@
+private import powershell as P
+private import codeql.util.test.InlineExpectationsTest
+
+module Impl implements InlineExpectationsTestSig {
+  /**
+   * A class representing line comments in Powershell.
+   */
+  class ExpectationComment extends P::SingleLineComment {
+    string getContents() { result = this.getCommentContents().getValue().suffix(1) }
+  }
+
+  class Location = P::Location;
+}

--- a/powershell/ql/test/library-tests/dataflow/params/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/params/test.expected
@@ -1,0 +1,6 @@
+models
+edges
+nodes
+subpaths
+testFailures
+#select

--- a/powershell/ql/test/library-tests/dataflow/params/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/params/test.ps1
@@ -1,0 +1,6 @@
+function Foo($a) {
+    Sink $a # $ MISSING: hasValueFlow=1
+}
+
+$x = Source "1"
+Foo $x

--- a/powershell/ql/test/library-tests/dataflow/params/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/params/test.ql
@@ -1,0 +1,13 @@
+/**
+ * @kind path-problem
+ */
+
+import powershell
+import semmle.code.powershell.dataflow.DataFlow
+private import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
+
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()


### PR DESCRIPTION
This PR instantiates the `InlineExpectationsTest` library which is a key component all languages use to write dataflow library tests.

## What problem does the `InlineExpectationsTest` library solve?

I'm glad you asked! The motivation for the library is that it should be easy to read library test output, and quickly review if anything has changes. For example, consider a test such as:
```powershell
$x = Source
Sink $x; # there should be flow from line 1
```
we _could_ have a test that looked like:
```ql
import semmle.code.powershell.dataflow.DataFlow

module Config implements DataFlow::ConfigSig {
  // ...
}

module Flow = DataFlow::Global<Config>;

from DataFlow::Node source, DataFlow::Node sink
where Flow::flow(source, sink)
select sink, "Flow from $@", source, source.toString()
```
(or something like that.)

But there are some problems with this approach:
1. The `.expected` will be one long list of results, and it's hard to judge whether all the results are there (and whether there are too many results)
2. It's hard to keep the comments in the source file consistent with the `.expected` file.

## How does the `InlineExpectationsTest` library solve these problems?

GitHub has solved these problems with a QL library called `InlineExpectationsTest` which allows you to annotate the expected files _in the source file itself_ by using the language's comment syntax. The `InlineExpectationsTest` then compares the library test output with the comment and checks if they match.

For example, for dataflow, the test files will look like:
```powershell
$x = Source "myLabel"
Sink $x; # $ hasValueFlow=myLabel
```
(notice the $ in the beginning of the comment. That's the "marker" for the library to interpret the comment as an inline expectations test).
And the library then checks that there is value-preserving flow from `Source "myLabel"` to `$x`. Similarly, there is also a `hasTaintFlow` version to check if there is taint flow from source to sink.

If the test output matches the comment the test will "pass" and nothing is written to the .expected file. However, if someone accidentally breaks the test, the library will write something along the lines of:
```
| test.ps1:2:15:2:33 | # $ hasValueFlow=myLabel | Missing result:hasValueFlow=myLabel |
```
in the `.expected file`.

Thus, the `.expected` file will _always_ be empty (which ensures that the .expected file is trivially consistent with the source code annotations), and it's easy to understand which flows exist in the source file (since they are simply annotations in the source code itself).

## More `InlineExpectationsTest` syntax

There exists annotation to mark results as spurious (read: false flow) or missing (read: missing flow). For example, one could write:
```powershell
$x = Source "myLabel"
$x = 0 # clears taint
Sink $x; # $ SPURIOUS: hasValueFlow=myLabel
```
to mark that there's currently spurious flow that's not supposed to be there, and once that is fixed the `.expected` file will say something like:
```
| test.ps1:2:15:2:33 | # $ SPURIOUS: hasValueFlow=myLabel | Fixed spurious result:hasValueFlow=myLabel |
```
and the comment will need to be updated to remove the inline expectations marker, and the test should be rerun to make sure the `.expected` file is empty.