### PR TITLE
C#: Make `StartsWith` and `EndsWith` sanitizers on normalized paths

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
@@ -4,6 +4,7 @@
  */
 
 import csharp
+private import codeql.util.Unit
 private import semmle.code.csharp.controlflow.Guards
 private import semmle.code.csharp.security.dataflow.flowsinks.FlowSinks
 private import semmle.code.csharp.security.dataflow.flowsources.FlowSources
@@ -26,21 +27,62 @@ abstract class Sink extends ApiSinkExprNode { }
  */
 abstract class Sanitizer extends DataFlow::ExprNode { }
 
+/** A path normalization step. */
+private class PathNormalizationStep extends Unit {
+  /**
+   * Holds if the flow step from `n1` to `n2` transforms the path into an
+   * absolute path.
+   *
+   * For example, the argument-to-return-value step through a call
+   * to `System.IO.Path.GetFullPath` is a normalization step.
+   */
+  abstract predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2);
+}
+
+private class GetFullPathStep extends PathNormalizationStep {
+  override predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
+    exists(Call call |
+      call.getARuntimeTarget().hasFullyQualifiedName("System.IO.Path", "GetFullPath") and
+      n1.asExpr() = call.getArgument(0) and
+      n2.asExpr() = call
+    )
+  }
+}
+
 /**
  * A taint-tracking configuration for uncontrolled data in path expression vulnerabilities.
  */
-private module TaintedPathConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module TaintedPathConfig implements DataFlow::StateConfigSig {
+  newtype FlowState =
+    additional NotNormalized() or
+    additional Normalized()
 
-  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSource(DataFlow::Node source, FlowState state) {
+    source instanceof Source and state = NotNormalized()
+  }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isSink(DataFlow::Node sink, FlowState state) {
+    sink instanceof Sink and
+    exists(state)
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node n1, FlowState s1, DataFlow::Node n2, FlowState s2) {
+    any(PathNormalizationStep step).isAdditionalFlowStep(n1, n2) and
+    s1 = NotNormalized() and
+    s2 = Normalized()
+  }
+
+  predicate isBarrier(DataFlow::Node node, FlowState state) { node.(Sanitizer).isBarrier(state) }
+
+  predicate isBarrierOut(DataFlow::Node node, FlowState state) {
+    isAdditionalFlowStep(node, state, _, _)
+  }
 }
 
 /**
  * A taint-tracking module for uncontrolled data in path expression vulnerabilities.
  */
