### PR TITLE
PS: Add `Emptiness` completion to get rid of CFG inconsistencies

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/controlflow/ControlFlowGraph.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/ControlFlowGraph.qll
@@ -108,6 +108,15 @@ module SuccessorTypes {
   class ExitSuccessor extends SuccessorType, CfgImpl::TExitSuccessor {
     final override string toString() { result = "exit" }
   }
+
+  class EmptinessSuccessor extends ConditionalSuccessor, CfgImpl::TEmptinessSuccessor {
+    EmptinessSuccessor() { this = CfgImpl::TEmptinessSuccessor(value) }
+
+    /** Holds if this is an empty successor. */
+    predicate isEmpty() { value = true }
+
+    override string toString() { if this.isEmpty() then result = "empty" else result = "non-empty" }
+  }
 }
 
 class Split = Splitting::Split;

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
@@ -404,7 +404,7 @@ module Trees {
     final override predicate last(AstNode last, Completion c) {
       // Emptiness test exits with no more elements
       last = this and
-      completionIsSimple(c)
+      c.(EmptinessCompletion).isEmpty()
       or
       super.last(last, c)
     }
@@ -418,7 +418,7 @@ module Trees {
       // Emptiness test to variable declaration
       pred = this and
       first(super.getVarAccess(), succ) and
-      completionIsSimple(c)
+      c = any(EmptinessCompletion ec | not ec.isEmpty())
       or
       // Variable declaration to body
       last(super.getVarAccess(), pred, c) and
@@ -779,7 +779,8 @@ private module Cached {
     TContinueSuccessor() or
     TThrowSuccessor() or
     TExitSuccessor() or
-    TMatchingSuccessor(Boolean b)
+    TMatchingSuccessor(Boolean b) or
+    TEmptinessSuccessor(Boolean b)
 }
 
 import Cached

--- a/powershell/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/powershell/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -276,8 +276,8 @@
 | functions.ps1:28:5:28:13 | ...=... | functions.ps1:28:5:28:9 | sum |  |
 | functions.ps1:28:12:28:13 | 0 | functions.ps1:28:12:28:13 | 0 |  |
 | functions.ps1:28:12:28:13 | 0 | functions.ps1:29:25:29:33 | numbers |  |
-| functions.ps1:29:5:32:6 | forach(... in ...) | functions.ps1:29:14:29:21 | number |  |
-| functions.ps1:29:5:32:6 | forach(... in ...) | functions.ps1:33:5:33:9 | sum |  |
+| functions.ps1:29:5:32:6 | forach(... in ...) | functions.ps1:29:14:29:21 | number | non-empty |
+| functions.ps1:29:5:32:6 | forach(... in ...) | functions.ps1:33:5:33:9 | sum | empty |
 | functions.ps1:29:14:29:21 | number | functions.ps1:29:35:32:6 | {...} |  |
 | functions.ps1:29:25:29:33 | numbers | functions.ps1:29:5:32:6 | forach(... in ...) |  |
 | functions.ps1:29:25:29:33 | numbers | functions.ps1:29:25:29:33 | numbers |  |
@@ -480,8 +480,8 @@
 | loops.ps1:51:5:51:11 | ...=... | loops.ps1:51:5:51:7 | a |  |
 | loops.ps1:51:10:51:11 | 0 | loops.ps1:51:10:51:11 | 0 |  |
 | loops.ps1:51:10:51:11 | 0 | loops.ps1:52:25:52:37 | letterArray |  |
-| loops.ps1:52:5:55:6 | forach(... in ...) | loops.ps1:49:23:56:2 | exit {...} (normal) |  |
-| loops.ps1:52:5:55:6 | forach(... in ...) | loops.ps1:52:14:52:21 | letter |  |
+| loops.ps1:52:5:55:6 | forach(... in ...) | loops.ps1:49:23:56:2 | exit {...} (normal) | empty |
+| loops.ps1:52:5:55:6 | forach(... in ...) | loops.ps1:52:14:52:21 | letter | non-empty |
 | loops.ps1:52:14:52:21 | letter | loops.ps1:53:5:55:6 | {...} |  |
 | loops.ps1:52:25:52:37 | letterArray | loops.ps1:52:5:55:6 | forach(... in ...) |  |
 | loops.ps1:52:25:52:37 | letterArray | loops.ps1:52:25:52:37 | letterArray |  |


### PR DESCRIPTION
Without this PR we get two `SimpleSuccessor`s out of the `foreach` loop in something like:
```powershell
foreach ($x in $xs) {
  # ...
}
# ...
```
one that goes from the `foreach` itself to `$x` (which represents going into the loop), and one that goes from the `foreach` itself to the next statement (which represents the `foreach` being empty).

No control-flow element should have two successors with the same kind out of it. So this PR adds an `Emptiness` successor to distinguish between these two situations. This is the same strategy that C# uses.