### PR TITLE
PS: Add more type-tracking flow

### DIFF
--- a/powershell/ql/consistency-queries/TypeTrackingConsistency.ql
+++ b/powershell/ql/consistency-queries/TypeTrackingConsistency.ql
@@ -1,0 +1,8 @@
+import semmle.code.powershell.dataflow.DataFlow
+import semmle.code.powershell.typetracking.internal.TypeTrackingImpl
+
+private module ConsistencyChecksInput implements ConsistencyChecksInputSig {
+  predicate unreachableNodeExclude(DataFlow::Node n) { n instanceof DataFlow::PostUpdateNode }
+}
+
+import ConsistencyChecks<ConsistencyChecksInput>

--- a/powershell/ql/lib/powershell.qll
+++ b/powershell/ql/lib/powershell.qll
@@ -71,6 +71,7 @@ import semmle.code.powershell.StringConstantExpression
 import semmle.code.powershell.MemberExpr
 import semmle.code.powershell.InvokeMemberExpression
 import semmle.code.powershell.Call
+import semmle.code.powershell.ObjectCreation
 import semmle.code.powershell.SubExpression
 import semmle.code.powershell.ErrorExpr
 import semmle.code.powershell.ConvertExpr

--- a/powershell/ql/lib/semmle/code/powershell/Call.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Call.qll
@@ -12,6 +12,9 @@ abstract private class AbstractCall extends Ast {
   /** Gets the i'th positional argument to this call. */
   abstract Expr getPositionalArgument(int i);
 
+  /** Holds if an argument with name `name` is provided to this call. */
+  final predicate hasNamedArgument(string name) { exists(this.getNamedArgument(name)) }
+
   /** Gets the argument to this call with the name `name`. */
   abstract Expr getNamedArgument(string name);
 
@@ -25,7 +28,8 @@ abstract private class AbstractCall extends Ast {
   abstract Function getATarget();
 }
 
-private class CmdCall extends AbstractCall instanceof Cmd {
+/** A call to a command. For example, `Write-Host "Hello, world!"`. */
+class CmdCall extends AbstractCall instanceof Cmd {
   final override Expr getCommand() { result = Cmd.super.getCommand() }
 
   final override Expr getPositionalArgument(int i) { result = Cmd.super.getPositionalArgument(i) }
@@ -43,7 +47,8 @@ private class CmdCall extends AbstractCall instanceof Cmd {
   }
 }
 
-private class InvokeMemberCall extends AbstractCall instanceof InvokeMemberExpr {
+/** A call to a method on an object. For example, `$obj.ToString()`. */
+class MethodCall extends AbstractCall instanceof InvokeMemberExpr {
   final override Expr getCommand() { result = super.getMember() }
 
   final override Expr getPositionalArgument(int i) {

--- a/powershell/ql/lib/semmle/code/powershell/Command.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Command.qll
@@ -49,6 +49,9 @@ class Cmd extends @command, CmdBase {
       )
   }
 
+  /** Holds if this call has an argument named `name`. */
+  predicate hasNamedArgument(string name) { exists(this.getNamedArgument(name)) }
+
   /** Gets the named argument with the given name. */
   Expr getNamedArgument(string name) {
     exists(int i, CmdParameter p |

--- a/powershell/ql/lib/semmle/code/powershell/Function.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Function.qll
@@ -2,32 +2,58 @@ import powershell
 import semmle.code.powershell.controlflow.BasicBlocks
 
 abstract private class AbstractFunction extends Ast {
+  /** Gets the name of this function. */
   abstract string getName();
 
+  /** Holds if this function has name `name`. */
   final predicate hasName(string name) { this.getName() = name }
 
+  /** Gets the body of this function. */
   abstract ScriptBlock getBody();
 
+  /**
+   * Gets the i'th function parameter, if any.
+   *
+   * Note that this predicate only returns _function_ parameters.
+   * To also get _block_ parameters use the `getParameter` predicate.
+   */
   abstract Parameter getFunctionParameter(int i);
 
+  /** Gets the declaring type of this function, if any. */
+  abstract Type getDeclaringType();
+
+  /**
+   * Gets any function parameter of this function.
+   *
+   * Note that this only gets _function_ paramters. To get any parameter
+   * use the `getAParameter` predicate.
+   */
   final Parameter getAFunctionParameter() { result = this.getFunctionParameter(_) }
 
+  /** Gets the number of function parameters. */
   final int getNumberOfFunctionParameters() { result = count(this.getAFunctionParameter()) }
 
+  /** Gets the number of parameters (both function and block). */
   final int getNumberOfParameters() { result = count(this.getAParameter()) }
 
+  /** Gets the i'th parameter of this function, if any. */
   final Parameter getParameter(int i) {
     result = this.getFunctionParameter(i)
     or
     result = this.getBody().getParamBlock().getParameter(i)
   }
 
+  /** Gets any parameter of this function. */
   final Parameter getAParameter() { result = this.getParameter(_) }
 
+  /** Gets the entry point of this function in the control-flow graph. */
   EntryBasicBlock getEntryBasicBlock() { result.getScope() = this.getBody() }
 }
 
-class NonMemberFunction extends @function_definition, Stmt, AbstractFunction {
+/**
+ * A function definition.
+ */
+private class FunctionBase extends @function_definition, Stmt, AbstractFunction {
   override string toString() { result = this.getName() }
 
   override SourceLocation getLocation() { function_definition_location(this, result) }
@@ -41,34 +67,32 @@ class NonMemberFunction extends @function_definition, Stmt, AbstractFunction {
   predicate isWorkflow() { function_definition(this, _, _, _, true) }
 
   override Parameter getFunctionParameter(int i) { result.isFunctionParameter(this, i) }
+
+  override Type getDeclaringType() { none() }
 }
 
-class MemberFunction extends @function_member, Member, AbstractFunction {
-  override string getName() { function_member(this, _, _, _, _, _, _, result, _) }
-
-  override SourceLocation getLocation() { function_member_location(this, result) }
-
-  override string toString() { result = this.getName() }
-
-  override ScriptBlock getBody() { function_member(this, result, _, _, _, _, _, _, _) }
-
-  override predicate isHidden() { function_member(this, _, _, true, _, _, _, _, _) }
-
-  override predicate isPrivate() { function_member(this, _, _, _, true, _, _, _, _) }
-
-  override predicate isPublic() { function_member(this, _, _, _, _, true, _, _, _) }
-
-  override predicate isStatic() { function_member(this, _, _, _, _, _, true, _, _) }
-
-  predicate isConstructor() { function_member(this, _, true, _, _, _, _, _, _) }
-
-  override Parameter getFunctionParameter(int i) { result.isFunctionParameter(this, i) }
-
-  TypeConstraint getTypeConstraint() { function_member_return_type(this, result) }
+private predicate isMethod(Member m, ScriptBlock body) {
+  function_member(m, body, _, _, _, _, _, _, _)
 }
 
-class Constructor extends MemberFunction {
+/**
+ * A method definition. That is, a function defined inside a class definition.
+ */
+class Method extends FunctionBase {
+  Method() { isMethod(_, super.getBody()) }
+
+  /** Gets the member corresponding to this function definition. */
+  Member getMember() { isMethod(result, super.getBody()) }
+
+  /** Holds if this method is a constructor. */
+  predicate isConstructor() { function_member(this.getMember(), _, true, _, _, _, _, _, _) }
+
+  final override Type getDeclaringType() { result = this.getMember().getDeclaringType() }
+}
+
+/** A constructor definition. */
+class Constructor extends Method {
   Constructor() { this.isConstructor() }
 }
 
-final class Function = AbstractFunction;
+final class Function = FunctionBase;

--- a/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/InvokeMemberExpression.qll
@@ -18,8 +18,30 @@ class InvokeMemberExpr extends @invoke_member_expression, MemberExprBase {
   override predicate isStatic() { this.getQualifier() instanceof TypeNameExpr }
 }
 
+/**
+ * A call to a constructor. For example:
+ *
+ * ```powershell
+ * [System.IO.FileInfo]::new("C:\\file.txt")
+ * ```
+ */
 class ConstructorCall extends InvokeMemberExpr {
-  ConstructorCall() { this.isStatic() and this.getName() = "new" }
+  TypeNameExpr typename;
 
-  Type getConstructedType() { result = this.getQualifier().(TypeNameExpr).getType() }
+  ConstructorCall() {
+    this.isStatic() and typename = this.getQualifier() and this.getName() = "new"
+  }
+
+  /**
+   * Gets the type being constructed by this constructor call.
+   *
+   * Note that the type may not exist in the database.
+   *
+   * Use `getConstructedTypeName` to get the name of the type (which will
+   * always exist in the database).
+   */
+  Type getConstructedType() { result = typename.getType() }
+
+  /** Gets the name of the type being constructed by this constructor call. */
+  string getConstructedTypeName() { result = typename.getName() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/ObjectCreation.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ObjectCreation.qll
@@ -1,0 +1,55 @@
+import powershell
+
+abstract private class AbstractObjectCreation extends Call {
+  /**
+   * The type of the object being constructed.
+   * Note that the type may not exist in the database.
+   *
+   * Use `getConstructedTypeName` to get the name of the type (which will
+   * always exist in the database).
+   */
+  abstract Type getConstructedType();
+
+  /** The name of the type of the object being constructed. */
+  abstract string getConstructedTypeName();
+}
+
+/**
+ * An object creation from a call to a constructor. For example:
+ * ```powershell
+ * [System.IO.FileInfo]::new("C:\\file.txt")
+ * ```
+ */
+class NewObjectCreation extends AbstractObjectCreation instanceof ConstructorCall {
+  final override Type getConstructedType() { result = ConstructorCall.super.getConstructedType() }
+
+  final override string getConstructedTypeName() {
+    result = ConstructorCall.super.getConstructedTypeName()
+  }
+}
+
+/**
+ * An object creation from a call to `New-Object`. For example:
+ * ```powershell
+ * New-Object -TypeName System.IO.FileInfo -ArgumentList "C:\\file.txt"
+ * ```
+ */
+class DotNetObjectCreation extends AbstractObjectCreation instanceof Cmd {
+  DotNetObjectCreation() { this.getCommandName() = "New-Object" }
+
+  final override Type getConstructedType() { none() }
+
+  final override string getConstructedTypeName() {
+    // Either it's the named argument `TypeName`
+    result = Cmd.super.getNamedArgument("TypeName").(StringConstExpr).getValue().getValue()
+    or
+    // Or it's the first positional argument if that's the named argument
+    not Cmd.super.hasNamedArgument("TypeName") and
+    exists(StringConstExpr arg | arg = Cmd.super.getPositionalArgument(0) |
+      result = arg.getValue().getValue() and
+      not arg = Cmd.super.getNamedArgument(["ArgumentList", "Property"])
+    )
+  }
+}
+
+final class ObjectCreation = AbstractObjectCreation;

--- a/powershell/ql/lib/semmle/code/powershell/Type.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Type.qll
@@ -11,10 +11,15 @@ class Type extends @type_definition, Stmt {
 
   Member getAMember() { result = this.getMember(_) }
 
-  MemberFunction getMemberFunction(string name) {
-    result = this.getAMember() and
+  Method getMethod(string name) {
+    result.getMember() = this.getAMember() and
     result.hasName(name)
   }
 
-  MemberFunction getAMemberFunction() { result = this.getMemberFunction(_) }
+  Constructor getAConstructor() {
+    result = this.getAMethod() and
+    result.getName() = this.getName()
+  }
+
+  Method getAMethod() { result = this.getMethod(_) }
 }

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -4,8 +4,6 @@ private import internal.Internal as Internal
 
 private predicate isFunctionParameterImpl(Internal::Parameter p, Function f, int i) {
   function_definition_parameter(f, i, p)
-  or
-  function_member_parameter(f, i, p)
 }
 
 private predicate hasParameterBlockImpl(Internal::Parameter p, ParamBlock block, int i) {

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -128,6 +128,8 @@ abstract private class NonExprChildMapping extends ChildMapping {
 abstract private class AbstractCallCfgNode extends AstCfgNode {
   override string getAPrimaryQlClass() { result = "CfgCall" }
 
+  final predicate hasName(string name) { this.getName() = name }
+
   abstract string getName();
 
   ExprCfgNode getQualifier() { none() }
@@ -231,7 +233,7 @@ module ExprNodes {
     final override ExprCfgNode getCommand() { none() }
   }
 
-    /** A control-flow node that wraps an `ConstructorCall` expression. */
+  /** A control-flow node that wraps an `ConstructorCall` expression. */
   class ConstructorCallCfgNode extends InvokeMemberCfgNode {
     ConstructorCallCfgNode() { super.getExpr() instanceof ConstructorCall }
 

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -147,6 +147,18 @@ abstract private class AbstractCallCfgNode extends AstCfgNode {
 
 final class CallCfgNode = AbstractCallCfgNode;
 
+class ObjectCreationCfgNode extends CallCfgNode {
+  ObjectCreation objectCreation;
+
+  ObjectCreationCfgNode() { this.getAstNode() = objectCreation }
+
+  ObjectCreation getObjectCreation() { result = objectCreation }
+
+  Type getConstructedType() { result = objectCreation.getConstructedType() }
+
+  string getConstructedTypeName() { result = objectCreation.getConstructedTypeName() }
+}
+
 /** Provides classes for control-flow nodes that wrap AST expressions. */
 module ExprNodes {
   private class VarAccessChildMapping extends ExprChildMapping, VarAccess {
@@ -228,7 +240,7 @@ module ExprNodes {
 
     final override ExprCfgNode getAnArgument() { e.hasCfgChild(e.getAnArgument(), this, result) }
 
-    final override string getName() { none() }
+    final override string getName() { result = e.getName() }
 
     final override ExprCfgNode getCommand() { none() }
   }
@@ -247,6 +259,23 @@ module ExprNodes {
     QualifierCfgNode() { this = any(InvokeMemberCfgNode invoke).getQualifier() }
 
     InvokeMemberCfgNode getInvokeMember() { this = result.getQualifier() }
+  }
+
+  class TypeNameChildMapping extends ExprChildMapping, TypeNameExpr {
+    override predicate relevantChild(Ast n) { none() }
+  }
+
+  /** A control-flow node that wraps a `TypeName` expression. */
+  class TypeNameCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "TypeNameCfgNode" }
+
+    override TypeNameChildMapping e;
+
+    override TypeNameExpr getExpr() { result = super.getExpr() }
+
+    Type getType() { result = this.getExpr().getType() }
+
+    string getTypeName() { result = this.getExpr().getName() }
   }
 
   class ConditionalChildMapping extends ExprChildMapping, ConditionalExpr {
@@ -351,5 +380,20 @@ module StmtNodes {
 
     /** Gets the RHS of this assignment. */
     final StmtCfgNode getRightHandSide() { s.hasCfgChild(s.getRightHandSide(), this, result) }
+  }
+
+  class CmdExprChildMapping extends NonExprChildMapping, CmdExpr {
+    override predicate relevantChild(Ast n) { n = this.getExpr() }
+  }
+
+  /** A control-flow node that wraps a `CmdExpr` expression. */
+  class CmdExprCfgNode extends StmtCfgNode {
+    override string getAPrimaryQlClass() { result = "CmdExprCfgNode" }
+
+    override CmdExprChildMapping s;
+
+    override CmdExpr getStmt() { result = super.getStmt() }
+
+    final ExprCfgNode getExpr() { s.hasCfgChild(s.getExpr(), this, result) }
   }
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
@@ -155,7 +155,7 @@ private predicate qualifiedCall(CfgNodes::CallCfgNode call, Node receiver, strin
   call.getName() = method
 }
 
-private Node trackInstance(Type t, boolean exact) {
+Node trackInstance(Type t, boolean exact) {
   result =
     CallGraphConstruction::Make<TrackInstanceInput>::track(TrackInstanceInput::MkState(t, exact))
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
@@ -122,21 +122,34 @@ class NormalCall extends DataFlowCall, TNormalCall {
   override Location getLocation() { result = c.getLocation() }
 }
 
-/** A call for which we want to compute call targets. */
-private class RelevantCall extends CfgNodes::CallCfgNode { }
+private predicate localFlowStep(Node nodeFrom, Node nodeTo, StepSummary summary) {
+  localFlowStepTypeTracker(nodeFrom, nodeTo) and
+  summary.toString() = "level"
+}
 
 private module TrackInstanceInput implements CallGraphConstruction::InputSig {
-  newtype State = additional MkState(Type m, Boolean exact)
+  private predicate start0(Node start, string typename, boolean exact) {
+    start.(ObjectCreationNode).getObjectCreationNode().getConstructedTypeName() = typename and
+    exact = true
+    or
+    start.asExpr().(CfgNodes::ExprNodes::TypeNameCfgNode).getTypeName() = typename and
+    exact = true
+  }
+
+  newtype State = additional MkState(string typename, Boolean exact) { start0(_, typename, exact) }
 
   predicate start(Node start, State state) {
-    exists(Type tp, boolean exact | state = MkState(tp, exact) |
-      start.asExpr().(CfgNodes::ExprNodes::ConstructorCallCfgNode).getConstructedType() = tp
+    exists(string typename, boolean exact |
+      state = MkState(typename, exact) and
+      start0(start, typename, exact)
     )
   }
 
   pragma[nomagic]
   predicate stepNoCall(Node nodeFrom, Node nodeTo, StepSummary summary) {
     smallStepNoCall(nodeFrom, nodeTo, summary)
+    or
+    localFlowStep(nodeFrom, nodeTo, summary)
   }
 
   predicate stepCall(Node nodeFrom, Node nodeTo, StepSummary summary) {
@@ -155,16 +168,22 @@ private predicate qualifiedCall(CfgNodes::CallCfgNode call, Node receiver, strin
   call.getName() = method
 }
 
-Node trackInstance(Type t, boolean exact) {
+Node trackInstance(string typename, boolean exact) {
   result =
-    CallGraphConstruction::Make<TrackInstanceInput>::track(TrackInstanceInput::MkState(t, exact))
+    CallGraphConstruction::Make<TrackInstanceInput>::track(TrackInstanceInput::MkState(typename,
+        exact))
 }
 
 private CfgScope getTargetInstance(CfgNodes::CallCfgNode call) {
-  exists(Node receiver, string method, Type t |
+  // TODO: Also match argument/parameter types
+  exists(Node receiver, string method, string typename, Type t |
     qualifiedCall(call, receiver, method) and
-    receiver = trackInstance(t, _) and
-    result = t.getMemberFunction(method).getBody()
+    receiver = trackInstance(typename, _) and
+    t.getName() = typename
+  |
+    if method = "new"
+    then result = t.getAConstructor().getBody()
+    else result = t.getMethod(method).getBody()
   )
 }
 

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -94,6 +94,8 @@ module LocalFlow {
     nodeFrom.asExpr() = nodeTo.asExpr().(CfgNodes::ExprNodes::ConditionalCfgNode).getABranch()
     or
     nodeFrom.asStmt() = nodeTo.asStmt().(CfgNodes::StmtNodes::AssignStmtCfgNode).getRightHandSide()
+    or
+    nodeFrom.asExpr() = nodeTo.asStmt().(CfgNodes::StmtNodes::CmdExprCfgNode).getExpr()
   }
 
   predicate localMustFlowStep(Node nodeFrom, Node nodeTo) {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
@@ -228,3 +228,20 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     none() // TODO
   }
 }
+
+/**
+ * A dataflow node that represents the creation of an object.
+ * 
+ * For example, `[Foo]::new()` or `New-Object Foo`.
+ */
+class ObjectCreationNode extends Node {
+  CfgNodes::ObjectCreationCfgNode objectCreation;
+
+  ObjectCreationNode() {
+    this.asExpr() = objectCreation
+    or
+    this.asStmt() = objectCreation
+  }
+
+  final CfgNodes::ObjectCreationCfgNode getObjectCreationNode() { result = objectCreation }
+}

--- a/powershell/ql/test/library-tests/dataflow/local/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/test.expected
@@ -4,6 +4,7 @@
 | test.ps1:4:1:4:3 | b | test.ps1:5:4:5:6 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:3 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:13 | ...=... |
+| test.ps1:5:4:5:6 | b | test.ps1:5:4:5:6 | b |
 | test.ps1:6:5:6:8 | a2 | test.ps1:8:6:8:9 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:8 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:17 | ...=... |

--- a/powershell/ql/test/library-tests/dataflow/typetracking/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/typetracking/test.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/powershell/ql/test/library-tests/dataflow/typetracking/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/typetracking/test.ps1
@@ -7,13 +7,13 @@ class MyClass {
 
 $myClass = [MyClass]::new("hello")
 
-Sink $myClass # $ MISSING: type=MyClass
+Sink $myClass # $ type=MyClass
 
 
 $withNamedArg = New-Object -TypeName PSObject
 
-Sink $withNamedArg # $ MISSING: type=PSObject
+Sink $withNamedArg # $ type=PSObject
 
 $withPositionalArg = New-Object PSObject
 
-Sink $withPositionalArg # $ MISSING: type=PSObject
+Sink $withPositionalArg # $ type=PSObject

--- a/powershell/ql/test/library-tests/dataflow/typetracking/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/typetracking/test.ps1
@@ -1,0 +1,19 @@
+class MyClass {
+    [string] $field
+    MyClass($val) {
+        $this.field = $val
+    }
+}
+
+$myClass = [MyClass]::new("hello")
+
+Sink $myClass # $ MISSING: type=MyClass
+
+
+$withNamedArg = New-Object -TypeName PSObject
+
+Sink $withNamedArg # $ MISSING: type=PSObject
+
+$withPositionalArg = New-Object PSObject
+
+Sink $withPositionalArg # $ MISSING: type=PSObject

--- a/powershell/ql/test/library-tests/dataflow/typetracking/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/typetracking/test.ql
@@ -1,0 +1,23 @@
+import powershell
+import semmle.code.powershell.dataflow.internal.DataFlowDispatch
+import semmle.code.powershell.dataflow.internal.DataFlowPublic
+import semmle.code.powershell.dataflow.internal.DataFlowPrivate
+import TestUtilities.InlineExpectationsTest
+
+module TypeTrackingTest implements TestSig {
+  string getARelevantTag() { result = "type" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(Node n, DataFlowCall c, Type t |
+      location = n.getLocation() and
+      element = n.toString() and
+      tag = "type" and
+      value = t.getName() and
+      n = trackInstance(t, _) and
+      isArgumentNode(n, c, _) and
+      c.asCall().hasName("Sink")
+    )
+  }
+}
+
+import MakeTest<TypeTrackingTest>

--- a/powershell/ql/test/library-tests/dataflow/typetracking/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/typetracking/test.ql
@@ -8,12 +8,11 @@ module TypeTrackingTest implements TestSig {
   string getARelevantTag() { result = "type" }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(Node n, DataFlowCall c, Type t |
+    exists(Node n, DataFlowCall c |
       location = n.getLocation() and
       element = n.toString() and
       tag = "type" and
-      value = t.getName() and
-      n = trackInstance(t, _) and
+      n = trackInstance(value, _) and
       isArgumentNode(n, c, _) and
       c.asCall().hasName("Sink")
     )


### PR DESCRIPTION
This PR adds more type-tracking flow in addition to adding some more tests which for type-tracking which was long overdue 😅

32f7f1b7e440df57518cef5f1473a9e0559c0068 simplifies our AST handling of methods. Previously, we were using two different extensionals to represent functions and methods (i.e., member functions), but I realizied that they're actually _both_ represented by the extensional that we were using for functions. So we could simplify some stuff there 🎉