### PR TITLE
PS: Add very basic dataflow steps

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -197,6 +197,29 @@ module ExprNodes {
 
     InvokeMemberCfgNode getInvokeMember() { this = result.getQualifier() }
   }
+
+  class ConditionalChildMapping extends ExprChildMapping, ConditionalExpr {
+    override predicate relevantChild(Ast n) { n = this.getCondition() or n = this.getABranch() }
+  }
+
+  /** A control-flow node that wraps a `ConditionalExpr` expression. */
+  class ConditionalCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "ConditionalCfgNode" }
+
+    override ConditionalChildMapping e;
+
+    final override ConditionalExpr getExpr() { result = super.getExpr() }
+
+    final ExprCfgNode getCondition() { e.hasCfgChild(e.getCondition(), this, result) }
+
+    final ExprCfgNode getBranch(boolean value) { e.hasCfgChild(e.getBranch(value), this, result) }
+
+    final ExprCfgNode getABranch() { result = this.getBranch(_) }
+
+    final ExprCfgNode getIfTrue() { e.hasCfgChild(e.getIfTrue(), this, result) }
+
+    final ExprCfgNode getIfFalse() { e.hasCfgChild(e.getIfFalse(), this, result) }
+  }
 }
 
 module StmtNodes {


### PR DESCRIPTION
Now that https://github.com/microsoft/codeql/pull/101 added `StmtNode`s to dataflow we can add a couple of really basic dataflow steps. Specifically, this PR adds:
- The dataflow steps offered by the SSA library that we added in https://github.com/microsoft/codeql/pull/97
- Flow from the right-hand side of assignments to the assignment itself (i.e., flow from `42` to `$x = 42`).

There are no changes to expected files since we're still missing CFG for command invocations. I'm hoping that Dilan or Ben will add those soon (hint hint, wink wink 😄)