### PR TITLE
PS: Implement argument/parameter matching in dataflow

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/Command.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Command.qll
@@ -19,8 +19,14 @@ class Cmd extends @command, CmdBase {
 
   StringConstExpr getCmdName() { result = this.getElement(0) }
 
-  Expr getAnArgument() { result = this.getArgument(_) or result = this.getNamedArgument(_) }
+  /** Gets any argument to this command. */
+  Expr getAnArgument() { result = this.getArgument(_) }
 
+  /**
+   * Gets the `i`th argument to this command.
+   *
+   * The argument may be named or positional.
+   */
   Expr getArgument(int i) {
     result =
       rank[i + 1](CmdElement e, int j |
@@ -32,6 +38,18 @@ class Cmd extends @command, CmdBase {
       )
   }
 
+  /** Gets the `i`th positional argument to this command. */
+  Expr getPositionalArgument(int i) {
+    result =
+      rank[i + 1](Argument e, int j |
+        e = this.getArgument(j) and
+        e instanceof PositionalArgument
+      |
+        e order by j
+      )
+  }
+
+  /** Gets the named argument with the given name. */
   Expr getNamedArgument(string name) {
     exists(int i, CmdParameter p |
       this.getElement(i) = p and
@@ -53,11 +71,21 @@ class Cmd extends @command, CmdBase {
 class Argument extends Expr {
   Cmd cmd;
 
-  Argument() { cmd.getArgument(_) = this or cmd.getNamedArgument(_) = this }
+  Argument() { cmd.getAnArgument() = this }
 
   Cmd getCmd() { result = cmd }
 
-  int getIndex() { cmd.getArgument(result) = this }
+  int getPosition() { cmd.getPositionalArgument(result) = this }
 
   string getName() { cmd.getNamedArgument(result) = this }
+}
+
+/** A positional argument to a command. */
+class PositionalArgument extends Argument {
+  PositionalArgument() { not this instanceof NamedArgument }
+}
+
+/** A named argument to a command. */
+class NamedArgument extends Argument {
+  NamedArgument() { this = cmd.getNamedArgument(_) }
 }

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -14,10 +14,10 @@ private predicate hasParameterBlockImpl(Internal::Parameter p, ParamBlock block,
 
 /**
  * Gets the enclosing scope of `p`.
- * 
+ *
  * For a function parameter, this is the function body. For a parameter from a
  * parameter block, this is the enclosing scope of the parameter block.
- * 
+ *
  * In both of the above cases, the enclosing scope is the function body.
  */
 private Scope getEnclosingScopeImpl(Internal::Parameter p) {
@@ -176,6 +176,8 @@ class Parameter extends AbstractLocalScopeVariable, TParameter {
 
   override string getName() { result = p.getName() }
 
+  final predicate hasName(string name) { name = p.getName() }
+
   final override Scope getDeclaringScope() { result = p.getEnclosingScope() }
 
   predicate hasParameterBlock(ParamBlock block, int i) { p.hasParameterBlock(block, i) }
@@ -186,7 +188,18 @@ class Parameter extends AbstractLocalScopeVariable, TParameter {
 
   predicate hasDefaultValue() { exists(this.getDefaultValue()) }
 
-  int getIndex() { this.isFunctionParameter(_, result) }
+  /**
+   * Gets the index of this parameter.
+   *
+   * The parameter may be in a parameter block or a function parameter.
+   */
+  int getIndex() { result = this.getFunctionIndex() or result = this.getBlockIndex() }
+
+  /** Gets the index of this parameter in the parameter block, if any. */
+  int getBlockIndex() { this.hasParameterBlock(_, result) }
+
+  /** Gets the index of this parameter in the function, if any. */
+  int getFunctionIndex() { this.isFunctionParameter(_, result) }
 
   Function getFunction() { result.getBody() = this.getDeclaringScope() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -174,6 +174,14 @@ module ExprNodes {
     override Argument e;
 
     final override Argument getExpr() { result = super.getExpr() }
+
+    /** Gets the position of this argument, if any. */
+    int getPosition() { result = e.getPosition() }
+
+    /** Gets the name of this argument, if any. */
+    string getName() { result = e.getName() }
+
+    StmtNodes::CmdCfgNode getCmd() { result.getAnArgument() = this }
   }
 
   private class InvokeMemberChildMapping extends ExprChildMapping, InvokeMemberExpr {
@@ -253,7 +261,7 @@ module ExprNodes {
 
 module StmtNodes {
   private class CmdChildMapping extends NonExprChildMapping, Cmd {
-    override predicate relevantChild(Ast n) { n = this.getElement(_) }
+    override predicate relevantChild(Ast n) { n = this.getAnArgument() or n = this.getCommand() }
   }
 
   /** A control-flow node that wraps a `Cmd` AST expression. */
@@ -263,6 +271,20 @@ module StmtNodes {
     override CmdChildMapping s;
 
     override Cmd getStmt() { result = super.getStmt() }
+
+    ExprCfgNode getArgument(int i) { s.hasCfgChild(s.getArgument(i), this, result) }
+
+    ExprCfgNode getPositionalArgument(int i) {
+      s.hasCfgChild(s.getPositionalArgument(i), this, result)
+    }
+
+    ExprCfgNode getNamedArgument(string name) {
+      s.hasCfgChild(s.getNamedArgument(name), this, result)
+    }
+
+    ExprCfgNode getAnArgument() { s.hasCfgChild(s.getAnArgument(), this, result) }
+
+    ExprCfgNode getCommand() { s.hasCfgChild(s.getCommand(), this, result) }
   }
 
   private class AssignStmtChildMapping extends NonExprChildMapping, AssignStmt {

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
@@ -176,7 +176,7 @@ module Trees {
       exists(Parameter p |
         p =
           rank[i + 1](Parameter cand, int j |
-            cand.hasDefaultValue() and j = cand.getIndex()
+            cand.hasDefaultValue() and j = cand.getFunctionIndex()
           |
             cand order by j
           ) and

--- a/powershell/ql/test/library-tests/dataflow/params/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/params/test.ps1
@@ -4,3 +4,36 @@ function Foo($a) {
 
 $x = Source "1"
 Foo $x
+
+function ThreeArgs($x, $y, $z) {
+    Sink $x # $ MISSING: hasValueFlow=x
+    Sink $y # $ MISSING: hasValueFlow=y
+    Sink $z # $ MISSING: hasValueFlow=z
+}
+
+$first = Source "x"
+$second = Source "y"
+$third = Source "z"
+
+ThreeArgs $first $second $third
+ThreeArgs $second -x $first $third
+ThreeArgs -x $first $second $third
+ThreeArgs $first -y $second $third
+ThreeArgs -y $second $first $third
+ThreeArgs $second -x $first -z $third
+ThreeArgs -x $first $second -z $third
+ThreeArgs $first -y $second -z $third
+ThreeArgs -y $second $first -z $third
+ThreeArgs $second -x $first -z $third
+ThreeArgs -x $first -z $third $second
+ThreeArgs $first -y $second -z $third
+ThreeArgs -y $second -z $third $first
+ThreeArgs $second -z $third -x $first
+ThreeArgs -x $first -z $third $second
+ThreeArgs $first -z $third -y $second
+ThreeArgs -y $second -z $third $first
+ThreeArgs -z $third -y $second $first
+ThreeArgs -z $third $second -x $first
+ThreeArgs -z $third -x $first $second
+ThreeArgs -z $third $first -y $second
+ThreeArgs -z $third -y $second $first


### PR DESCRIPTION
## Warning

Not gonna lie - this code was actually kinda complex 🙈

## What is this PR about?

This PR implements the logic for matching up arguments and parameters. For Powershell, this is harder than it sounds!

For most languages this is simply an integer: match up (e.g.,) the 3rd argument with the 3rd parameter. However, some languages also allow passing arguments by keyword such as:
```python
def foo(x, y):
  print(x, y)

foo(x=1, y=2)
foo(y=2, x=1)
```
Both these calls print `1 2`.

## Why is hard Powershell in Powershell?

Poweshell has the interesting feature that you can do _both_ in a single call. For example:
```powershell
Function Foo($x, $y) {
  Write-Host "$x $y"
}

Foo 1 2
Foo -x 1 -y 2
Foo 2 -x 1
Foo -y 2 1
```
All of these print `1 2`. And now the challenge is to match up the arguments with the right parameter.

## What do we need to tell the dataflow library?

DataFlow provides a set of hooks that need to be implemented in order to match up arguments and parameters:
- We need to implement a `ParameterPosition` type to represent "the position" of a parameter. In simple languages (for example, C) this would just be an integer.
- We need to implement a `ArgumentPosition` type to represent "the position" of an argument. In simple languages, this would _also_ simply be an integer.
- Finally, we need to implement a predicate `parameterMatch(ParameterPosition, ArgumentPosition)` that holds whenever the `ArgumentPosition` and `ParameterPosition` represents the same position. In simple languages where both of these types are `int`, this would simply be equality between the two.

## The strategy

I discussed this with `@hvitved` from the CodeQL C# team (who implemented similarly tricky stuff for Ruby's dataflow implementation), and I think we came up with a nifty idea:

We will have two kinds of parameters/arguments: A "keyword" parameter/argument, and a "positional" parameter/argument. Keyword parameters/arguments are easy:

When we see an argument such as `-x 42` we will assign it the argument position `keyword(x)`. Similarly, every parameter will be assigned a `keyword(name)` parameter position where `name` is the name of the parameter (for example, `$x` or `$y` in `Foo`).

For positional arguments we will assign it a special argument `position(i, S)` which represents the `i`'th positional (i.e., "unnamed") argument in a call given that the set of named arguments provided to the call call is `S`.

## Example

For example, consider the function `Foo` above. We will assign `x` the parameter positions:
1. `keyword(x)`
2. `position(0, {})`
3. `position(0, {y})`

The second line represents the fact that, when there are no named parameters, the 0'th unnamed argument will go to the `x` parameter. The third line represents the fact that, when the `y` argument is provided by-name, the 0'th argument is `x`.

Similarly, we will assign `y` the parameter positions:
1. `keyword(y)`
2. `position(1, {})`
3. `position(0, {x})`

The second line represents the fact that, when there are no named parameters, the 0'th unnamed argument will go to the `y` parameter. The third line represents the fact that, when the `x` argument is provided by-name, the 0'th argument is `y`.

Now, consider the call `Foo 2 -x 1`. We will assign the argument `1` the position `keyword(x)`, and we will assign the argument `2` the position `position(0, {x})` since it's the 0'th unnamed argument to the call.

And since the argument position `position(0, {x})` maps to the parameter position `position(0, {x})` we will flow `2` into `y`.