### PR TITLE
Powershell: Fix dataflow/SSA consistency errors.

### DIFF
--- a/powershell/ql/consistency-queries/DataFlowConsistency.ql
+++ b/powershell/ql/consistency-queries/DataFlowConsistency.ql
@@ -1,0 +1,11 @@
+import semmle.code.powershell.dataflow.DataFlow::DataFlow as DataFlow
+private import powershell
+private import semmle.code.powershell.dataflow.internal.DataFlowImplSpecific
+private import semmle.code.powershell.dataflow.internal.TaintTrackingImplSpecific
+private import codeql.dataflow.internal.DataFlowImplConsistency
+
+private module Input implements InputSig<Location, PowershellDataFlow> {
+  private import PowershellDataFlow
+}
+
+import MakeConsistency<Location, PowershellDataFlow, PowershellTaintTracking, Input>

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -34,7 +34,7 @@ abstract class NodeImpl extends Node {
 }
 
 private class ExprNodeImpl extends ExprNode, NodeImpl {
-  override CfgScope getCfgScope() { none() /* TODO */ }
+  override CfgScope getCfgScope() { result = this.getExprNode().getExpr().getEnclosingScope() }
 
   override Location getLocationImpl() { result = this.getExprNode().getLocation() }
 
@@ -42,7 +42,7 @@ private class ExprNodeImpl extends ExprNode, NodeImpl {
 }
 
 private class StmtNodeImpl extends StmtNode, NodeImpl {
-  override CfgScope getCfgScope() { none() /* TODO */ }
+  override CfgScope getCfgScope() { result = this.getStmtNode().getStmt().getEnclosingScope() }
 
   override Location getLocationImpl() { result = this.getStmtNode().getLocation() }
 
@@ -69,7 +69,9 @@ module SsaFlow {
   Impl::Node asNode(Node n) {
     n = TSsaNode(result)
     or
-    result.(Impl::ExprNode).getExpr() = n.asExpr() // TODO: Statement nodes?
+    result.(Impl::ExprNode).getExpr() = n.asExpr()
+    or
+    result.(Impl::ExprNode).getExpr() = n.asStmt()
     or
     result.(Impl::ExprPostUpdateNode).getExpr() = n.(PostUpdateNode).getPreUpdateNode().asExpr()
     or
@@ -371,7 +373,8 @@ private module ParameterNodes {
     override Parameter getParameter() { result = parameter }
 
     override predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
-      exists(CfgScope callable | callable = c.asCfgScope() |
+      parameter.getDeclaringScope() = c.asCfgScope() and
+      (
         pos.isKeyword(parameter.getName())
         or
         // Given a function f with parameters x, y we map

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
@@ -344,7 +344,7 @@ class ParameterExt extends TParameterExt {
 private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInputSig {
   class Parameter = ParameterExt;
 
-  class Expr extends Cfg::CfgNodes::ExprCfgNode {
+  class Expr extends Cfg::CfgNodes::AstCfgNode {
     predicate hasCfgNode(SsaInput::BasicBlock bb, int i) { this = bb.getNode(i) }
   }
 


### PR DESCRIPTION
This adds the dataflow consistency queries for Powershell, and also fixes the worst offenders. In particular, every dataflow node must have an enclosing callable, and I had forgotten to implement this predicate 😅

In addition, Poweshell, unfortunately, needs dataflow nodes for certain statements (because of the structure of the AST), and I had forgotten to include these in SSA.

Both of these problems are fixed in this PR. There are no changes to results because we're still missing loads of control flow.