-module TaintedPath = TaintTracking::Global<TaintedPathConfig>;
+module TaintedPath = TaintTracking::GlobalWithState<TaintedPathConfig>;
 
 /**
  * DEPRECATED: Use `ThreatModelSource` instead.

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
@@ -59,7 +59,7 @@ public class TaintedPathHandler : IHttpHandler
         string fullPath = Path.GetFullPath(path);
         if (fullPath.StartsWith("C:\\Foo"))
         {
-            File.ReadAllText(fullPath); // GOOD [FALSE POSITIVE]
+            File.ReadAllText(fullPath); // GOOD
         }
     }
 

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
@@ -55,6 +55,12 @@ public class TaintedPathHandler : IHttpHandler
 
         // GOOD: A simple type.
         File.ReadAllText(int.Parse(path).ToString());
+
+        string fullPath = Path.GetFullPath(path);
+        if (fullPath.StartsWith("C:\\Foo"))
+        {
+            File.ReadAllText(fullPath); // GOOD [FALSE POSITIVE]
+        }
     }
 
     public bool IsReusable

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
@@ -6,7 +6,6 @@
 | TaintedPath.cs:36:25:36:31 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:36:25:36:31 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:38:49:38:55 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:51:26:51:29 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
-| TaintedPath.cs:62:30:62:37 | access to local variable fullPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:62:30:62:37 | access to local variable fullPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:12:50:12:53 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:17:51:17:54 | access to local variable path | provenance |  |
@@ -14,18 +13,13 @@ edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:31:30:31:33 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:51:26:51:29 | access to local variable path | provenance |  |
-| TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:59:44:59:47 | access to local variable path : String | provenance |  |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:16:10:19 | access to local variable path : String | provenance |  |
-| TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:23:10:53 | access to indexer : String | provenance | MaD:2 |
+| TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:23:10:53 | access to indexer : String | provenance | MaD:1 |
 | TaintedPath.cs:10:23:10:53 | access to indexer : String | TaintedPath.cs:10:16:10:19 | access to local variable path : String | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:36:25:36:31 | access to local variable badPath | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:38:49:38:55 | access to local variable badPath | provenance |  |
-| TaintedPath.cs:59:16:59:23 | access to local variable fullPath : String | TaintedPath.cs:62:30:62:37 | access to local variable fullPath | provenance |  |
-| TaintedPath.cs:59:27:59:48 | call to method GetFullPath : String | TaintedPath.cs:59:16:59:23 | access to local variable fullPath : String | provenance |  |
-| TaintedPath.cs:59:44:59:47 | access to local variable path : String | TaintedPath.cs:59:27:59:48 | call to method GetFullPath : String | provenance | MaD:1 |
 models
-| 1 | Summary: System.IO; Path; false; GetFullPath; (System.String); ; Argument[0]; ReturnValue; taint; manual |
-| 2 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
+| 1 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
 nodes
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | semmle.label | access to local variable path : String |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
@@ -38,8 +32,4 @@ nodes
 | TaintedPath.cs:36:25:36:31 | access to local variable badPath | semmle.label | access to local variable badPath |
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | semmle.label | access to local variable badPath |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | semmle.label | access to local variable path |
-| TaintedPath.cs:59:16:59:23 | access to local variable fullPath : String | semmle.label | access to local variable fullPath : String |
-| TaintedPath.cs:59:27:59:48 | call to method GetFullPath : String | semmle.label | call to method GetFullPath : String |
-| TaintedPath.cs:59:44:59:47 | access to local variable path : String | semmle.label | access to local variable path : String |
-| TaintedPath.cs:62:30:62:37 | access to local variable fullPath | semmle.label | access to local variable fullPath |
 subpaths

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
@@ -6,6 +6,7 @@
 | TaintedPath.cs:36:25:36:31 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:36:25:36:31 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:38:49:38:55 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:51:26:51:29 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
+| TaintedPath.cs:62:30:62:37 | access to local variable fullPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:62:30:62:37 | access to local variable fullPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:12:50:12:53 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:17:51:17:54 | access to local variable path | provenance |  |
@@ -13,13 +14,18 @@ edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:31:30:31:33 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:51:26:51:29 | access to local variable path | provenance |  |
+| TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:59:44:59:47 | access to local variable path : String | provenance |  |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:16:10:19 | access to local variable path : String | provenance |  |
-| TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:23:10:53 | access to indexer : String | provenance | MaD:1 |
+| TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:23:10:53 | access to indexer : String | provenance | MaD:2 |
 | TaintedPath.cs:10:23:10:53 | access to indexer : String | TaintedPath.cs:10:16:10:19 | access to local variable path : String | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:36:25:36:31 | access to local variable badPath | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:38:49:38:55 | access to local variable badPath | provenance |  |
+| TaintedPath.cs:59:16:59:23 | access to local variable fullPath : String | TaintedPath.cs:62:30:62:37 | access to local variable fullPath | provenance |  |
+| TaintedPath.cs:59:27:59:48 | call to method GetFullPath : String | TaintedPath.cs:59:16:59:23 | access to local variable fullPath : String | provenance |  |
+| TaintedPath.cs:59:44:59:47 | access to local variable path : String | TaintedPath.cs:59:27:59:48 | call to method GetFullPath : String | provenance | MaD:1 |
 models
-| 1 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
+| 1 | Summary: System.IO; Path; false; GetFullPath; (System.String); ; Argument[0]; ReturnValue; taint; manual |
+| 2 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
 nodes
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | semmle.label | access to local variable path : String |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
@@ -32,4 +38,8 @@ nodes
 | TaintedPath.cs:36:25:36:31 | access to local variable badPath | semmle.label | access to local variable badPath |
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | semmle.label | access to local variable badPath |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | semmle.label | access to local variable path |
+| TaintedPath.cs:59:16:59:23 | access to local variable fullPath : String | semmle.label | access to local variable fullPath : String |
+| TaintedPath.cs:59:27:59:48 | call to method GetFullPath : String | semmle.label | call to method GetFullPath : String |
+| TaintedPath.cs:59:44:59:47 | access to local variable path : String | semmle.label | access to local variable path : String |
+| TaintedPath.cs:62:30:62:37 | access to local variable fullPath | semmle.label | access to local variable fullPath |
 subpaths


### PR DESCRIPTION
The current `cs/path-injection` query explicitly disables `String.StartsWith` and `String.EndsWith` as sanitizers. Presumably because a prefix check such as `path.StartsWith("C:/Foo")` doesn't gurantee that the path points into the `Foo` directory if the path contains `..` (for example, `C:/Foo/../Bar` would satisfy the prefix check, but would point to the `Bar` directory).

However, if the path has been "normalized" (i.e., made absolute) by a call such as `Path.GetFullPath(path)` then no `..` are present in the path, and the `EndsWith` or `StartsWith` checks should be sufficient to avoid path injections.

This PR fixes this by introducing a flow state to represent whether the path is normalized, allowing `StartsWith` and `EndsWith` to act as barriers when the path is in a normalized state.

Commit-by-commit review recommended:
- Commit 1 adds a FP testcase
- Commit 2 adds a flow state to the dataflow configuration that tracks whether the path has gone through a `Path.GetFullPath` call
- Commit 3 makes the previous explicitly-banned barriers block flow when the path is normalized
- Commit 4 accepts the test changes 