### PR TITLE
PS: Add flow out of functions

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
@@ -33,6 +33,16 @@ class Node extends TNode {
   Node getASuccessor() { localFlowStep(this, result) }
 }
 
+/** A control-flow node, viewed as a node in a data flow graph. */
+abstract private class AbstractAstNode extends Node {
+  CfgNodes::AstCfgNode n;
+
+  /** Gets the control-flow node corresponding to this node. */
+  CfgNodes::AstCfgNode getCfgNode() { result = n }
+}
+
+final class AstNode = AbstractAstNode;
+
 /**
  * An expression, viewed as a node in a data flow graph.
  *
@@ -40,8 +50,8 @@ class Node extends TNode {
  * to multiple `ExprNode`s, just like it may correspond to multiple
  * `ControlFlow::Node`s.
  */
-class ExprNode extends Node, TExprNode {
-  private CfgNodes::ExprCfgNode n;
+class ExprNode extends AbstractAstNode, TExprNode {
+  override CfgNodes::ExprCfgNode n;
 
   ExprNode() { this = TExprNode(n) }
 
@@ -56,8 +66,8 @@ class ExprNode extends Node, TExprNode {
  * to multiple `StmtNode`s, just like it may correspond to multiple
  * `ControlFlow::Node`s.
  */
-class StmtNode extends Node, TStmtNode {
-  private CfgNodes::StmtCfgNode n;
+class StmtNode extends AbstractAstNode, TStmtNode {
+  override CfgNodes::StmtCfgNode n;
 
   StmtNode() { this = TStmtNode(n) }
 
@@ -311,4 +321,13 @@ class ObjectCreationNode extends Node {
   }
 
   final CfgNodes::ObjectCreationCfgNode getObjectCreationNode() { result = objectCreation }
+}
+
+/** A call, viewed as a node in a data flow graph. */
+class CallNode extends AstNode {
+  CfgNodes::CallCfgNode call;
+
+  CallNode() { call = this.getCfgNode() }
+
+  CfgNodes::CallCfgNode getCallNode() { result = call }
 }

--- a/powershell/ql/test/library-tests/dataflow/returns/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.expected
@@ -1,0 +1,6 @@
+models
+edges
+nodes
+subpaths
+testFailures
+#select

--- a/powershell/ql/test/library-tests/dataflow/returns/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.expected
@@ -1,6 +1,40 @@
 models
 edges
+| test.ps1:2:5:2:15 | Source | test.ps1:5:6:5:20 | callSourceOnce | provenance |  |
+| test.ps1:5:6:5:20 | callSourceOnce | test.ps1:6:6:6:8 | x | provenance |  |
+| test.ps1:9:5:9:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
+| test.ps1:10:5:10:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
+| test.ps1:13:6:13:21 | callSourceTwice | test.ps1:14:6:14:8 | x | provenance |  |
+| test.ps1:17:12:17:22 | Source | test.ps1:20:6:20:19 | returnSource1 | provenance |  |
+| test.ps1:20:6:20:19 | returnSource1 | test.ps1:21:6:21:8 | x | provenance |  |
+| test.ps1:24:10:24:20 | Source | test.ps1:25:5:25:7 | x | provenance |  |
+| test.ps1:25:5:25:7 | x | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
+| test.ps1:26:10:26:20 | Source | test.ps1:27:12:27:14 | y | provenance |  |
+| test.ps1:27:12:27:14 | y | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
+| test.ps1:30:6:30:19 | returnSource2 | test.ps1:31:6:31:8 | x | provenance |  |
 nodes
+| test.ps1:2:5:2:15 | Source | semmle.label | Source |
+| test.ps1:5:6:5:20 | callSourceOnce | semmle.label | callSourceOnce |
+| test.ps1:6:6:6:8 | x | semmle.label | x |
+| test.ps1:9:5:9:15 | Source | semmle.label | Source |
+| test.ps1:10:5:10:15 | Source | semmle.label | Source |
+| test.ps1:13:6:13:21 | callSourceTwice | semmle.label | callSourceTwice |
+| test.ps1:14:6:14:8 | x | semmle.label | x |
+| test.ps1:17:12:17:22 | Source | semmle.label | Source |
+| test.ps1:20:6:20:19 | returnSource1 | semmle.label | returnSource1 |
+| test.ps1:21:6:21:8 | x | semmle.label | x |
+| test.ps1:24:10:24:20 | Source | semmle.label | Source |
+| test.ps1:25:5:25:7 | x | semmle.label | x |
+| test.ps1:26:10:26:20 | Source | semmle.label | Source |
+| test.ps1:27:12:27:14 | y | semmle.label | y |
+| test.ps1:30:6:30:19 | returnSource2 | semmle.label | returnSource2 |
+| test.ps1:31:6:31:8 | x | semmle.label | x |
 subpaths
 testFailures
 #select
+| test.ps1:6:6:6:8 | x | test.ps1:2:5:2:15 | Source | test.ps1:6:6:6:8 | x | $@ | test.ps1:2:5:2:15 | Source | Source |
+| test.ps1:14:6:14:8 | x | test.ps1:9:5:9:15 | Source | test.ps1:14:6:14:8 | x | $@ | test.ps1:9:5:9:15 | Source | Source |
+| test.ps1:14:6:14:8 | x | test.ps1:10:5:10:15 | Source | test.ps1:14:6:14:8 | x | $@ | test.ps1:10:5:10:15 | Source | Source |
+| test.ps1:21:6:21:8 | x | test.ps1:17:12:17:22 | Source | test.ps1:21:6:21:8 | x | $@ | test.ps1:17:12:17:22 | Source | Source |
+| test.ps1:31:6:31:8 | x | test.ps1:24:10:24:20 | Source | test.ps1:31:6:31:8 | x | $@ | test.ps1:24:10:24:20 | Source | Source |
+| test.ps1:31:6:31:8 | x | test.ps1:26:10:26:20 | Source | test.ps1:31:6:31:8 | x | $@ | test.ps1:26:10:26:20 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/returns/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.ps1
@@ -1,0 +1,31 @@
+function callSourceOnce {
+    Source "1"
+}
+
+$x = callSourceOnce
+Sink $x # $ MISSING: hasValueFlow=1
+
+function callSourceTwice {
+    Source "2"
+    Source "3"
+}
+
+$x = callSourceTwice
+Sink $x # $ MISSING: hasValueFlow=2 hasValueFlow=3
+
+function returnSource1 {
+    return Source "4"
+}
+
+$x = returnSource1
+Sink $x # $ MISSING: hasValueFlow=4
+
+function returnSource2 {
+    $x = Source "5"
+    $x
+    $y = Source "6"
+    return $y
+}
+
+$x = returnSource2
+Sink $x # $ MISSING: hasValueFlow=5 hasValueFlow=6

--- a/powershell/ql/test/library-tests/dataflow/returns/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.ps1
@@ -3,7 +3,7 @@ function callSourceOnce {
 }
 
 $x = callSourceOnce
-Sink $x # $ MISSING: hasValueFlow=1
+Sink $x # $ hasValueFlow=1
 
 function callSourceTwice {
     Source "2"
@@ -11,14 +11,14 @@ function callSourceTwice {
 }
 
 $x = callSourceTwice
-Sink $x # $ MISSING: hasValueFlow=2 hasValueFlow=3
+Sink $x # $ hasValueFlow=2 hasValueFlow=3
 
 function returnSource1 {
     return Source "4"
 }
 
 $x = returnSource1
-Sink $x # $ MISSING: hasValueFlow=4
+Sink $x # $ hasValueFlow=4
 
 function returnSource2 {
     $x = Source "5"
@@ -28,4 +28,4 @@ function returnSource2 {
 }
 
 $x = returnSource2
-Sink $x # $ MISSING: hasValueFlow=5 hasValueFlow=6
+Sink $x # $ hasValueFlow=5 hasValueFlow=6

--- a/powershell/ql/test/library-tests/dataflow/returns/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.ql
@@ -1,0 +1,13 @@
+/**
+ * @kind path-problem
+ */
+
+import powershell
+import semmle.code.powershell.dataflow.DataFlow
+private import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
+
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()


### PR DESCRIPTION
This PR implements flow out of Powershell functions. For example:
```powershell
function Foo {
  return 42
}

$x = Foo
Sink $x
```

To describe what's going on in this PR I'll first describe the necessary internal dataflow concepts, and then how we make these work in the context of Powershell.

## How to model flow out of functions in the dataflow library

There are three concepts we need to understand:
- `ReturnNode`
- `OutNode`
- `ReturnKind`

A `ReturnNode` is the node that represents the value to be returned from a callee. That is, in the above example, `42` is a `ReturnNode`. An `OutNode` is the node that represents the function call that's supposed to receive the return value when we leave the function. In the above example, that's `Foo` in `$x = Foo`.

The `Return`/`Out` naming scheme is less standard compared to the `Parameter`/`Argument` naming scheme, but it's the same idea: we need to distinguish between the value in the _caller_ and the value in the _callee_).

Finally (and this isn't needed for anything in Powershell yet), a `ReturnKind` is used to model different ways a function can return a value. This is used to coordinate which `ReturnNode` should be connected to which `OutNode`.

For example, in C++, we have a `ReturnKind` that represents `return x` (just like in Powershell), but we also have a `ReturnKind` that represents writing to a parameter (i.e., `void f(int* p) { *p = 42 }`).

For Powershell I don't see a reason to have any other `ReturnKind`s other than normal returns, so that's super simple for now.

## How these should work in the context of Powershell

The `OutNode`s are pretty standard stuff: We'll have an `OutNode` for each function call. The `ReturnNode`s are a bit more tricky since, in `Powershell` you can do stuff like:
```powershell
function f {
  "x"
  "y"
}

$x = f
```
which will print both `x` and `y`.

Thus, we can't just look for `return` statements and mark its expression as a `ReturnNode`. Instead, we have to traverse the function body to find these expressions.

Other than this it's all pretty simple.