### PR TITLE
PS: Add field flow

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/MemberExpr.qll
+++ b/powershell/ql/lib/semmle/code/powershell/MemberExpr.qll
@@ -3,13 +3,26 @@ import powershell
 class MemberExpr extends @member_expression, MemberExprBase {
   final override Location getLocation() { member_expression_location(this, result) }
 
-  Expr getExpr() { member_expression(this, result, _, _, _) }
+  Expr getBase() { member_expression(this, result, _, _, _) }
 
   CmdElement getMember() { member_expression(this, _, result, _, _) }
+
+  /** Gets the name of the member being looked up, if any. */
+  string getMemberName() { result = this.getMember().(StringConstExpr).getValue().getValue() }
 
   predicate isNullConditional() { member_expression(this, _, _, true, _) }
 
   predicate isStatic() { member_expression(this, _, _, _, true) }
 
   final override string toString() { result = this.getMember().toString() }
+}
+
+/** A `MemberExpr` that is being written to. */
+class MemberExprWriteAccess extends MemberExpr {
+  MemberExprWriteAccess() { this = any(AssignStmt assign).getLeftHandSide() }
+}
+
+/** A `MemberExpr` that is being read from. */
+class MemberExprReadAccess extends MemberExpr {
+  MemberExprReadAccess() { not this instanceof MemberExprWriteAccess }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -191,7 +191,7 @@ module ExprNodes {
     final ExprCfgNode getQualifier() { e.hasCfgChild(e.getQualifier(), this, result) }
   }
 
-    /** A control-flow node that wraps a qualifier expression. */
+  /** A control-flow node that wraps a qualifier expression. */
   class QualifierCfgNode extends ExprCfgNode {
     QualifierCfgNode() { this = any(InvokeMemberCfgNode invoke).getQualifier() }
 
@@ -219,6 +219,35 @@ module ExprNodes {
     final ExprCfgNode getIfTrue() { e.hasCfgChild(e.getIfTrue(), this, result) }
 
     final ExprCfgNode getIfFalse() { e.hasCfgChild(e.getIfFalse(), this, result) }
+  }
+
+  class MemberChildMapping extends ExprChildMapping, MemberExpr {
+    override predicate relevantChild(Ast n) { n = this.getBase() or n = this.getMember() }
+  }
+
+  /** A control-flow node that wraps a `MemberExpr` expression. */
+  class MemberCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "MemberCfgNode" }
+
+    override MemberChildMapping e;
+
+    final override MemberExpr getExpr() { result = super.getExpr() }
+
+    final ExprCfgNode getBase() { e.hasCfgChild(e.getBase(), this, result) }
+
+    final string getMemberName() { result = e.getMemberName() }
+
+    predicate isStatic() { e.isStatic() }
+  }
+
+  /** A control-flow node that wraps a `MemberExpr` expression that is being written to. */
+  class MemberCfgWriteAccessNode extends MemberCfgNode {
+    MemberCfgWriteAccessNode() { this.getExpr() instanceof MemberExprWriteAccess }
+  }
+
+  /** A control-flow node that wraps a `MemberExpr` expression that is being read from. */
+  class MemberCfgReadAccessNode extends MemberCfgNode {
+    MemberCfgReadAccessNode() { this.getExpr() instanceof MemberExprReadAccess }
   }
 }
 

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
@@ -161,7 +161,19 @@ class Content extends TContent {
 }
 
 /** Provides different sub classes of `Content`. */
-module Content { }
+module Content {
+  /** A field of an object. */
+  class FieldContent extends Content, TFieldContent {
+    private string name;
+
+    FieldContent() { this = TFieldContent(name) }
+
+    /** Gets the name of the field. */
+    string getName() { result = name }
+
+    override string toString() { result = name }
+  }
+}
 
 /**
  * An entity that represents a set of `Content`s.

--- a/powershell/ql/test/library-tests/dataflow/fields/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.expected
@@ -1,0 +1,6 @@
+models
+edges
+nodes
+subpaths
+testFailures
+#select

--- a/powershell/ql/test/library-tests/dataflow/fields/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.ps1
@@ -1,0 +1,6 @@
+$a.f = Source "1"
+Sink $a.f # $ MISSING: hasValueFlow=1
+
+$a.f = Source "2"
+$a.f = 0
+Sink $a.f # clean

--- a/powershell/ql/test/library-tests/dataflow/fields/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.ql
@@ -1,0 +1,13 @@
+/**
+ * @kind path-problem
+ */
+
+import powershell
+import semmle.code.powershell.dataflow.DataFlow
+private import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
+
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()


### PR DESCRIPTION
This PR implements field-based dataflow (i.e., "field flow") for Powershell.

Field flow is what allows us to get flow in examples such as:
```powershell
$x.f = Source
Sink $x.f
```

While it may look innocent, field flow is _extremely_ powerful, and _extremely_ hard to get to perform well. Luckily, all the complications are hidden away inside the shared dataflow library, so all we need to do is:
- Make sure there exists `DataFlow::Node`s to represent the notion of "a dataflow node where we have just stored data into". These nodes are known as "post-update nodes".
- Tell the dataflow library what a write into a field looks like. This is the job of `storeStep`.
- Tell the dataflow library what a read of a field looks like. This is the job of `readStep`.

Consider an example such as:
```powershell
$x.f = Source # line 1
$y = $x # line 2
Sink $y.f # line 3
```
operationally, what happens is that:
- There is a `storeStep` from `Source` to the post-update node for `$x` (which is printed as `[post] $x`). Internally, the data flow "remembers" that there has been a write to `f` when it generates `PathNode`s (that's the part that's _extremely_ hard to get to perform well). When viewing paths, this will be printed as something like `[post] $x [f]`. The `[f]` part is known as the "access path" and can contain up to 5 entries (which represents tracking a value that's been stored into 5 nested structs/classes).
- There's a flow step from `[post] $x` on line 1 to `$x` on line 2 (we get this from SSA).
- There's a flow step from `$x` to `$y`
- There's a `readStep` from `$y` to `$y.f` that reads from `y`. Because the dataflow library "remembers" that there was a previous write to `f` it will "pop off" `f` from the access path.