### PR TITLE
PS: Resolve function calls

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/Ast.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Ast.qll
@@ -8,5 +8,7 @@ class Ast extends @ast {
 
   Location getLocation() { none() }
 
-  final Scope getEnclosingScope() { result = scopeOf(this) }
+  Scope getEnclosingScope() { result = scopeOf(this) }
+
+  final Function getEnclosingFunction() { this.getEnclosingScope() = result.getBody() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/Call.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Call.qll
@@ -3,17 +3,26 @@ import powershell
 abstract private class AbstractCall extends Ast {
   abstract Expr getCommand();
 
+  /** Gets the i'th argument to this call. */
   abstract Expr getArgument(int i);
 
-  Expr getNamedArgument(string name) { none() }
+  /** Gets the i'th positional argument to this call. */
+  abstract Expr getPositionalArgument(int i);
 
-  Expr getAnArgument() { result = this.getArgument(_) or result = this.getNamedArgument(_) }
+  /** Gets the argument to this call with the name `name`. */
+  abstract Expr getNamedArgument(string name);
 
+  /** Gets any argument to this call. */
+  final Expr getAnArgument() { result = this.getArgument(_) }
+
+  /** Gets the qualifier of this call, if any. */
   Expr getQualifier() { none() }
 }
 
 private class CmdCall extends AbstractCall instanceof Cmd {
   final override Expr getCommand() { result = Cmd.super.getCommand() }
+
+  final override Expr getPositionalArgument(int i) { result = Cmd.super.getPositionalArgument(i) }
 
   final override Expr getArgument(int i) { result = Cmd.super.getArgument(i) }
 
@@ -23,9 +32,15 @@ private class CmdCall extends AbstractCall instanceof Cmd {
 private class InvokeMemberCall extends AbstractCall instanceof InvokeMemberExpr {
   final override Expr getCommand() { result = super.getMember() }
 
-  final override Expr getArgument(int i) { result = InvokeMemberExpr.super.getArgument(i) }
+  final override Expr getPositionalArgument(int i) {
+    result = InvokeMemberExpr.super.getArgument(i)
+  }
+
+  final override Expr getArgument(int i) { result = this.getPositionalArgument(i) }
 
   final override Expr getQualifier() { result = InvokeMemberExpr.super.getQualifier() }
+
+  final override Expr getNamedArgument(string name) { none() }
 }
 
 final class Call = AbstractCall;

--- a/powershell/ql/lib/semmle/code/powershell/Function.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Function.qll
@@ -4,6 +4,8 @@ import semmle.code.powershell.controlflow.BasicBlocks
 abstract private class AbstractFunction extends Ast {
   abstract string getName();
 
+  final predicate hasName(string name) { this.getName() = name }
+
   abstract ScriptBlock getBody();
 
   abstract Parameter getFunctionParameter(int i);

--- a/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
@@ -17,3 +17,9 @@ class InvokeMemberExpr extends @invoke_member_expression, MemberExprBase {
 
   override predicate isStatic() { this.getQualifier() instanceof TypeNameExpr }
 }
+
+class ConstructorCall extends InvokeMemberExpr {
+  ConstructorCall() { this.isStatic() and this.getName() = "new" }
+
+  Type getConstructedType() { result = this.getQualifier().(TypeNameExpr).getType() }
+}

--- a/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
@@ -5,11 +5,15 @@ class InvokeMemberExpr extends @invoke_member_expression, MemberExprBase {
 
   Expr getQualifier() { invoke_member_expression(this, result, _) }
 
+  string getName() { result = this.getMember().(StringConstExpr).getValue().getValue() }
+
   CmdElement getMember() { invoke_member_expression(this, _, result) }
 
   Expr getArgument(int i) { invoke_member_expression_argument(this, i, result) }
 
   Expr getAnArgument() { invoke_member_expression_argument(this, _, result) }
 
-  override string toString() { result = "call to " + this.getMember() }
+  override string toString() { result = "call to " + this.getName() }
+
+  override predicate isStatic() { this.getQualifier() instanceof TypeNameExpr }
 }

--- a/powershell/ql/lib/semmle/code/powershell/MemberExpr.qll
+++ b/powershell/ql/lib/semmle/code/powershell/MemberExpr.qll
@@ -12,7 +12,7 @@ class MemberExpr extends @member_expression, MemberExprBase {
 
   predicate isNullConditional() { member_expression(this, _, _, true, _) }
 
-  predicate isStatic() { member_expression(this, _, _, _, true) }
+  override predicate isStatic() { member_expression(this, _, _, _, true) }
 
   final override string toString() { result = this.getMember().toString() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/MemberExpressionBase.qll
+++ b/powershell/ql/lib/semmle/code/powershell/MemberExpressionBase.qll
@@ -1,3 +1,5 @@
 import powershell
 
-class MemberExprBase extends @member_expression_base, Expr { }
+class MemberExprBase extends @member_expression_base, Expr {
+  predicate isStatic() { none() }
+}

--- a/powershell/ql/lib/semmle/code/powershell/ScriptBlock.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ScriptBlock.qll
@@ -1,4 +1,5 @@
 import powershell
+private import semmle.code.powershell.controlflow.internal.Scope
 
 class ScriptBlock extends @script_block, Ast {
   predicate isTopLevel() { not exists(this.getParent()) }
@@ -48,4 +49,6 @@ class ScriptBlock extends @script_block, Ast {
   }
 
   ModuleSpecification getAModuleSpecification() { result = this.getModuleSpecification(_) }
+
+  final override Scope getEnclosingScope() { result = this }
 }

--- a/powershell/ql/lib/semmle/code/powershell/Type.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Type.qll
@@ -10,4 +10,11 @@ class Type extends @type_definition, Stmt {
   Member getMember(int i) { type_definition_members(this, i, result) }
 
   Member getAMember() { result = this.getMember(_) }
+
+  MemberFunction getMemberFunction(string name) {
+    result = this.getAMember() and
+    result.hasName(name)
+  }
+
+  MemberFunction getAMemberFunction() { result = this.getMemberFunction(_) }
 }

--- a/powershell/ql/lib/semmle/code/powershell/TypeExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/TypeExpression.qll
@@ -8,4 +8,7 @@ class TypeNameExpr extends @type_expression, Expr {
   override string toString() { result = this.getName() }
 
   override SourceLocation getLocation() { type_expression_location(this, result) }
+
+  /** Gets the type referred to by this `TypeNameExpr`. */
+  Type getType() { result.getName() = this.getName() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -214,7 +214,7 @@ module ExprNodes {
 
     override InvokeMemberChildMapping e;
 
-    final override InvokeMemberExpr getExpr() { result = super.getExpr() }
+    override InvokeMemberExpr getExpr() { result = super.getExpr() }
 
     final override ExprCfgNode getQualifier() { e.hasCfgChild(e.getQualifier(), this, result) }
 
@@ -229,6 +229,15 @@ module ExprNodes {
     final override string getName() { none() }
 
     final override ExprCfgNode getCommand() { none() }
+  }
+
+    /** A control-flow node that wraps an `ConstructorCall` expression. */
+  class ConstructorCallCfgNode extends InvokeMemberCfgNode {
+    ConstructorCallCfgNode() { super.getExpr() instanceof ConstructorCall }
+
+    final override ConstructorCall getExpr() { result = super.getExpr() }
+
+    Type getConstructedType() { result = this.getExpr().getConstructedType() }
   }
 
   /** A control-flow node that wraps a qualifier expression. */

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -128,6 +128,8 @@ abstract private class NonExprChildMapping extends ChildMapping {
 abstract private class AbstractCallCfgNode extends AstCfgNode {
   override string getAPrimaryQlClass() { result = "CfgCall" }
 
+  abstract string getName();
+
   ExprCfgNode getQualifier() { none() }
 
   abstract ExprCfgNode getArgument(int i);
@@ -137,6 +139,8 @@ abstract private class AbstractCallCfgNode extends AstCfgNode {
   abstract ExprCfgNode getNamedArgument(string name);
 
   abstract ExprCfgNode getAnArgument();
+
+  abstract ExprCfgNode getCommand();
 }
 
 final class CallCfgNode = AbstractCallCfgNode;
@@ -221,6 +225,10 @@ module ExprNodes {
     final override ExprCfgNode getNamedArgument(string name) { none() }
 
     final override ExprCfgNode getAnArgument() { e.hasCfgChild(e.getAnArgument(), this, result) }
+
+    final override string getName() { none() }
+
+    final override ExprCfgNode getCommand() { none() }
   }
 
   /** A control-flow node that wraps a qualifier expression. */
@@ -308,7 +316,9 @@ module StmtNodes {
 
     override ExprCfgNode getAnArgument() { s.hasCfgChild(s.getAnArgument(), this, result) }
 
-    ExprCfgNode getCommand() { s.hasCfgChild(s.getCommand(), this, result) }
+    final override ExprCfgNode getCommand() { s.hasCfgChild(s.getCommand(), this, result) }
+
+    final override string getName() { result = s.getCmdName().getValue().getValue() }
   }
 
   private class AssignStmtChildMapping extends NonExprChildMapping, AssignStmt {

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -125,6 +125,22 @@ abstract private class NonExprChildMapping extends ChildMapping {
   }
 }
 
+abstract private class AbstractCallCfgNode extends AstCfgNode {
+  override string getAPrimaryQlClass() { result = "CfgCall" }
+
+  ExprCfgNode getQualifier() { none() }
+
+  abstract ExprCfgNode getArgument(int i);
+
+  abstract ExprCfgNode getPositionalArgument(int i);
+
+  abstract ExprCfgNode getNamedArgument(string name);
+
+  abstract ExprCfgNode getAnArgument();
+}
+
+final class CallCfgNode = AbstractCallCfgNode;
+
 /** Provides classes for control-flow nodes that wrap AST expressions. */
 module ExprNodes {
   private class VarAccessChildMapping extends ExprChildMapping, VarAccess {
@@ -189,14 +205,22 @@ module ExprNodes {
   }
 
   /** A control-flow node that wraps an `InvokeMemberExpr` expression. */
-  class InvokeMemberCfgNode extends ExprCfgNode {
+  class InvokeMemberCfgNode extends ExprCfgNode, AbstractCallCfgNode {
     override string getAPrimaryQlClass() { result = "InvokeMemberCfgNode" }
 
     override InvokeMemberChildMapping e;
 
     final override InvokeMemberExpr getExpr() { result = super.getExpr() }
 
-    final ExprCfgNode getQualifier() { e.hasCfgChild(e.getQualifier(), this, result) }
+    final override ExprCfgNode getQualifier() { e.hasCfgChild(e.getQualifier(), this, result) }
+
+    final override ExprCfgNode getArgument(int i) { e.hasCfgChild(e.getArgument(i), this, result) }
+
+    final override ExprCfgNode getPositionalArgument(int i) { result = this.getArgument(i) }
+
+    final override ExprCfgNode getNamedArgument(string name) { none() }
+
+    final override ExprCfgNode getAnArgument() { e.hasCfgChild(e.getAnArgument(), this, result) }
   }
 
   /** A control-flow node that wraps a qualifier expression. */
@@ -265,24 +289,24 @@ module StmtNodes {
   }
 
   /** A control-flow node that wraps a `Cmd` AST expression. */
-  class CmdCfgNode extends StmtCfgNode {
+  class CmdCfgNode extends StmtCfgNode, AbstractCallCfgNode {
     override string getAPrimaryQlClass() { result = "CmdCfgNode" }
 
     override CmdChildMapping s;
 
     override Cmd getStmt() { result = super.getStmt() }
 
-    ExprCfgNode getArgument(int i) { s.hasCfgChild(s.getArgument(i), this, result) }
+    override ExprCfgNode getArgument(int i) { s.hasCfgChild(s.getArgument(i), this, result) }
 
-    ExprCfgNode getPositionalArgument(int i) {
+    override ExprCfgNode getPositionalArgument(int i) {
       s.hasCfgChild(s.getPositionalArgument(i), this, result)
     }
 
-    ExprCfgNode getNamedArgument(string name) {
+    override ExprCfgNode getNamedArgument(string name) {
       s.hasCfgChild(s.getNamedArgument(name), this, result)
     }
 
-    ExprCfgNode getAnArgument() { s.hasCfgChild(s.getAnArgument(), this, result) }
+    override ExprCfgNode getAnArgument() { s.hasCfgChild(s.getAnArgument(), this, result) }
 
     ExprCfgNode getCommand() { s.hasCfgChild(s.getCommand(), this, result) }
   }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
@@ -77,7 +77,7 @@ abstract class DataFlowCall extends TDataFlowCall {
   abstract DataFlowCallable getEnclosingCallable();
 
   /** Gets the underlying source code call, if any. */
-  abstract CfgNodes::StmtNodes::CmdCfgNode asCall();
+  abstract CfgNodes::CallCfgNode asCall();
 
   /** Gets a textual representation of this call. */
   abstract string toString();
@@ -107,11 +107,11 @@ abstract class DataFlowCall extends TDataFlowCall {
 }
 
 class NormalCall extends DataFlowCall, TNormalCall {
-  private CfgNodes::StmtNodes::CmdCfgNode c;
+  private CfgNodes::CallCfgNode c;
 
   NormalCall() { this = TNormalCall(c) }
 
-  override CfgNodes::StmtNodes::CmdCfgNode asCall() { result = c }
+  override CfgNodes::CallCfgNode asCall() { result = c }
 
   override DataFlowCallable getEnclosingCallable() { result = TCfgScope(c.getScope()) }
 
@@ -121,7 +121,7 @@ class NormalCall extends DataFlowCall, TNormalCall {
 }
 
 /** A call for which we want to compute call targets. */
-private class RelevantCall extends CfgNodes::StmtNodes::CmdCfgNode { }
+private class RelevantCall extends CfgNodes::CallCfgNode { }
 
 /** Holds if `call` may resolve to the returned source-code method. */
 private DataFlowCallable viableSourceCallable(DataFlowCall call) {
@@ -139,15 +139,7 @@ class AdditionalCallTarget extends Unit {
   /**
    * Gets a viable target for `call`.
    */
-  abstract DataFlowCallable viableTarget(CfgNodes::StmtNodes::CmdCfgNode call);
-}
-
-/** Holds if `call` may resolve to the returned summarized library method. */
-DataFlowCallable viableLibraryCallable(DataFlowCall call) {
-  exists(LibraryCallable callable |
-    result = TLibraryCallable(callable) and
-    call.asCall().getStmt() = callable.getACall()
-  )
+  abstract DataFlowCallable viableTarget(CfgNodes::CallCfgNode call);
 }
 
 cached
@@ -158,23 +150,19 @@ private module Cached {
     TLibraryCallable(LibraryCallable callable)
 
   cached
-  newtype TDataFlowCall = TNormalCall(CfgNodes::StmtNodes::CmdCfgNode c)
+  newtype TDataFlowCall = TNormalCall(CfgNodes::CallCfgNode c)
 
   /** Gets a viable run-time target for the call `call`. */
   cached
-  DataFlowCallable viableCallable(DataFlowCall call) {
-    result = viableSourceCallable(call)
-    or
-    result = viableLibraryCallable(call)
-  }
+  DataFlowCallable viableCallable(DataFlowCall call) { result = viableSourceCallable(call) }
 
   cached
   newtype TArgumentPosition =
     TKeywordArgumentPosition(string name) { name = any(CmdParameter p).getName() } or
     TPositionalArgumentPosition(int pos, NamedSet ns) {
-      exists(Cmd cmd |
-        cmd = ns.getABindingCall() and
-        exists(cmd.getArgument(pos))
+      exists(CfgNodes::CallCfgNode call |
+        call = ns.getABindingCall() and
+        exists(call.getArgument(pos))
       )
     }
 
@@ -182,9 +170,9 @@ private module Cached {
   newtype TParameterPosition =
     TKeywordParameter(string name) { name = any(CmdParameter p).getName() } or
     TPositionalParameter(int pos, NamedSet ns) {
-      exists(Cmd cmd |
-        cmd = ns.getABindingCall() and
-        exists(cmd.getArgument(pos))
+      exists(CfgNodes::CallCfgNode call |
+        call = ns.getABindingCall() and
+        exists(call.getArgument(pos))
       )
     }
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -597,22 +597,25 @@ predicate isUnreachableInCall(NodeRegion nr, DataFlowCall call) { none() }
 
 newtype LambdaCallKind = TLambdaCallKind()
 
-/** Holds if `creation` is an expression that creates a lambda of kind `kind` for `c`. */
-predicate lambdaCreation(Node creation, LambdaCallKind kind, DataFlowCallable c) { none() }
+private class CmdName extends StringConstExpr {
+  CmdName() { this = any(Cmd c).getCmdName() }
 
-/**
- * Holds if `call` is a from-source lambda call of kind `kind` where `receiver`
- * is the lambda expression.
- */
-predicate lambdaSourceCall(CfgNodes::StmtNodes::CmdCfgNode call, LambdaCallKind kind, Node receiver) {
-  none()
+  string getName() { result = this.getValue().getValue() }
+}
+
+/** Holds if `creation` is an expression that creates a lambda of kind `kind` for `c`. */
+predicate lambdaCreation(Node creation, LambdaCallKind kind, DataFlowCallable c) {
+  creation.asExpr().getExpr().(CmdName).getName() = c.asCfgScope().getEnclosingFunction().getName() and
+  exists(kind)
 }
 
 /**
  * Holds if `call` is a (from-source or from-summary) lambda call of kind `kind`
  * where `receiver` is the lambda expression.
  */
-predicate lambdaCall(DataFlowCall call, LambdaCallKind kind, Node receiver) { none() }
+predicate lambdaCall(DataFlowCall call, LambdaCallKind kind, Node receiver) {
+  call.asCall().getCommand() = receiver.asExpr() and exists(kind)
+}
 
 /** Extra data-flow steps needed for lambda flow analysis. */
 predicate additionalLambdaFlowStep(Node nodeFrom, Node nodeTo, boolean preservesValue) { none() }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -229,9 +229,10 @@ class SsaInputNode extends SsaNode {
   override CfgScope getCfgScope() { result = node.getDefinitionExt().getBasicBlock().getScope() }
 }
 
-private string getANamedArgument(Cmd c) { exists(c.getNamedArgument(result)) }
+private string getANamedArgument(CfgNodes::CallCfgNode c) { exists(c.getNamedArgument(result)) }
 
-private module NamedSetModule = QlBuiltins::InternSets<Cmd, string, getANamedArgument/1>;
+private module NamedSetModule =
+  QlBuiltins::InternSets<CfgNodes::CallCfgNode, string, getANamedArgument/1>;
 
 private newtype NamedSet0 =
   TEmptyNamedSet() or
@@ -257,11 +258,11 @@ class NamedSet extends NamedSet0 {
   }
 
   /**
-   * Gets a `Cmd` that provides a named parameter for every name in `this`.
+   * Gets a `CfgNodes::CallCfgNode` that provides a named parameter for every name in `this`.
    *
-   * NOTE: The `Cmd` may also provide more names.
+   * NOTE: The `CfgNodes::CallCfgNode` may also provide more names.
    */
-  Cmd getABindingCall() {
+  CfgNodes::CallCfgNode getABindingCall() {
     forex(string name | name = this.getAName() | exists(result.getNamedArgument(name)))
     or
     this.isEmpty() and
@@ -272,7 +273,7 @@ class NamedSet extends NamedSet0 {
    * Gets a `Cmd` that provides exactly the named parameters represented by
    * this set.
    */
-  Cmd getAnExactBindingCall() {
+  CfgNodes::CallCfgNode getAnExactBindingCall() {
     forex(string name | name = this.getAName() | exists(result.getNamedArgument(name))) and
     forex(string name | exists(result.getNamedArgument(name)) | name = this.getAName())
     or
@@ -366,7 +367,7 @@ module ArgumentNodes {
         or
         exists(NamedSet ns, int i |
           i = arg.getPosition() and
-          ns.getAnExactBindingCall() = call.asCall().getStmt() and
+          ns.getAnExactBindingCall() = call.asCall() and
           pos.isPositional(i, ns)
         )
       )

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
@@ -77,6 +77,13 @@ class ParameterNode extends Node {
 }
 
 /**
+ * A data-flow node that is a source of local flow.
+ */
+class LocalSourceNode extends Node {
+  LocalSourceNode() { isLocalSourceNode(this) }
+}
+
+/**
  * A node associated with an object after an operation that might have
  * changed its state.
  *

--- a/powershell/ql/lib/semmle/code/powershell/typetracking/TypeTracking.qll
+++ b/powershell/ql/lib/semmle/code/powershell/typetracking/TypeTracking.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for simple data-flow reachability suitable
+ * for tracking types.
+ */
+
+private import semmle.code.powershell.typetracking.internal.TypeTrackingImpl as Impl
+import Impl::Shared::TypeTracking<Impl::TypeTrackingInput>

--- a/powershell/ql/lib/semmle/code/powershell/typetracking/internal/TypeTrackingImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/typetracking/internal/TypeTrackingImpl.qll
@@ -1,0 +1,244 @@
+import codeql.typetracking.TypeTracking as Shared
+import codeql.typetracking.internal.TypeTrackingImpl as SharedImpl
+private import powershell
+private import semmle.code.powershell.controlflow.Cfg as Cfg
+private import Cfg::CfgNodes
+private import codeql.typetracking.internal.SummaryTypeTracker as SummaryTypeTracker
+private import semmle.code.powershell.dataflow.DataFlow
+private import semmle.code.powershell.dataflow.internal.DataFlowImplCommon as DataFlowImplCommon
+private import semmle.code.powershell.dataflow.internal.DataFlowPublic as DataFlowPublic
+private import semmle.code.powershell.dataflow.internal.DataFlowPrivate as DataFlowPrivate
+private import semmle.code.powershell.dataflow.internal.DataFlowDispatch as DataFlowDispatch
+private import codeql.util.Unit
+
+pragma[noinline]
+private predicate argumentPositionMatch(
+  DataFlowDispatch::DataFlowCall call, DataFlowPrivate::ArgumentNode arg,
+  DataFlowDispatch::ParameterPosition ppos
+) {
+  exists(DataFlowDispatch::ArgumentPosition apos |
+    arg.argumentOf(call, apos) and
+    DataFlowDispatch::parameterMatch(ppos, apos)
+  )
+}
+
+pragma[noinline]
+private predicate viableParam(
+  DataFlowDispatch::DataFlowCall call, DataFlowPrivate::ParameterNodeImpl p,
+  DataFlowDispatch::ParameterPosition ppos
+) {
+  exists(DataFlowDispatch::DataFlowCallable callable |
+    DataFlowDispatch::getTarget(call) = callable.asCfgScope()
+  |
+    p.isParameterOf(callable, ppos)
+  )
+}
+
+/** Holds if there is flow from `arg` to `p` via the call `call`. */
+pragma[nomagic]
+predicate callStep(
+  DataFlowDispatch::DataFlowCall call, DataFlow::Node arg, DataFlowPrivate::ParameterNodeImpl p
+) {
+  exists(DataFlowDispatch::ParameterPosition pos |
+    argumentPositionMatch(call, arg, pos) and
+    viableParam(call, p, pos)
+  )
+}
+
+private module SummaryTypeTrackerInput implements SummaryTypeTracker::Input {
+  class Node = DataFlow::Node;
+
+  class Content = DataFlowPublic::ContentSet;
+
+  class ContentFilter = TypeTrackingInput::ContentFilter;
+
+  ContentFilter getFilterFromWithoutContentStep(Content content) {
+    none() // TODO
+  }
+
+  ContentFilter getFilterFromWithContentStep(Content content) {
+    none() // TODO
+  }
+
+  // Summaries and their stacks
+  class SummaryComponent extends Unit {
+    SummaryComponent() { none() }
+  }
+
+  class SummaryComponentStack extends Unit {
+    SummaryComponent head() { none() }
+  }
+
+  SummaryComponentStack singleton(SummaryComponent component) { none() }
+
+  SummaryComponentStack push(SummaryComponent head, SummaryComponentStack tail) { none() }
+
+  SummaryComponent return() { none() }
+
+  SummaryComponent content(Content contents) { none() }
+
+  SummaryComponent withoutContent(Content contents) { none() }
+
+  SummaryComponent withContent(Content contents) { none() }
+
+  class SummarizedCallable extends Unit {
+    SummarizedCallable() { none() }
+
+    predicate propagatesFlow(
+      SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+    ) {
+      none()
+    }
+  }
+
+  Node argumentOf(Node call, SummaryComponent arg, boolean isPostUpdate) { none() }
+
+  Node parameterOf(Node callable, SummaryComponent param) { none() }
+
+  Node returnOf(Node callable, SummaryComponent return) { none() }
+
+  Node callTo(SummarizedCallable callable) { none() }
+}
+
+private module TypeTrackerSummaryFlow = SummaryTypeTracker::SummaryFlow<SummaryTypeTrackerInput>;
+
+private newtype TContentFilter = MkElementFilter()
+
+module TypeTrackingInput implements Shared::TypeTrackingInput {
+  class Node = DataFlowPublic::Node;
+
+  class LocalSourceNode = DataFlowPublic::LocalSourceNode;
+
+  class Content = DataFlowPublic::ContentSet;
+
+  /**
+   * A label to use for `WithContent` and `WithoutContent` steps, restricting
+   * which `ContentSet` may pass through.
+   */
+  class ContentFilter extends TContentFilter {
+    /** Gets a string representation of this content filter. */
+    string toString() { this = MkElementFilter() and result = "elements" }
+
+    /** Gets the content of a type-tracker that matches this filter. */
+    Content getAMatchingContent() {
+      none() // TODO
+    }
+  }
+
+  /**
+   * Holds if a value stored with `storeContents` can be read back with `loadContents`.
+   */
+  pragma[inline]
+  predicate compatibleContents(Content storeContents, Content loadContents) {
+    storeContents.getAStoreContent() = loadContents.getAReadContent()
+  }
+
+  /** Holds if there is a simple local flow step from `nodeFrom` to `nodeTo` */
+  predicate simpleLocalSmallStep = DataFlowPrivate::localFlowStepTypeTracker/2;
+
+  /** Holds if there is a level step from `nodeFrom` to `nodeTo`, which does not depend on the call graph. */
+  pragma[nomagic]
+  predicate levelStepNoCall(Node nodeFrom, LocalSourceNode nodeTo) {
+    TypeTrackerSummaryFlow::levelStepNoCall(nodeFrom, nodeTo)
+  }
+
+  /** Holds if there is a level step from `nodeFrom` to `nodeTo`, which may depend on the call graph. */
+  pragma[nomagic]
+  predicate levelStepCall(Node nodeFrom, LocalSourceNode nodeTo) { none() }
+
+  /**
+   * Holds if `nodeFrom` steps to `nodeTo` by being passed as a parameter in a call.
+   *
+   * Flow into summarized library methods is not included, as that will lead to negative
+   * recursion (or, at best, terrible performance), since identifying calls to library
+   * methods is done using API graphs (which uses type tracking).
+   */
+  predicate callStep(Node nodeFrom, LocalSourceNode nodeTo) { callStep(_, nodeFrom, nodeTo) }
+
+  /**
+   * Holds if `nodeFrom` steps to `nodeTo` by being returned from a call.
+   */
+  predicate returnStep(Node nodeFrom, LocalSourceNode nodeTo) {
+    exists(CallCfgNode call |
+      nodeFrom instanceof DataFlowPrivate::ReturnNode and
+      nodeFrom.(DataFlowPrivate::NodeImpl).getCfgScope() =
+        DataFlowDispatch::getTarget(DataFlowDispatch::TNormalCall(call)) and
+      nodeTo.asExpr().getAstNode() = call.getAstNode()
+    )
+  }
+
+  /**
+   * Holds if `nodeFrom` is being written to the `contents` of the object
+   * in `nodeTo`.
+   *
+   * Note that the choice of `nodeTo` does not have to make sense
+   * "chronologically". All we care about is whether the `contents` of
+   * `nodeTo` can have a specific type, and the assumption is that if a specific
+   * type appears here, then any access of that particular content can yield
+   * something of that particular type.
+   */
+  predicate storeStep(Node nodeFrom, Node nodeTo, Content contents) {
+    DataFlowPrivate::storeStep(nodeFrom, contents, nodeTo)
+    or
+    TypeTrackerSummaryFlow::basicStoreStep(nodeFrom, nodeTo, contents)
+  }
+
+  /**
+   * Holds if `nodeTo` is the result of accessing the `content` content of `nodeFrom`.
+   */
+  predicate loadStep(Node nodeFrom, LocalSourceNode nodeTo, Content contents) {
+    DataFlowPrivate::readStep(nodeFrom, contents, nodeTo)
+    or
+    TypeTrackerSummaryFlow::basicLoadStep(nodeFrom, nodeTo, contents)
+  }
+
+  /**
+   * Holds if the `loadContent` of `nodeFrom` is stored in the `storeContent` of `nodeTo`.
+   */
+  predicate loadStoreStep(Node nodeFrom, Node nodeTo, Content loadContent, Content storeContent) {
+    TypeTrackerSummaryFlow::basicLoadStoreStep(nodeFrom, nodeTo, loadContent, storeContent)
+  }
+
+  /**
+   * Same as `withContentStep`, but `nodeTo` has type `Node` instead of `LocalSourceNode`,
+   * which allows for it by used in the definition of `LocalSourceNode`.
+   */
+  additional predicate withContentStepImpl(Node nodeFrom, Node nodeTo, ContentFilter filter) {
+    TypeTrackerSummaryFlow::basicWithContentStep(nodeFrom, nodeTo, filter)
+  }
+
+  /**
+   * Holds if type-tracking should step from `nodeFrom` to `nodeTo` if inside a
+   * content matched by `filter`.
+   */
+  predicate withContentStep(Node nodeFrom, LocalSourceNode nodeTo, ContentFilter filter) {
+    withContentStepImpl(nodeFrom, nodeTo, filter)
+  }
+
+  /**
+   * Same as `withoutContentStep`, but `nodeTo` has type `Node` instead of `LocalSourceNode`,
+   * which allows for it by used in the definition of `LocalSourceNode`.
+   */
+  additional predicate withoutContentStepImpl(Node nodeFrom, Node nodeTo, ContentFilter filter) {
+    TypeTrackerSummaryFlow::basicWithoutContentStep(nodeFrom, nodeTo, filter)
+  }
+
+  /**
+   * Holds if type-tracking should step from `nodeFrom` to `nodeTo` but block
+   * flow of contents matched by `filter` through here.
+   */
+  predicate withoutContentStep(Node nodeFrom, LocalSourceNode nodeTo, ContentFilter filter) {
+    withoutContentStepImpl(nodeFrom, nodeTo, filter)
+  }
+
+  /**
+   * Holds if data can flow from `node1` to `node2` in a way that discards call contexts.
+   */
+  predicate jumpStep(Node nodeFrom, LocalSourceNode nodeTo) {
+    DataFlowPrivate::jumpStep(nodeFrom, nodeTo)
+  }
+
+  predicate hasFeatureBacktrackStoreTarget() { none() }
+}
+
+import SharedImpl::TypeTracking<TypeTrackingInput>


### PR DESCRIPTION
This PR implements function call resolution. That is, the mapping from function _calls_ to the set of possible functions that the call may target.

There are two algorithms at play here:

- In order to resolve member function calls we need to compute the runtime type of the qualifier. For example, in order to know where `$x.Foo()` goes we need to know the runtime type of `$x`. We can then look up the `Foo` member function declared by the type that we compute for `$x`.

  The runtime type of a qualifier is computed using the shared type-tracking library. There are still quite a lot to be done here, but for now it gets the job done. I will add some more testcases once we have more control-flow so that we actually have some function calls to resolve 😅
- In order to resolve non-member functions we simply track flow from the function object to the call site. For example, in order to resolve:
  ```powershell
  $x = $function:Foo
  $x.Invoke()
  ```
  we track flow from `$function:Foo` to `$x` in `$x.Invoke()`. A function call such as `Foo()` is just a special case where the flow is "trivial".