### PR TITLE
PS: Flow through pipelines

### DIFF
--- a/powershell/ql/lib/powershell.qll
+++ b/powershell/ql/lib/powershell.qll
@@ -7,6 +7,7 @@ import semmle.code.powershell.Expression
 import semmle.code.powershell.CommandBase
 import semmle.code.powershell.AttributeBase
 import semmle.code.powershell.PipelineBase
+import semmle.code.powershell.PipelineChain
 import semmle.code.powershell.BaseConstantExpression
 import semmle.code.powershell.ConstantExpression
 import semmle.code.powershell.MemberExpressionBase

--- a/powershell/ql/lib/semmle/code/powershell/ConstantExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ConstantExpression.qll
@@ -13,6 +13,8 @@ class ConstExpr extends @constant_expression, BaseConstExpr {
 private newtype TConstantValue =
   TConstInteger(int value) {
     exists(ConstExpr ce | ce.getType() = "Int32" and ce.getValue().getValue().toInt() = value)
+    or
+    value = [0 .. 10] // needed for `trackKnownValue` in `DataFlowPrivate`
   } or
   TConstDouble(float double) {
     exists(ConstExpr ce | ce.getType() = "Double" and ce.getValue().getValue().toFloat() = double)

--- a/powershell/ql/lib/semmle/code/powershell/Function.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Function.qll
@@ -43,11 +43,12 @@ abstract private class AbstractFunction extends Ast {
    * Gets the i'th parameter of this function, if any.
    *
    * This does not include the `this` parameter.
+   *
+   * The implicit underscore parameter (if any) is included at index `-1`.
    */
   final Parameter getParameter(int i) {
-    result = this.getFunctionParameter(i)
-    or
-    result = this.getBody().getParamBlock().getParameter(i)
+    result.getFunction() = this and
+    result.getIndex() = i
   }
 
   final Parameter getParameterExcludingPipline(int i) {

--- a/powershell/ql/lib/semmle/code/powershell/Function.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Function.qll
@@ -50,6 +50,12 @@ abstract private class AbstractFunction extends Ast {
     result = this.getBody().getParamBlock().getParameter(i)
   }
 
+  final Parameter getParameterExcludingPipline(int i) {
+    result = this.getFunctionParameter(i)
+    or
+    result = this.getBody().getParamBlock().getParameterExcludingPipline(i)
+  }
+
   final Parameter getThisParameter() {
     result.isThis() and
     result.getFunction() = this

--- a/powershell/ql/lib/semmle/code/powershell/NamedAttributeArgument.qll
+++ b/powershell/ql/lib/semmle/code/powershell/NamedAttributeArgument.qll
@@ -1,11 +1,15 @@
 import powershell
 
 class NamedAttributeArgument extends @named_attribute_argument, Ast {
-  final override string toString() { result = this.getValue().toString() }
+  final override string toString() { result = this.getName() }
 
   final override SourceLocation getLocation() { named_attribute_argument_location(this, result) }
 
   string getName() { named_attribute_argument(this, result, _) }
 
   Expr getValue() { named_attribute_argument(this, _, result) }
+}
+
+class ValueFromPipelineAttribute extends NamedAttributeArgument {
+  ValueFromPipelineAttribute() { this.getName() = "ValueFromPipeline" }
 }

--- a/powershell/ql/lib/semmle/code/powershell/ParamBlock.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ParamBlock.qll
@@ -15,5 +15,7 @@ class ParamBlock extends @param_block, Ast {
 
   Parameter getParameter(int i) { result.hasParameterBlock(this, i) }
 
+  Parameter getParameterExcludingPipline(int i) { result.hasParameterBlockExcludingPipeline(this, i) }
+
   Parameter getAParameter() { result = this.getParameter(_) }
 }

--- a/powershell/ql/lib/semmle/code/powershell/ScriptBlock.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ScriptBlock.qll
@@ -52,3 +52,12 @@ class ScriptBlock extends @script_block, Ast {
 
   final override Scope getEnclosingScope() { result = this }
 }
+
+/** A `process` block. */
+class ProcessBlock extends NamedBlock {
+  ScriptBlock scriptBlock;
+
+  ProcessBlock() { scriptBlock.getProcessBlock() = this }
+
+  ScriptBlock getScriptBlock() { result = scriptBlock }
+}

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -41,7 +41,7 @@ private predicate isParameterImpl(string name, Scope scope) {
 private newtype TParameterImpl =
   TInternalParameter(Internal::Parameter p) or
   TUnderscore(Scope scope) {
-    exists(VarAccess va | va.getUserPath() = "_" and scope = va.getEnclosingScope())
+    exists(VarAccess va | va.getUserPath() = ["_", "PSItem"] and scope = va.getEnclosingScope())
   } or
   TThisParameter(Scope scope) { exists(scope.getEnclosingFunction().getDeclaringType()) }
 
@@ -87,6 +87,11 @@ private class InternalParameter extends ParameterImpl, TInternalParameter {
   override Expr getDefaultValue() { result = p.getDefaultValue() }
 }
 
+/**
+ * The variable that represents an element in the pipeline.
+ *
+ * This is either the variable `$_` or the variable `$PSItem`.
+ */
 private class Underscore extends ParameterImpl, TUnderscore {
   Scope scope;
 

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -82,6 +82,8 @@ private class ParameterImpl extends TParameterImpl {
     result.getUserPath() = this.getName() and
     result.getEnclosingScope() = this.getEnclosingScope()
   }
+
+  abstract predicate isPipeline();
 }
 
 private class InternalParameter extends ParameterImpl, TInternalParameter {
@@ -108,6 +110,10 @@ private class InternalParameter extends ParameterImpl, TInternalParameter {
   override Expr getDefaultValue() { result = p.getDefaultValue() }
 
   override Attribute getAnAttribute() { result = p.getAnAttribute() }
+
+  override predicate isPipeline() {
+    this.getAnAttribute().getANamedArgument() instanceof ValueFromPipelineAttribute
+  }
 }
 
 /**
@@ -138,6 +144,10 @@ private class Underscore extends ParameterImpl, TUnderscore {
   final override Scope getEnclosingScope() { result = scope }
 
   final override Attribute getAnAttribute() { none() }
+
+  final override predicate isPipeline() { any() }
+
+  final override predicate isFunctionParameter(Function f, int i) { f.getBody() = scope and i = -1 }
 }
 
 private class ThisParameter extends ParameterImpl, TThisParameter {
@@ -152,6 +162,8 @@ private class ThisParameter extends ParameterImpl, TThisParameter {
   final override Scope getEnclosingScope() { result = scope }
 
   final override Attribute getAnAttribute() { none() }
+
+  final override predicate isPipeline() { none() }
 }
 
 private newtype TVariable =
@@ -265,9 +277,7 @@ class Parameter extends AbstractLocalScopeVariable, TParameter {
 
   Attribute getAnAttribute() { result = p.getAnAttribute() }
 
-  predicate isPipeline() {
-    this.getAnAttribute().getANamedArgument() instanceof ValueFromPipelineAttribute
-  }
+  predicate isPipeline() { p.isPipeline() }
 }
 
 class PipelineParameter extends Parameter {
@@ -276,7 +286,7 @@ class PipelineParameter extends Parameter {
 
 /**
  * The variable that represents the value of a pipeline during a process block.
- * 
+ *
  * That is, it is _not_ the pipeline variable, but the value that is obtained by reading
  * from the pipeline.
  */

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -169,6 +169,8 @@ private class AbstractVariable extends TVariable {
 
   abstract string getName();
 
+  final predicate hasName(string s) { this.getName() = s }
+
   abstract Scope getDeclaringScope();
 
   VarAccess getAnAccess() {
@@ -265,4 +267,8 @@ class Parameter extends AbstractLocalScopeVariable, TParameter {
   predicate isPipeline() {
     this.getAnAttribute().getANamedArgument() instanceof ValueFromPipelineAttribute
   }
+}
+
+class PipelineParameter extends Parameter {
+  PipelineParameter() { this.isPipeline() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Variable.qll
@@ -160,7 +160,8 @@ private newtype TVariable =
     not name = "this" and // This is modeled as a parameter
     exists(VarAccess va | va.getUserPath() = name and scope = va.getEnclosingScope())
   } or
-  TParameter(ParameterImpl p)
+  TParameter(ParameterImpl p) or
+  TPipelineIteratorVariable(ProcessBlock pb)
 
 private class AbstractVariable extends TVariable {
   abstract Location getLocation();
@@ -271,4 +272,24 @@ class Parameter extends AbstractLocalScopeVariable, TParameter {
 
 class PipelineParameter extends Parameter {
   PipelineParameter() { this.isPipeline() }
+}
+
+/**
+ * The variable that represents the value of a pipeline during a process block.
+ * 
+ * That is, it is _not_ the pipeline variable, but the value that is obtained by reading
+ * from the pipeline.
+ */
+class PipelineIteratorVariable extends AbstractLocalScopeVariable, TPipelineIteratorVariable {
+  private ProcessBlock pb;
+
+  PipelineIteratorVariable() { this = TPipelineIteratorVariable(pb) }
+
+  override Location getLocation() { result = pb.getLocation() }
+
+  override string getName() { result = "pipeline iterator for " + pb.toString() }
+
+  final override Scope getDeclaringScope() { result = pb.getEnclosingScope() }
+
+  ProcessBlock getProcessBlock() { result = pb }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -175,6 +175,32 @@ class ObjectCreationCfgNode extends CallCfgNode {
   string getConstructedTypeName() { result = objectCreation.getConstructedTypeName() }
 }
 
+private class NamedBlockChildMapping extends NonExprChildMapping, NamedBlock {
+  override predicate relevantChild(Ast n) { n = this.getAStmt() } // TODO: Handle getATrap
+}
+
+class NamedBlockCfgNode extends AstCfgNode {
+  NamedBlockChildMapping block;
+
+  NamedBlockCfgNode() { this.getAstNode() = block }
+
+  NamedBlock getBlock() { result = block }
+
+  StmtCfgNode getStmt(int i) { block.hasCfgChild(block.getStmt(i), this, result) }
+
+  StmtCfgNode getAStmt() { block.hasCfgChild(block.getAStmt(), this, result) }
+}
+
+private class ProcessBlockChildMapping extends NamedBlockChildMapping, ProcessBlock { }
+
+class ProcessBlockCfgNode extends NamedBlockCfgNode {
+  override ProcessBlockChildMapping block;
+
+  override ProcessBlock getBlock() { result = block }
+
+  PipelineParameter getPipelineParameter() { result = block.getEnclosingFunction().getAParameter() }
+}
+
 /** Provides classes for control-flow nodes that wrap AST expressions. */
 module ExprNodes {
   private class VarAccessChildMapping extends ExprChildMapping, VarAccess {

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -130,20 +130,34 @@ abstract private class NonExprChildMapping extends ChildMapping {
 abstract private class AbstractCallCfgNode extends AstCfgNode {
   override string getAPrimaryQlClass() { result = "CfgCall" }
 
+  /** Holds if this call invokes a function with the name `name`. */
   final predicate hasName(string name) { this.getName() = name }
 
+  /** Gets the name of the function that is invoked by this call. */
   abstract string getName();
 
+  /** Gets the qualifier of this call, if any. */
   ExprCfgNode getQualifier() { none() }
 
+  /** Gets the i'th argument to this call. */
   abstract ExprCfgNode getArgument(int i);
 
+  /** Gets the i'th positional argument to this call. */
   abstract ExprCfgNode getPositionalArgument(int i);
 
+  /** Gets the argument with the name `name`, if any. */
   abstract ExprCfgNode getNamedArgument(string name);
 
+  /**
+   * Gets any argument of this call.
+   *
+   * Note that this predicate doesn't get the pipeline argument, if any.
+   */
   abstract ExprCfgNode getAnArgument();
 
+  /**
+   * Gets the expression that provides the call target of this call, if any.
+   */
   abstract ExprCfgNode getCommand();
 }
 
@@ -381,12 +395,12 @@ module ExprNodes {
 }
 
 module StmtNodes {
-  private class CmdChildMapping extends NonExprChildMapping, Cmd {
+  private class CmdChildMapping extends CmdBaseChildMapping, Cmd {
     override predicate relevantChild(Ast n) { n = this.getAnArgument() or n = this.getCommand() }
   }
 
   /** A control-flow node that wraps a `Cmd` AST expression. */
-  class CmdCfgNode extends StmtCfgNode, AbstractCallCfgNode {
+  class CmdCfgNode extends CmdBaseCfgNode, AbstractCallCfgNode {
     override string getAPrimaryQlClass() { result = "CmdCfgNode" }
 
     override CmdChildMapping s;
@@ -410,14 +424,14 @@ module StmtNodes {
     final override string getName() { result = s.getCmdName().getValue().getValue() }
   }
 
-  private class AssignStmtChildMapping extends NonExprChildMapping, AssignStmt {
+  private class AssignStmtChildMapping extends PipelineBaseChildMapping, AssignStmt {
     override predicate relevantChild(Ast n) {
       n = this.getLeftHandSide() or n = this.getRightHandSide()
     }
   }
 
   /** A control-flow node that wraps an `AssignStmt` AST expression. */
-  class AssignStmtCfgNode extends StmtCfgNode {
+  class AssignStmtCfgNode extends PipelineBaseCfgNode {
     override string getAPrimaryQlClass() { result = "AssignCfgNode" }
 
     override AssignStmtChildMapping s;
@@ -431,12 +445,12 @@ module StmtNodes {
     final StmtCfgNode getRightHandSide() { s.hasCfgChild(s.getRightHandSide(), this, result) }
   }
 
-  class CmdExprChildMapping extends NonExprChildMapping, CmdExpr {
+  class CmdExprChildMapping extends CmdBaseChildMapping, CmdExpr {
     override predicate relevantChild(Ast n) { n = this.getExpr() }
   }
 
   /** A control-flow node that wraps a `CmdExpr` expression. */
-  class CmdExprCfgNode extends StmtCfgNode {
+  class CmdExprCfgNode extends CmdBaseCfgNode {
     override string getAPrimaryQlClass() { result = "CmdExprCfgNode" }
 
     override CmdExprChildMapping s;
@@ -444,5 +458,71 @@ module StmtNodes {
     override CmdExpr getStmt() { result = super.getStmt() }
 
     final ExprCfgNode getExpr() { s.hasCfgChild(s.getExpr(), this, result) }
+  }
+
+  class PipelineBaseChildMapping extends NonExprChildMapping, PipelineBase {
+    override predicate relevantChild(Ast n) { none() }
+  }
+
+  class PipelineBaseCfgNode extends StmtCfgNode {
+    override string getAPrimaryQlClass() { result = "PipelineBaseCfgNode" }
+
+    override PipelineBaseChildMapping s;
+
+    override PipelineBase getStmt() { result = super.getStmt() }
+  }
+
+  class ChainableChildMapping extends PipelineBaseChildMapping, Chainable {
+    override predicate relevantChild(Ast n) { none() }
+  }
+
+  class ChainableCfgNode extends PipelineBaseCfgNode {
+    override string getAPrimaryQlClass() { result = "ChainableCfgNode" }
+
+    override ChainableChildMapping s;
+
+    override Chainable getStmt() { result = super.getStmt() }
+  }
+
+  class PipelineChainChildMapping extends ChainableChildMapping, PipelineChain {
+    override predicate relevantChild(Ast n) { n = this.getLeft() or n = this.getRight() }
+  }
+
+  class PipelineChainCfgNode extends ChainableCfgNode {
+    override string getAPrimaryQlClass() { result = "PipelineChainCfgNode" }
+
+    override PipelineChainChildMapping s;
+
+    override PipelineChain getStmt() { result = super.getStmt() }
+
+    final ChainableCfgNode getLeft() { s.hasCfgChild(s.getLeft(), this, result) }
+
+    final ChainableCfgNode getRight() { s.hasCfgChild(s.getRight(), this, result) }
+  }
+
+  class CmdBaseChildMapping extends ChainableChildMapping, CmdBase { }
+
+  class CmdBaseCfgNode extends ChainableCfgNode {
+    override string getAPrimaryQlClass() { result = "CmdBaseCfgNode" }
+
+    override CmdBaseChildMapping s;
+
+    override CmdBase getStmt() { result = super.getStmt() }
+  }
+
+  class PipelineChildMapping extends ChainableChildMapping, Pipeline {
+    override predicate relevantChild(Ast n) { n = this.getAComponent() }
+  }
+
+  class PipelineCfgNode extends ChainableCfgNode {
+    override string getAPrimaryQlClass() { result = "PipelineCfgNode" }
+
+    override PipelineChildMapping s;
+
+    override Pipeline getStmt() { result = super.getStmt() }
+
+    final CmdBaseCfgNode getComponent(int i) { s.hasCfgChild(s.getComponent(i), this, result) }
+
+    final CmdBaseCfgNode getAComponent() { s.hasCfgChild(s.getAComponent(), this, result) }
   }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -213,6 +213,8 @@ module ExprNodes {
     override VarAccessChildMapping e;
 
     override VarAccess getExpr() { result = super.getExpr() }
+
+    Variable getVariable() { result = e.getVariable() }
   }
 
   private class VarReadAccessChildMapping extends VarAccessChildMapping, VarReadAccess { }
@@ -233,8 +235,6 @@ module ExprNodes {
     override VarWriteAccessChildMapping e;
 
     override VarWriteAccess getExpr() { result = super.getExpr() }
-
-    Variable getVariable() { result = e.getVariable() }
 
     predicate isExplicitWrite(StmtNodes::AssignStmtCfgNode assignment) {
       this = assignment.getLeftHandSide()

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
@@ -727,7 +727,7 @@ module Trees {
     }
   }
 
-  class CmdExprTree extends StandardPreOrderTree instanceof CmdExpr {
+  class CmdExprTree extends StandardPostOrderTree instanceof CmdExpr {
     override AstNode getChildNode(int i) { i = 0 and result = super.getExpr() }
   }
 

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
@@ -9,7 +9,8 @@ module Ssa {
   private import semmle.code.powershell.Cfg
   private import powershell
   private import internal.SsaImpl as SsaImpl
-  private import CfgNodes::ExprNodes
+  private import CfgNodes
+  private import ExprNodes
 
   /** A static single assignment (SSA) definition. */
   class Definition extends SsaImpl::Definition {
@@ -23,7 +24,7 @@ module Ssa {
     }
 
     /** Gets a control-flow node that reads the value of this SSA definition. */
-    final VarReadAccessCfgNode getARead() { result = SsaImpl::getARead(this) }
+    final AstCfgNode  getARead() { result = SsaImpl::getARead(this) }
 
     /**
      * Gets a first control-flow node that reads the value of this SSA definition.

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
@@ -229,7 +229,8 @@ private module Cached {
         call = ns.getABindingCall() and
         exists(call.getArgument(pos))
       )
-    }
+    } or
+    TPipelineArgumentPosition()
 
   cached
   newtype TParameterPosition =
@@ -240,7 +241,8 @@ private module Cached {
         call = ns.getABindingCall() and
         exists(call.getArgument(pos))
       )
-    }
+    } or
+    TPipelineParameter()
 }
 
 import Cached
@@ -259,6 +261,8 @@ class ParameterPosition extends TParameterPosition {
   /** Holds if this parameter is a keyword parameter with `name`. */
   predicate isKeyword(string name) { this = TKeywordParameter(name) }
 
+  predicate isPipeline() { this = TPipelineParameter() }
+
   /** Gets a textual representation of this position. */
   string toString() {
     this.isThis() and result = "this"
@@ -268,6 +272,8 @@ class ParameterPosition extends TParameterPosition {
     )
     or
     exists(string name | this.isKeyword(name) and result = "kw(" + name + ")")
+    or
+    this.isPipeline() and result = "pipeline"
   }
 }
 
@@ -281,6 +287,8 @@ class ArgumentPosition extends TArgumentPosition {
 
   predicate isKeyword(string name) { this = TKeywordArgumentPosition(name) }
 
+  predicate isPipeline() { this = TPipelineArgumentPosition() }
+
   /** Gets a textual representation of this position. */
   string toString() {
     this.isThis() and result = "this"
@@ -290,6 +298,8 @@ class ArgumentPosition extends TArgumentPosition {
     )
     or
     exists(string name | this.isKeyword(name) and result = "kw(" + name + ")")
+    or
+    this.isPipeline() and result = "pipeline"
   }
 }
 
@@ -307,4 +317,6 @@ predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
     ppos.isPositional(pos, ns) and
     apos.isPositional(pos, ns)
   )
+  or
+  ppos.isPipeline() and apos.isPipeline()
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowImplSpecific.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowImplSpecific.qll
@@ -21,4 +21,6 @@ module PowershellDataFlow implements InputSig<Location> {
   class ParameterNode = Private::ParameterNodeImpl;
 
   Node exprNode(DataFlowExpr e) { result = Public::exprNode(e) }
+
+  predicate neverSkipInPathGraph = Private::neverSkipInPathGraph/1;
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -573,14 +573,7 @@ private module ReturnNodes {
     )
   }
 
-  class NormalReturnNode extends ReturnNode instanceof NodeImpl {
-    NormalReturnNode() {
-      exists(ReturnContainer container |
-        container = this.getEnclosingCallable().asCfgScope() and
-        this = container.getAReturnedNode()
-      )
-    }
-
+  class NormalReturnNode extends ReturnNode instanceof ReturnNodeImpl {
     final override NormalReturnKind getKind() { any() }
   }
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -494,7 +494,7 @@ private module ReturnNodes {
     /**
      * Gets a direct node that will may be returned when evaluating this node.
      */
-    Node getANode() { none() }
+    CfgNode getANode() { none() }
 
     /** Gets a child that may produce more nodes that may be returned. */
     abstract ReturnContainer getAChild();
@@ -503,7 +503,7 @@ private module ReturnNodes {
      * Gets a (possibly transitive) node that may be returned when evaluating
      * this node.
      */
-    final Node getAReturnedNode() {
+    final CfgNode getAReturnedNode() {
       result = this.getANode()
       or
       result = this.getAChild().getAReturnedNode()
@@ -519,7 +519,7 @@ private module ReturnNodes {
   }
 
   class CmdExprReturnContainer extends ReturnContainer, CmdExpr {
-    final override ExprNode getANode() { result.getExprNode().getExpr() = this.getExpr() }
+    final override CfgNodes::ExprCfgNode getANode() { result.getExpr() = this.getExpr() }
 
     final override ReturnContainer getAChild() { none() }
   }
@@ -551,15 +551,23 @@ private module ReturnNodes {
   }
 
   class CmdBaseReturnContainer extends ReturnContainer, CmdExpr {
-    final override ExprNode getANode() { result.getExprNode().getExpr() = this.getExpr() }
+    final override CfgNodes::ExprCfgNode getANode() { result.getExpr() = this.getExpr() }
 
     final override ReturnContainer getAChild() { none() }
   }
 
   class CmdReturnContainer extends ReturnContainer, Cmd {
-    final override StmtNode getANode() { result.getStmtNode().getStmt() = this }
+    final override CfgNodes::StmtCfgNode getANode() { result.getStmt() = this }
 
     final override ReturnContainer getAChild() { none() }
+  }
+
+  /** Holds if `n` is returned from the enclosing callable. */
+  predicate isReturned(CfgNodes::AstCfgNode n) {
+    exists(ReturnContainer container |
+      container = n.getScope() and
+      n = container.getAReturnedNode()
+    )
   }
 
   class NormalReturnNode extends ReturnNode instanceof NodeImpl {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -31,6 +31,9 @@ abstract class NodeImpl extends Node {
 
   /** Do not call: use `toString()` instead. */
   abstract string toStringImpl();
+
+  /** Holds if this node should be hidden from path explanations. */
+  predicate nodeIsHidden() { none() }
 }
 
 private class ExprNodeImpl extends ExprNode, NodeImpl {
@@ -284,7 +287,13 @@ private string approxKnownElementIndex(ConstantValue cv) {
 import Cached
 
 /** Holds if `n` should be hidden from path explanations. */
-predicate nodeIsHidden(Node n) { none() }
+predicate nodeIsHidden(Node n) { n.(NodeImpl).nodeIsHidden() }
+
+/**
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
+ */
+predicate neverSkipInPathGraph(Node n) { isReturned(n.(AstNode).getCfgNode()) }
 
 /** An SSA node. */
 abstract class SsaNode extends NodeImpl, TSsaNode {
@@ -795,6 +804,8 @@ private class ImplicitWrapNode extends TImplicitWrapNode, NodeImpl {
   override Location getLocationImpl() { result = n.getLocation() }
 
   override string toStringImpl() { result = "implicit unwrapping of " + n.toString() }
+
+  override predicate nodeIsHidden() { any() }
 }
 
 /**
@@ -829,6 +840,8 @@ private class ReturnNodeImpl extends TReturnNodeImpl, NodeImpl {
   override Location getLocationImpl() { result = scope.getLocation() }
 
   override string toStringImpl() { result = "return value for " + scope.toString() }
+
+  override predicate nodeIsHidden() { any() }
 }
 
 /** A node that performs a type cast. */

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -667,19 +667,19 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
     c.isSingleton(fc)
   )
   or
-  exists(
-    CfgNodes::ExprNodes::IndexCfgWriteNode var, Content::KnownElementContent ec, int index,
-    CfgNodes::ExprCfgNode e
-  |
+  exists(CfgNodes::ExprNodes::IndexCfgWriteNode var, CfgNodes::ExprCfgNode e |
     node2.(PostUpdateNode).getPreUpdateNode().asExpr() = var.getBase() and
     node1.asStmt() = var.getAssignStmt().getRightHandSide() and
-    c.isKnownOrUnknownElement(ec) and
-    index = ec.getIndex().asInt() and
     e = var.getIndex()
   |
-    index = e.getValue().asInt()
+    exists(int index, Content::KnownElementContent ec |
+      c.isKnownOrUnknownElement(ec) and
+      index = ec.getIndex().asInt() and
+      index = e.getValue().asInt()
+    )
     or
-    not exists(e.getValue().asInt())
+    not exists(e.getValue().asInt()) and
+    c.isAnyElement()
   )
   or
   exists(Content::KnownElementContent ec, int index |
@@ -712,19 +712,19 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
     c.isSingleton(fc)
   )
   or
-  exists(
-    CfgNodes::ExprNodes::IndexCfgReadNode var, Content::KnownElementContent ec, int index,
-    CfgNodes::ExprCfgNode e
-  |
+  exists(CfgNodes::ExprNodes::IndexCfgReadNode var, CfgNodes::ExprCfgNode e |
     node2.asExpr() = var and
     node1.asExpr() = var.getBase() and
-    c.isKnownOrUnknownElement(ec) and
-    index = ec.getIndex().asInt() and
     e = var.getIndex()
   |
-    index = e.getValue().asInt()
+    exists(int index, Content::KnownElementContent ec |
+      c.isKnownOrUnknownElement(ec) and
+      index = ec.getIndex().asInt() and
+      index = e.getValue().asInt()
+    )
     or
-    not exists(e.getValue().asInt())
+    not exists(e.getValue().asInt()) and
+    c.isAnyElement()
   )
   or
   exists(CfgNode cfgNode |

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -96,6 +96,18 @@ module LocalFlow {
     nodeFrom.asStmt() = nodeTo.asStmt().(CfgNodes::StmtNodes::AssignStmtCfgNode).getRightHandSide()
     or
     nodeFrom.asExpr() = nodeTo.asStmt().(CfgNodes::StmtNodes::CmdExprCfgNode).getExpr()
+    or
+    nodeFrom.(AstNode).getCfgNode() = nodeTo.(PreReturNodeImpl).getReturnedNode()
+    or
+    exists(CfgNode cfgNode |
+      nodeFrom = TPreReturnNodeImpl(cfgNode, true) and
+      nodeTo = TImplicitWrapNode(cfgNode, false)
+    )
+    or
+    exists(CfgNode cfgNode |
+      nodeFrom = TImplicitWrapNode(cfgNode, false) and
+      nodeTo = TReturnNodeImpl(cfgNode.getScope())
+    )
   }
 
   predicate localMustFlowStep(Node nodeFrom, Node nodeTo) {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -449,12 +449,18 @@ private module ParameterNodes {
         // keywords in S are specified.
         exists(int i, int j, string name, NamedSet ns, Function f |
           pos.isPositional(j, ns) and
-          parameter.getIndex() = i and
+          parameter.getIndexExcludingPipeline() = i and
           f = parameter.getFunction() and
           f = ns.getAFunction() and
           name = parameter.getName() and
           not name = ns.getAName() and
-          j = i - count(int k | k < i and f.getParameter(k).getName() = ns.getAName())
+          j =
+            i -
+              count(int k, Parameter p |
+                k < i and
+                p = f.getParameterExcludingPipline(k) and
+                p.getName() = ns.getAName()
+              )
         )
       )
     }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
@@ -3,7 +3,9 @@ private import powershell
 private import semmle.code.powershell.Cfg as Cfg
 private import semmle.code.powershell.controlflow.internal.ControlFlowGraphImpl as ControlFlowGraphImpl
 private import semmle.code.powershell.dataflow.Ssa
-private import Cfg::CfgNodes::ExprNodes
+import Cfg::CfgNodes
+private import ExprNodes
+private import StmtNodes
 
 module SsaInput implements SsaImplCommon::InputSig<Location> {
   private import semmle.code.powershell.controlflow.ControlFlowGraph as Cfg

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
@@ -209,10 +209,10 @@ private module Cached {
   }
 
   cached
-  VarReadAccessCfgNode getARead(Definition def) {
+  AstCfgNode getARead(Definition def) {
     exists(SsaInput::SourceVariable v, Cfg::BasicBlock bb, int i |
       Impl::ssaDefReachesRead(v, def, bb, i) and
-      variableReadActual(bb, i, v) and
+      SsaInput::variableRead(bb, i, v, true) and
       result = bb.getNode(i)
     )
   }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingPrivate.qll
@@ -15,7 +15,10 @@ predicate defaultTaintSanitizer(DataFlow::Node node) { none() }
  * of `c` at sinks and inputs to additional taint steps.
  */
 bindingset[node]
-predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet c) { none() }
+predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet c) {
+  node instanceof ArgumentNode and
+  c.isAnyElement()
+}
 
 cached
 private module Cached {

--- a/powershell/ql/lib/semmle/code/powershell/internal/Argument.qll
+++ b/powershell/ql/lib/semmle/code/powershell/internal/Argument.qll
@@ -7,10 +7,10 @@ module Private {
    * The argument may be named or positional.
    */
   abstract class AbstractArgument extends Expr {
-    Ast call;
+    Call call;
 
     /** Gets the call that this is an argumnt of. */
-    final Ast getCall() { result = call }
+    final Call getCall() { result = call }
 
     /** Gets the position if this is a positional argument. */
     abstract int getPosition();
@@ -23,7 +23,7 @@ module Private {
   }
 
   class CmdArgument extends AbstractArgument {
-    override Cmd call;
+    override CmdCall call;
 
     CmdArgument() { call.getAnArgument() = this }
 
@@ -34,10 +34,10 @@ module Private {
     final override predicate isQualifier() { none() }
   }
 
-  class InvokeArgument extends AbstractArgument {
-    override InvokeMemberExpr call;
+  class MethodArgument extends AbstractArgument {
+    override MethodCall call;
 
-    InvokeArgument() { call.getAnArgument() = this or call.getQualifier() = this }
+    MethodArgument() { call.getAnArgument() = this or call.getQualifier() = this }
 
     override int getPosition() { call.getArgument(result) = this }
 

--- a/powershell/ql/test/library-tests/dataflow/fields/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.expected
@@ -6,157 +6,33 @@ edges
 | test.ps1:8:1:8:6 | [post] arr1 [element 3] | test.ps1:9:6:9:11 | arr1 [element 3] | provenance |  |
 | test.ps1:8:12:8:22 | Source | test.ps1:8:1:8:6 | [post] arr1 [element 3] | provenance |  |
 | test.ps1:9:6:9:11 | arr1 [element 3] | test.ps1:9:6:9:14 | ...[...] | provenance |  |
-| test.ps1:12:1:12:6 | [post] arr2 [element 4] | test.ps1:13:6:13:11 | arr2 [element 4] | provenance |  |
-| test.ps1:12:19:12:29 | Source | test.ps1:12:1:12:6 | [post] arr2 [element 4] | provenance |  |
-| test.ps1:13:6:13:11 | arr2 [element 4] | test.ps1:13:6:13:14 | ...[...] | provenance |  |
+| test.ps1:12:1:12:6 | [post] arr2 [element] | test.ps1:13:6:13:11 | arr2 [element] | provenance |  |
+| test.ps1:12:19:12:29 | Source | test.ps1:12:1:12:6 | [post] arr2 [element] | provenance |  |
+| test.ps1:13:6:13:11 | arr2 [element] | test.ps1:13:6:13:14 | ...[...] | provenance |  |
 | test.ps1:15:1:15:6 | [post] arr3 [element 3] | test.ps1:16:6:16:11 | arr3 [element 3] | provenance |  |
 | test.ps1:15:12:15:22 | Source | test.ps1:15:1:15:6 | [post] arr3 [element 3] | provenance |  |
 | test.ps1:16:6:16:11 | arr3 [element 3] | test.ps1:16:6:16:21 | ...[...] | provenance |  |
-| test.ps1:18:1:18:6 | [post] arr4 [element 0] | test.ps1:19:6:19:11 | arr4 [element 0] | provenance |  |
-| test.ps1:18:1:18:6 | [post] arr4 [element 1] | test.ps1:19:6:19:11 | arr4 [element 1] | provenance |  |
-| test.ps1:18:1:18:6 | [post] arr4 [element 2] | test.ps1:19:6:19:11 | arr4 [element 2] | provenance |  |
-| test.ps1:18:1:18:6 | [post] arr4 [element 3] | test.ps1:19:6:19:11 | arr4 [element 3] | provenance |  |
-| test.ps1:18:1:18:6 | [post] arr4 [element 4] | test.ps1:19:6:19:11 | arr4 [element 4] | provenance |  |
-| test.ps1:18:20:18:30 | Source | test.ps1:18:1:18:6 | [post] arr4 [element 0] | provenance |  |
-| test.ps1:18:20:18:30 | Source | test.ps1:18:1:18:6 | [post] arr4 [element 1] | provenance |  |
-| test.ps1:18:20:18:30 | Source | test.ps1:18:1:18:6 | [post] arr4 [element 2] | provenance |  |
-| test.ps1:18:20:18:30 | Source | test.ps1:18:1:18:6 | [post] arr4 [element 3] | provenance |  |
-| test.ps1:18:20:18:30 | Source | test.ps1:18:1:18:6 | [post] arr4 [element 4] | provenance |  |
-| test.ps1:19:6:19:11 | arr4 [element 0] | test.ps1:19:6:19:22 | ...[...] | provenance |  |
-| test.ps1:19:6:19:11 | arr4 [element 1] | test.ps1:19:6:19:22 | ...[...] | provenance |  |
-| test.ps1:19:6:19:11 | arr4 [element 2] | test.ps1:19:6:19:22 | ...[...] | provenance |  |
-| test.ps1:19:6:19:11 | arr4 [element 3] | test.ps1:19:6:19:22 | ...[...] | provenance |  |
-| test.ps1:19:6:19:11 | arr4 [element 4] | test.ps1:19:6:19:22 | ...[...] | provenance |  |
-| test.ps1:21:1:21:6 | [post] arr5 [element 0, element 1] | test.ps1:22:6:22:11 | arr5 [element 0, element 1] | provenance |  |
-| test.ps1:21:1:21:6 | [post] arr5 [element 1, element 1] | test.ps1:22:6:22:11 | arr5 [element 1, element 1] | provenance |  |
-| test.ps1:21:1:21:6 | [post] arr5 [element 2, element 1] | test.ps1:22:6:22:11 | arr5 [element 2, element 1] | provenance |  |
-| test.ps1:21:1:21:6 | [post] arr5 [element 3, element 1] | test.ps1:22:6:22:11 | arr5 [element 3, element 1] | provenance |  |
-| test.ps1:21:1:21:6 | [post] arr5 [element 4, element 1] | test.ps1:22:6:22:11 | arr5 [element 4, element 1] | provenance |  |
-| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element 0, element 1] | provenance |  |
-| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element 1, element 1] | provenance |  |
-| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element 2, element 1] | provenance |  |
-| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element 3, element 1] | provenance |  |
-| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element 4, element 1] | provenance |  |
+| test.ps1:18:1:18:6 | [post] arr4 [element] | test.ps1:19:6:19:11 | arr4 [element] | provenance |  |
+| test.ps1:18:20:18:30 | Source | test.ps1:18:1:18:6 | [post] arr4 [element] | provenance |  |
+| test.ps1:19:6:19:11 | arr4 [element] | test.ps1:19:6:19:22 | ...[...] | provenance |  |
+| test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | test.ps1:22:6:22:11 | arr5 [element, element 1] | provenance |  |
+| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | provenance |  |
 | test.ps1:21:23:21:33 | Source | test.ps1:21:1:21:17 | [post] ...[...] [element 1] | provenance |  |
-| test.ps1:22:6:22:11 | arr5 [element 0, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:22:6:22:11 | arr5 [element 1, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:22:6:22:11 | arr5 [element 2, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:22:6:22:11 | arr5 [element 3, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:22:6:22:11 | arr5 [element 4, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
+| test.ps1:22:6:22:11 | arr5 [element, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
 | test.ps1:22:6:22:22 | ...[...] [element 1] | test.ps1:22:6:22:25 | ...[...] | provenance |  |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 0] | test.ps1:26:6:26:11 | arr6 [element 1, element 0] | provenance |  |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 1] | test.ps1:26:6:26:11 | arr6 [element 1, element 1] | provenance |  |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 2] | test.ps1:26:6:26:11 | arr6 [element 1, element 2] | provenance |  |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 3] | test.ps1:26:6:26:11 | arr6 [element 1, element 3] | provenance |  |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 4] | test.ps1:26:6:26:11 | arr6 [element 1, element 4] | provenance |  |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 0] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element 0] | provenance |  |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 1] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element 1] | provenance |  |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 2] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element 2] | provenance |  |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 3] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element 3] | provenance |  |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 4] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element 4] | provenance |  |
-| test.ps1:25:23:25:33 | Source | test.ps1:25:1:25:9 | [post] ...[...] [element 0] | provenance |  |
-| test.ps1:25:23:25:33 | Source | test.ps1:25:1:25:9 | [post] ...[...] [element 1] | provenance |  |
-| test.ps1:25:23:25:33 | Source | test.ps1:25:1:25:9 | [post] ...[...] [element 2] | provenance |  |
-| test.ps1:25:23:25:33 | Source | test.ps1:25:1:25:9 | [post] ...[...] [element 3] | provenance |  |
-| test.ps1:25:23:25:33 | Source | test.ps1:25:1:25:9 | [post] ...[...] [element 4] | provenance |  |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 0] | test.ps1:26:6:26:14 | ...[...] [element 0] | provenance |  |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 1] | test.ps1:26:6:26:14 | ...[...] [element 1] | provenance |  |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 2] | test.ps1:26:6:26:14 | ...[...] [element 2] | provenance |  |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 3] | test.ps1:26:6:26:14 | ...[...] [element 3] | provenance |  |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 4] | test.ps1:26:6:26:14 | ...[...] [element 4] | provenance |  |
-| test.ps1:26:6:26:14 | ...[...] [element 0] | test.ps1:26:6:26:25 | ...[...] | provenance |  |
-| test.ps1:26:6:26:14 | ...[...] [element 1] | test.ps1:26:6:26:25 | ...[...] | provenance |  |
-| test.ps1:26:6:26:14 | ...[...] [element 2] | test.ps1:26:6:26:25 | ...[...] | provenance |  |
-| test.ps1:26:6:26:14 | ...[...] [element 3] | test.ps1:26:6:26:25 | ...[...] | provenance |  |
-| test.ps1:26:6:26:14 | ...[...] [element 4] | test.ps1:26:6:26:25 | ...[...] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 0] | test.ps1:31:6:31:11 | arr7 [element 0, element 0] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 1] | test.ps1:31:6:31:11 | arr7 [element 0, element 1] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 2] | test.ps1:31:6:31:11 | arr7 [element 0, element 2] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 3] | test.ps1:31:6:31:11 | arr7 [element 0, element 3] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 4] | test.ps1:31:6:31:11 | arr7 [element 0, element 4] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 0] | test.ps1:31:6:31:11 | arr7 [element 1, element 0] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 1] | test.ps1:31:6:31:11 | arr7 [element 1, element 1] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 2] | test.ps1:30:6:30:11 | arr7 [element 1, element 2] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 2] | test.ps1:31:6:31:11 | arr7 [element 1, element 2] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 3] | test.ps1:31:6:31:11 | arr7 [element 1, element 3] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 4] | test.ps1:31:6:31:11 | arr7 [element 1, element 4] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 0] | test.ps1:31:6:31:11 | arr7 [element 2, element 0] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 1] | test.ps1:31:6:31:11 | arr7 [element 2, element 1] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 2] | test.ps1:31:6:31:11 | arr7 [element 2, element 2] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 3] | test.ps1:31:6:31:11 | arr7 [element 2, element 3] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 4] | test.ps1:31:6:31:11 | arr7 [element 2, element 4] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 0] | test.ps1:31:6:31:11 | arr7 [element 3, element 0] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 1] | test.ps1:31:6:31:11 | arr7 [element 3, element 1] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 2] | test.ps1:31:6:31:11 | arr7 [element 3, element 2] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 3] | test.ps1:31:6:31:11 | arr7 [element 3, element 3] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 4] | test.ps1:31:6:31:11 | arr7 [element 3, element 4] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 0] | test.ps1:31:6:31:11 | arr7 [element 4, element 0] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 1] | test.ps1:31:6:31:11 | arr7 [element 4, element 1] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 2] | test.ps1:31:6:31:11 | arr7 [element 4, element 2] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 3] | test.ps1:31:6:31:11 | arr7 [element 4, element 3] | provenance |  |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 4] | test.ps1:31:6:31:11 | arr7 [element 4, element 4] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 0] | test.ps1:29:1:29:6 | [post] arr7 [element 0, element 0] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 0] | test.ps1:29:1:29:6 | [post] arr7 [element 1, element 0] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 0] | test.ps1:29:1:29:6 | [post] arr7 [element 2, element 0] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 0] | test.ps1:29:1:29:6 | [post] arr7 [element 3, element 0] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 0] | test.ps1:29:1:29:6 | [post] arr7 [element 4, element 0] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 1] | test.ps1:29:1:29:6 | [post] arr7 [element 0, element 1] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 1] | test.ps1:29:1:29:6 | [post] arr7 [element 1, element 1] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 1] | test.ps1:29:1:29:6 | [post] arr7 [element 2, element 1] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 1] | test.ps1:29:1:29:6 | [post] arr7 [element 3, element 1] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 1] | test.ps1:29:1:29:6 | [post] arr7 [element 4, element 1] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 2] | test.ps1:29:1:29:6 | [post] arr7 [element 0, element 2] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 2] | test.ps1:29:1:29:6 | [post] arr7 [element 1, element 2] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 2] | test.ps1:29:1:29:6 | [post] arr7 [element 2, element 2] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 2] | test.ps1:29:1:29:6 | [post] arr7 [element 3, element 2] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 2] | test.ps1:29:1:29:6 | [post] arr7 [element 4, element 2] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 3] | test.ps1:29:1:29:6 | [post] arr7 [element 0, element 3] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 3] | test.ps1:29:1:29:6 | [post] arr7 [element 1, element 3] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 3] | test.ps1:29:1:29:6 | [post] arr7 [element 2, element 3] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 3] | test.ps1:29:1:29:6 | [post] arr7 [element 3, element 3] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 3] | test.ps1:29:1:29:6 | [post] arr7 [element 4, element 3] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 4] | test.ps1:29:1:29:6 | [post] arr7 [element 0, element 4] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 4] | test.ps1:29:1:29:6 | [post] arr7 [element 1, element 4] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 4] | test.ps1:29:1:29:6 | [post] arr7 [element 2, element 4] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 4] | test.ps1:29:1:29:6 | [post] arr7 [element 3, element 4] | provenance |  |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 4] | test.ps1:29:1:29:6 | [post] arr7 [element 4, element 4] | provenance |  |
-| test.ps1:29:31:29:41 | Source | test.ps1:29:1:29:17 | [post] ...[...] [element 0] | provenance |  |
-| test.ps1:29:31:29:41 | Source | test.ps1:29:1:29:17 | [post] ...[...] [element 1] | provenance |  |
-| test.ps1:29:31:29:41 | Source | test.ps1:29:1:29:17 | [post] ...[...] [element 2] | provenance |  |
-| test.ps1:29:31:29:41 | Source | test.ps1:29:1:29:17 | [post] ...[...] [element 3] | provenance |  |
-| test.ps1:29:31:29:41 | Source | test.ps1:29:1:29:17 | [post] ...[...] [element 4] | provenance |  |
-| test.ps1:30:6:30:11 | arr7 [element 1, element 2] | test.ps1:30:6:30:14 | ...[...] [element 2] | provenance |  |
-| test.ps1:30:6:30:14 | ...[...] [element 2] | test.ps1:30:6:30:17 | ...[...] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 0] | test.ps1:31:6:31:22 | ...[...] [element 0] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 1] | test.ps1:31:6:31:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 2] | test.ps1:31:6:31:22 | ...[...] [element 2] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 3] | test.ps1:31:6:31:22 | ...[...] [element 3] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 4] | test.ps1:31:6:31:22 | ...[...] [element 4] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 0] | test.ps1:31:6:31:22 | ...[...] [element 0] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 1] | test.ps1:31:6:31:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 2] | test.ps1:31:6:31:22 | ...[...] [element 2] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 3] | test.ps1:31:6:31:22 | ...[...] [element 3] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 4] | test.ps1:31:6:31:22 | ...[...] [element 4] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 0] | test.ps1:31:6:31:22 | ...[...] [element 0] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 1] | test.ps1:31:6:31:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 2] | test.ps1:31:6:31:22 | ...[...] [element 2] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 3] | test.ps1:31:6:31:22 | ...[...] [element 3] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 4] | test.ps1:31:6:31:22 | ...[...] [element 4] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 0] | test.ps1:31:6:31:22 | ...[...] [element 0] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 1] | test.ps1:31:6:31:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 2] | test.ps1:31:6:31:22 | ...[...] [element 2] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 3] | test.ps1:31:6:31:22 | ...[...] [element 3] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 4] | test.ps1:31:6:31:22 | ...[...] [element 4] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 0] | test.ps1:31:6:31:22 | ...[...] [element 0] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 1] | test.ps1:31:6:31:22 | ...[...] [element 1] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 2] | test.ps1:31:6:31:22 | ...[...] [element 2] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 3] | test.ps1:31:6:31:22 | ...[...] [element 3] | provenance |  |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 4] | test.ps1:31:6:31:22 | ...[...] [element 4] | provenance |  |
-| test.ps1:31:6:31:22 | ...[...] [element 0] | test.ps1:31:6:31:33 | ...[...] | provenance |  |
-| test.ps1:31:6:31:22 | ...[...] [element 1] | test.ps1:31:6:31:33 | ...[...] | provenance |  |
-| test.ps1:31:6:31:22 | ...[...] [element 2] | test.ps1:31:6:31:33 | ...[...] | provenance |  |
-| test.ps1:31:6:31:22 | ...[...] [element 3] | test.ps1:31:6:31:33 | ...[...] | provenance |  |
-| test.ps1:31:6:31:22 | ...[...] [element 4] | test.ps1:31:6:31:33 | ...[...] | provenance |  |
+| test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | test.ps1:26:6:26:11 | arr6 [element 1, element] | provenance |  |
+| test.ps1:25:1:25:9 | [post] ...[...] [element] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | provenance |  |
+| test.ps1:25:23:25:33 | Source | test.ps1:25:1:25:9 | [post] ...[...] [element] | provenance |  |
+| test.ps1:26:6:26:11 | arr6 [element 1, element] | test.ps1:26:6:26:14 | ...[...] [element] | provenance |  |
+| test.ps1:26:6:26:14 | ...[...] [element] | test.ps1:26:6:26:25 | ...[...] | provenance |  |
+| test.ps1:29:1:29:6 | [post] arr7 [element, element] | test.ps1:30:6:30:11 | arr7 [element, element] | provenance |  |
+| test.ps1:29:1:29:6 | [post] arr7 [element, element] | test.ps1:31:6:31:11 | arr7 [element, element] | provenance |  |
+| test.ps1:29:1:29:17 | [post] ...[...] [element] | test.ps1:29:1:29:6 | [post] arr7 [element, element] | provenance |  |
+| test.ps1:29:31:29:41 | Source | test.ps1:29:1:29:17 | [post] ...[...] [element] | provenance |  |
+| test.ps1:30:6:30:11 | arr7 [element, element] | test.ps1:30:6:30:14 | ...[...] [element] | provenance |  |
+| test.ps1:30:6:30:14 | ...[...] [element] | test.ps1:30:6:30:17 | ...[...] | provenance |  |
+| test.ps1:31:6:31:11 | arr7 [element, element] | test.ps1:31:6:31:22 | ...[...] [element] | provenance |  |
+| test.ps1:31:6:31:22 | ...[...] [element] | test.ps1:31:6:31:33 | ...[...] | provenance |  |
 | test.ps1:33:6:33:17 | Source | test.ps1:35:15:35:17 | x | provenance |  |
 | test.ps1:35:9:35:17 | ...,... [element 2] | test.ps1:38:6:38:11 | arr8 [element 2] | provenance |  |
 | test.ps1:35:9:35:17 | ...,... [element 2] | test.ps1:39:6:39:11 | arr8 [element 2] | provenance |  |
@@ -168,6 +44,20 @@ edges
 | test.ps1:59:1:59:9 | [post] myClass [field] | test.ps1:61:1:61:9 | myClass [field] | provenance |  |
 | test.ps1:59:18:59:29 | Source | test.ps1:59:1:59:9 | [post] myClass [field] | provenance |  |
 | test.ps1:61:1:61:9 | myClass [field] | test.ps1:52:22:54:6 | this [field] | provenance |  |
+| test.ps1:64:10:64:21 | Source | test.ps1:67:5:67:7 | x | provenance |  |
+| test.ps1:65:10:65:21 | Source | test.ps1:68:5:68:7 | y | provenance |  |
+| test.ps1:66:10:66:21 | Source | test.ps1:68:9:68:11 | z | provenance |  |
+| test.ps1:67:5:67:7 | x | test.ps1:71:6:71:13 | produce [element] | provenance |  |
+| test.ps1:68:5:68:7 | y | test.ps1:68:5:68:11 | ...,... [element 0] | provenance |  |
+| test.ps1:68:5:68:11 | ...,... [element 0] | test.ps1:71:6:71:13 | produce [element] | provenance |  |
+| test.ps1:68:5:68:11 | ...,... [element 1] | test.ps1:71:6:71:13 | produce [element] | provenance |  |
+| test.ps1:68:9:68:11 | z | test.ps1:68:5:68:11 | ...,... [element 1] | provenance |  |
+| test.ps1:71:6:71:13 | produce [element] | test.ps1:72:6:72:8 | x [element] | provenance |  |
+| test.ps1:71:6:71:13 | produce [element] | test.ps1:73:6:73:8 | x [element] | provenance |  |
+| test.ps1:71:6:71:13 | produce [element] | test.ps1:74:6:74:8 | x [element] | provenance |  |
+| test.ps1:72:6:72:8 | x [element] | test.ps1:72:6:72:11 | ...[...] | provenance |  |
+| test.ps1:73:6:73:8 | x [element] | test.ps1:73:6:73:11 | ...[...] | provenance |  |
+| test.ps1:74:6:74:8 | x [element] | test.ps1:74:6:74:11 | ...[...] | provenance |  |
 nodes
 | test.ps1:1:1:1:3 | [post] a [f] | semmle.label | [post] a [f] |
 | test.ps1:1:8:1:18 | Source | semmle.label | Source |
@@ -177,126 +67,38 @@ nodes
 | test.ps1:8:12:8:22 | Source | semmle.label | Source |
 | test.ps1:9:6:9:11 | arr1 [element 3] | semmle.label | arr1 [element 3] |
 | test.ps1:9:6:9:14 | ...[...] | semmle.label | ...[...] |
-| test.ps1:12:1:12:6 | [post] arr2 [element 4] | semmle.label | [post] arr2 [element 4] |
+| test.ps1:12:1:12:6 | [post] arr2 [element] | semmle.label | [post] arr2 [element] |
 | test.ps1:12:19:12:29 | Source | semmle.label | Source |
-| test.ps1:13:6:13:11 | arr2 [element 4] | semmle.label | arr2 [element 4] |
+| test.ps1:13:6:13:11 | arr2 [element] | semmle.label | arr2 [element] |
 | test.ps1:13:6:13:14 | ...[...] | semmle.label | ...[...] |
 | test.ps1:15:1:15:6 | [post] arr3 [element 3] | semmle.label | [post] arr3 [element 3] |
 | test.ps1:15:12:15:22 | Source | semmle.label | Source |
 | test.ps1:16:6:16:11 | arr3 [element 3] | semmle.label | arr3 [element 3] |
 | test.ps1:16:6:16:21 | ...[...] | semmle.label | ...[...] |
-| test.ps1:18:1:18:6 | [post] arr4 [element 0] | semmle.label | [post] arr4 [element 0] |
-| test.ps1:18:1:18:6 | [post] arr4 [element 1] | semmle.label | [post] arr4 [element 1] |
-| test.ps1:18:1:18:6 | [post] arr4 [element 2] | semmle.label | [post] arr4 [element 2] |
-| test.ps1:18:1:18:6 | [post] arr4 [element 3] | semmle.label | [post] arr4 [element 3] |
-| test.ps1:18:1:18:6 | [post] arr4 [element 4] | semmle.label | [post] arr4 [element 4] |
+| test.ps1:18:1:18:6 | [post] arr4 [element] | semmle.label | [post] arr4 [element] |
 | test.ps1:18:20:18:30 | Source | semmle.label | Source |
-| test.ps1:19:6:19:11 | arr4 [element 0] | semmle.label | arr4 [element 0] |
-| test.ps1:19:6:19:11 | arr4 [element 1] | semmle.label | arr4 [element 1] |
-| test.ps1:19:6:19:11 | arr4 [element 2] | semmle.label | arr4 [element 2] |
-| test.ps1:19:6:19:11 | arr4 [element 3] | semmle.label | arr4 [element 3] |
-| test.ps1:19:6:19:11 | arr4 [element 4] | semmle.label | arr4 [element 4] |
+| test.ps1:19:6:19:11 | arr4 [element] | semmle.label | arr4 [element] |
 | test.ps1:19:6:19:22 | ...[...] | semmle.label | ...[...] |
-| test.ps1:21:1:21:6 | [post] arr5 [element 0, element 1] | semmle.label | [post] arr5 [element 0, element 1] |
-| test.ps1:21:1:21:6 | [post] arr5 [element 1, element 1] | semmle.label | [post] arr5 [element 1, element 1] |
-| test.ps1:21:1:21:6 | [post] arr5 [element 2, element 1] | semmle.label | [post] arr5 [element 2, element 1] |
-| test.ps1:21:1:21:6 | [post] arr5 [element 3, element 1] | semmle.label | [post] arr5 [element 3, element 1] |
-| test.ps1:21:1:21:6 | [post] arr5 [element 4, element 1] | semmle.label | [post] arr5 [element 4, element 1] |
+| test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | semmle.label | [post] arr5 [element, element 1] |
 | test.ps1:21:1:21:17 | [post] ...[...] [element 1] | semmle.label | [post] ...[...] [element 1] |
 | test.ps1:21:23:21:33 | Source | semmle.label | Source |
-| test.ps1:22:6:22:11 | arr5 [element 0, element 1] | semmle.label | arr5 [element 0, element 1] |
-| test.ps1:22:6:22:11 | arr5 [element 1, element 1] | semmle.label | arr5 [element 1, element 1] |
-| test.ps1:22:6:22:11 | arr5 [element 2, element 1] | semmle.label | arr5 [element 2, element 1] |
-| test.ps1:22:6:22:11 | arr5 [element 3, element 1] | semmle.label | arr5 [element 3, element 1] |
-| test.ps1:22:6:22:11 | arr5 [element 4, element 1] | semmle.label | arr5 [element 4, element 1] |
+| test.ps1:22:6:22:11 | arr5 [element, element 1] | semmle.label | arr5 [element, element 1] |
 | test.ps1:22:6:22:22 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | test.ps1:22:6:22:25 | ...[...] | semmle.label | ...[...] |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 0] | semmle.label | [post] arr6 [element 1, element 0] |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 1] | semmle.label | [post] arr6 [element 1, element 1] |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 2] | semmle.label | [post] arr6 [element 1, element 2] |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 3] | semmle.label | [post] arr6 [element 1, element 3] |
-| test.ps1:25:1:25:6 | [post] arr6 [element 1, element 4] | semmle.label | [post] arr6 [element 1, element 4] |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 1] | semmle.label | [post] ...[...] [element 1] |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 2] | semmle.label | [post] ...[...] [element 2] |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 3] | semmle.label | [post] ...[...] [element 3] |
-| test.ps1:25:1:25:9 | [post] ...[...] [element 4] | semmle.label | [post] ...[...] [element 4] |
+| test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | semmle.label | [post] arr6 [element 1, element] |
+| test.ps1:25:1:25:9 | [post] ...[...] [element] | semmle.label | [post] ...[...] [element] |
 | test.ps1:25:23:25:33 | Source | semmle.label | Source |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 0] | semmle.label | arr6 [element 1, element 0] |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 1] | semmle.label | arr6 [element 1, element 1] |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 2] | semmle.label | arr6 [element 1, element 2] |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 3] | semmle.label | arr6 [element 1, element 3] |
-| test.ps1:26:6:26:11 | arr6 [element 1, element 4] | semmle.label | arr6 [element 1, element 4] |
-| test.ps1:26:6:26:14 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
-| test.ps1:26:6:26:14 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
-| test.ps1:26:6:26:14 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
-| test.ps1:26:6:26:14 | ...[...] [element 3] | semmle.label | ...[...] [element 3] |
-| test.ps1:26:6:26:14 | ...[...] [element 4] | semmle.label | ...[...] [element 4] |
+| test.ps1:26:6:26:11 | arr6 [element 1, element] | semmle.label | arr6 [element 1, element] |
+| test.ps1:26:6:26:14 | ...[...] [element] | semmle.label | ...[...] [element] |
 | test.ps1:26:6:26:25 | ...[...] | semmle.label | ...[...] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 0] | semmle.label | [post] arr7 [element 0, element 0] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 1] | semmle.label | [post] arr7 [element 0, element 1] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 2] | semmle.label | [post] arr7 [element 0, element 2] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 3] | semmle.label | [post] arr7 [element 0, element 3] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 0, element 4] | semmle.label | [post] arr7 [element 0, element 4] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 0] | semmle.label | [post] arr7 [element 1, element 0] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 1] | semmle.label | [post] arr7 [element 1, element 1] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 2] | semmle.label | [post] arr7 [element 1, element 2] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 3] | semmle.label | [post] arr7 [element 1, element 3] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 1, element 4] | semmle.label | [post] arr7 [element 1, element 4] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 0] | semmle.label | [post] arr7 [element 2, element 0] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 1] | semmle.label | [post] arr7 [element 2, element 1] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 2] | semmle.label | [post] arr7 [element 2, element 2] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 3] | semmle.label | [post] arr7 [element 2, element 3] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 2, element 4] | semmle.label | [post] arr7 [element 2, element 4] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 0] | semmle.label | [post] arr7 [element 3, element 0] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 1] | semmle.label | [post] arr7 [element 3, element 1] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 2] | semmle.label | [post] arr7 [element 3, element 2] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 3] | semmle.label | [post] arr7 [element 3, element 3] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 3, element 4] | semmle.label | [post] arr7 [element 3, element 4] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 0] | semmle.label | [post] arr7 [element 4, element 0] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 1] | semmle.label | [post] arr7 [element 4, element 1] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 2] | semmle.label | [post] arr7 [element 4, element 2] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 3] | semmle.label | [post] arr7 [element 4, element 3] |
-| test.ps1:29:1:29:6 | [post] arr7 [element 4, element 4] | semmle.label | [post] arr7 [element 4, element 4] |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 1] | semmle.label | [post] ...[...] [element 1] |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 2] | semmle.label | [post] ...[...] [element 2] |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 3] | semmle.label | [post] ...[...] [element 3] |
-| test.ps1:29:1:29:17 | [post] ...[...] [element 4] | semmle.label | [post] ...[...] [element 4] |
+| test.ps1:29:1:29:6 | [post] arr7 [element, element] | semmle.label | [post] arr7 [element, element] |
+| test.ps1:29:1:29:17 | [post] ...[...] [element] | semmle.label | [post] ...[...] [element] |
 | test.ps1:29:31:29:41 | Source | semmle.label | Source |
-| test.ps1:30:6:30:11 | arr7 [element 1, element 2] | semmle.label | arr7 [element 1, element 2] |
-| test.ps1:30:6:30:14 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
+| test.ps1:30:6:30:11 | arr7 [element, element] | semmle.label | arr7 [element, element] |
+| test.ps1:30:6:30:14 | ...[...] [element] | semmle.label | ...[...] [element] |
 | test.ps1:30:6:30:17 | ...[...] | semmle.label | ...[...] |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 0] | semmle.label | arr7 [element 0, element 0] |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 1] | semmle.label | arr7 [element 0, element 1] |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 2] | semmle.label | arr7 [element 0, element 2] |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 3] | semmle.label | arr7 [element 0, element 3] |
-| test.ps1:31:6:31:11 | arr7 [element 0, element 4] | semmle.label | arr7 [element 0, element 4] |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 0] | semmle.label | arr7 [element 1, element 0] |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 1] | semmle.label | arr7 [element 1, element 1] |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 2] | semmle.label | arr7 [element 1, element 2] |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 3] | semmle.label | arr7 [element 1, element 3] |
-| test.ps1:31:6:31:11 | arr7 [element 1, element 4] | semmle.label | arr7 [element 1, element 4] |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 0] | semmle.label | arr7 [element 2, element 0] |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 1] | semmle.label | arr7 [element 2, element 1] |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 2] | semmle.label | arr7 [element 2, element 2] |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 3] | semmle.label | arr7 [element 2, element 3] |
-| test.ps1:31:6:31:11 | arr7 [element 2, element 4] | semmle.label | arr7 [element 2, element 4] |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 0] | semmle.label | arr7 [element 3, element 0] |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 1] | semmle.label | arr7 [element 3, element 1] |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 2] | semmle.label | arr7 [element 3, element 2] |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 3] | semmle.label | arr7 [element 3, element 3] |
-| test.ps1:31:6:31:11 | arr7 [element 3, element 4] | semmle.label | arr7 [element 3, element 4] |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 0] | semmle.label | arr7 [element 4, element 0] |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 1] | semmle.label | arr7 [element 4, element 1] |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 2] | semmle.label | arr7 [element 4, element 2] |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 3] | semmle.label | arr7 [element 4, element 3] |
-| test.ps1:31:6:31:11 | arr7 [element 4, element 4] | semmle.label | arr7 [element 4, element 4] |
-| test.ps1:31:6:31:22 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
-| test.ps1:31:6:31:22 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
-| test.ps1:31:6:31:22 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
-| test.ps1:31:6:31:22 | ...[...] [element 3] | semmle.label | ...[...] [element 3] |
-| test.ps1:31:6:31:22 | ...[...] [element 4] | semmle.label | ...[...] [element 4] |
+| test.ps1:31:6:31:11 | arr7 [element, element] | semmle.label | arr7 [element, element] |
+| test.ps1:31:6:31:22 | ...[...] [element] | semmle.label | ...[...] [element] |
 | test.ps1:31:6:31:33 | ...[...] | semmle.label | ...[...] |
 | test.ps1:33:6:33:17 | Source | semmle.label | Source |
 | test.ps1:35:9:35:17 | ...,... [element 2] | semmle.label | ...,... [element 2] |
@@ -311,6 +113,21 @@ nodes
 | test.ps1:59:1:59:9 | [post] myClass [field] | semmle.label | [post] myClass [field] |
 | test.ps1:59:18:59:29 | Source | semmle.label | Source |
 | test.ps1:61:1:61:9 | myClass [field] | semmle.label | myClass [field] |
+| test.ps1:64:10:64:21 | Source | semmle.label | Source |
+| test.ps1:65:10:65:21 | Source | semmle.label | Source |
+| test.ps1:66:10:66:21 | Source | semmle.label | Source |
+| test.ps1:67:5:67:7 | x | semmle.label | x |
+| test.ps1:68:5:68:7 | y | semmle.label | y |
+| test.ps1:68:5:68:11 | ...,... [element 0] | semmle.label | ...,... [element 0] |
+| test.ps1:68:5:68:11 | ...,... [element 1] | semmle.label | ...,... [element 1] |
+| test.ps1:68:9:68:11 | z | semmle.label | z |
+| test.ps1:71:6:71:13 | produce [element] | semmle.label | produce [element] |
+| test.ps1:72:6:72:8 | x [element] | semmle.label | x [element] |
+| test.ps1:72:6:72:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:73:6:73:8 | x [element] | semmle.label | x [element] |
+| test.ps1:73:6:73:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:74:6:74:8 | x [element] | semmle.label | x [element] |
+| test.ps1:74:6:74:11 | ...[...] | semmle.label | ...[...] |
 subpaths
 testFailures
 #select
@@ -326,3 +143,12 @@ testFailures
 | test.ps1:38:6:38:14 | ...[...] | test.ps1:33:6:33:17 | Source | test.ps1:38:6:38:14 | ...[...] | $@ | test.ps1:33:6:33:17 | Source | Source |
 | test.ps1:39:6:39:21 | ...[...] | test.ps1:33:6:33:17 | Source | test.ps1:39:6:39:21 | ...[...] | $@ | test.ps1:33:6:33:17 | Source | Source |
 | test.ps1:53:14:53:25 | field | test.ps1:59:18:59:29 | Source | test.ps1:53:14:53:25 | field | $@ | test.ps1:59:18:59:29 | Source | Source |
+| test.ps1:72:6:72:11 | ...[...] | test.ps1:64:10:64:21 | Source | test.ps1:72:6:72:11 | ...[...] | $@ | test.ps1:64:10:64:21 | Source | Source |
+| test.ps1:72:6:72:11 | ...[...] | test.ps1:65:10:65:21 | Source | test.ps1:72:6:72:11 | ...[...] | $@ | test.ps1:65:10:65:21 | Source | Source |
+| test.ps1:72:6:72:11 | ...[...] | test.ps1:66:10:66:21 | Source | test.ps1:72:6:72:11 | ...[...] | $@ | test.ps1:66:10:66:21 | Source | Source |
+| test.ps1:73:6:73:11 | ...[...] | test.ps1:64:10:64:21 | Source | test.ps1:73:6:73:11 | ...[...] | $@ | test.ps1:64:10:64:21 | Source | Source |
+| test.ps1:73:6:73:11 | ...[...] | test.ps1:65:10:65:21 | Source | test.ps1:73:6:73:11 | ...[...] | $@ | test.ps1:65:10:65:21 | Source | Source |
+| test.ps1:73:6:73:11 | ...[...] | test.ps1:66:10:66:21 | Source | test.ps1:73:6:73:11 | ...[...] | $@ | test.ps1:66:10:66:21 | Source | Source |
+| test.ps1:74:6:74:11 | ...[...] | test.ps1:64:10:64:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:64:10:64:21 | Source | Source |
+| test.ps1:74:6:74:11 | ...[...] | test.ps1:65:10:65:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:65:10:65:21 | Source | Source |
+| test.ps1:74:6:74:11 | ...[...] | test.ps1:66:10:66:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:66:10:66:21 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/fields/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.ps1
@@ -59,3 +59,16 @@ $myClass = [MyClass]::new()
 $myClass.field = Source "12"
 
 $myClass.callSink()
+
+function produce {
+    $x = Source "13"
+    $y = Source "14"
+    $z = Source "15"
+    $x
+    $y, $z
+}
+
+$x = produce
+Sink $x[0] # $ hasValueFlow=13 hasValueFlow=14 hasValueFlow=15
+Sink $x[1] # $ hasValueFlow=13 hasValueFlow=14 hasValueFlow=15
+Sink $x[2] # $ hasValueFlow=13 hasValueFlow=14 hasValueFlow=15

--- a/powershell/ql/test/library-tests/dataflow/local/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/test.expected
@@ -1,16 +1,17 @@
 | test.ps1:1:1:1:4 | a1 | test.ps1:2:6:2:9 | a1 |
 | test.ps1:1:7:1:13 | Source | test.ps1:1:1:1:4 | a1 |
 | test.ps1:1:7:1:13 | Source | test.ps1:1:1:1:13 | ...=... |
-| test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | implicit unwrapping of Sink |
-| test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | implicit unwrapping of Sink |
+| test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | pre-return value for Sink |
+| test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | pre-return value for Sink |
 | test.ps1:2:1:2:9 | implicit unwrapping of Sink | test.ps1:1:1:8:9 | return value for test.ps1 |
+| test.ps1:2:1:2:9 | pre-return value for Sink | test.ps1:2:1:2:9 | implicit unwrapping of Sink |
 | test.ps1:4:1:4:3 | b | test.ps1:5:4:5:6 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:3 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:13 | ...=... |
-| test.ps1:5:4:5:6 | b | test.ps1:5:4:5:6 | b |
 | test.ps1:6:5:6:8 | a2 | test.ps1:8:6:8:9 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:8 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:17 | ...=... |
-| test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | implicit unwrapping of Sink |
-| test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | implicit unwrapping of Sink |
+| test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | pre-return value for Sink |
+| test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | pre-return value for Sink |
 | test.ps1:8:1:8:9 | implicit unwrapping of Sink | test.ps1:1:1:8:9 | return value for test.ps1 |
+| test.ps1:8:1:8:9 | pre-return value for Sink | test.ps1:8:1:8:9 | implicit unwrapping of Sink |

--- a/powershell/ql/test/library-tests/dataflow/local/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/test.expected
@@ -1,6 +1,9 @@
 | test.ps1:1:1:1:4 | a1 | test.ps1:2:6:2:9 | a1 |
 | test.ps1:1:7:1:13 | Source | test.ps1:1:1:1:4 | a1 |
 | test.ps1:1:7:1:13 | Source | test.ps1:1:1:1:13 | ...=... |
+| test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | implicit unwrapping of Sink |
+| test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | implicit unwrapping of Sink |
+| test.ps1:2:1:2:9 | implicit unwrapping of Sink | test.ps1:1:1:8:9 | return value for test.ps1 |
 | test.ps1:4:1:4:3 | b | test.ps1:5:4:5:6 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:3 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:13 | ...=... |
@@ -8,3 +11,6 @@
 | test.ps1:6:5:6:8 | a2 | test.ps1:8:6:8:9 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:8 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:17 | ...=... |
+| test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | implicit unwrapping of Sink |
+| test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | implicit unwrapping of Sink |
+| test.ps1:8:1:8:9 | implicit unwrapping of Sink | test.ps1:1:1:8:9 | return value for test.ps1 |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
@@ -1,0 +1,75 @@
+models
+edges
+| test.ps1:2:10:2:21 | Source | test.ps1:5:5:5:7 | x | provenance |  |
+| test.ps1:3:10:3:21 | Source | test.ps1:6:5:6:7 | y | provenance |  |
+| test.ps1:4:10:4:21 | Source | test.ps1:6:9:6:11 | z | provenance |  |
+| test.ps1:5:5:5:7 | x | test.ps1:17:1:17:8 | produce [element] | provenance |  |
+| test.ps1:6:5:6:7 | y | test.ps1:6:5:6:11 | ...,... [element 0] | provenance |  |
+| test.ps1:6:5:6:11 | ...,... [element 0] | test.ps1:17:1:17:8 | produce [element] | provenance |  |
+| test.ps1:6:5:6:11 | ...,... [element 1] | test.ps1:17:1:17:8 | produce [element] | provenance |  |
+| test.ps1:6:9:6:11 | z | test.ps1:6:5:6:11 | ...,... [element 1] | provenance |  |
+| test.ps1:10:11:10:44 | x [element 0] | test.ps1:13:14:13:16 | x | provenance |  |
+| test.ps1:10:11:10:44 | x [element 1] | test.ps1:13:14:13:16 | x | provenance |  |
+| test.ps1:10:11:10:44 | x [element] | test.ps1:13:14:13:16 | x | provenance |  |
+| test.ps1:17:1:17:8 | produce [element] | test.ps1:10:11:10:44 | x [element] | provenance |  |
+| test.ps1:19:6:19:17 | Source | test.ps1:21:1:21:3 | x | provenance |  |
+| test.ps1:20:6:20:17 | Source | test.ps1:21:5:21:7 | y | provenance |  |
+| test.ps1:21:1:21:3 | x | test.ps1:21:1:21:7 | ...,... [element 0] | provenance |  |
+| test.ps1:21:1:21:7 | ...,... [element 0] | test.ps1:10:11:10:44 | x [element 0] | provenance |  |
+| test.ps1:21:1:21:7 | ...,... [element 0] | test.ps1:21:1:21:7 | ...,... [element 0] | provenance |  |
+| test.ps1:21:1:21:7 | ...,... [element 1] | test.ps1:10:11:10:44 | x [element 1] | provenance |  |
+| test.ps1:21:1:21:7 | ...,... [element 1] | test.ps1:21:1:21:7 | ...,... [element 1] | provenance |  |
+| test.ps1:21:5:21:7 | y | test.ps1:21:1:21:7 | ...,... [element 1] | provenance |  |
+| test.ps1:25:14:25:16 | _ [element 0] | test.ps1:25:14:25:16 | _ | provenance |  |
+| test.ps1:25:14:25:16 | _ [element 1] | test.ps1:25:14:25:16 | _ | provenance |  |
+| test.ps1:29:6:29:17 | Source | test.ps1:31:1:31:3 | x | provenance |  |
+| test.ps1:30:6:30:17 | Source | test.ps1:31:5:31:7 | y | provenance |  |
+| test.ps1:31:1:31:3 | x | test.ps1:31:1:31:7 | ...,... [element 0] | provenance |  |
+| test.ps1:31:1:31:7 | ...,... [element 0] | test.ps1:25:14:25:16 | _ [element 0] | provenance |  |
+| test.ps1:31:1:31:7 | ...,... [element 0] | test.ps1:31:1:31:7 | ...,... [element 0] | provenance |  |
+| test.ps1:31:1:31:7 | ...,... [element 1] | test.ps1:25:14:25:16 | _ [element 1] | provenance |  |
+| test.ps1:31:1:31:7 | ...,... [element 1] | test.ps1:31:1:31:7 | ...,... [element 1] | provenance |  |
+| test.ps1:31:5:31:7 | y | test.ps1:31:1:31:7 | ...,... [element 1] | provenance |  |
+nodes
+| test.ps1:2:10:2:21 | Source | semmle.label | Source |
+| test.ps1:3:10:3:21 | Source | semmle.label | Source |
+| test.ps1:4:10:4:21 | Source | semmle.label | Source |
+| test.ps1:5:5:5:7 | x | semmle.label | x |
+| test.ps1:6:5:6:7 | y | semmle.label | y |
+| test.ps1:6:5:6:11 | ...,... [element 0] | semmle.label | ...,... [element 0] |
+| test.ps1:6:5:6:11 | ...,... [element 1] | semmle.label | ...,... [element 1] |
+| test.ps1:6:9:6:11 | z | semmle.label | z |
+| test.ps1:10:11:10:44 | x [element 0] | semmle.label | x [element 0] |
+| test.ps1:10:11:10:44 | x [element 1] | semmle.label | x [element 1] |
+| test.ps1:10:11:10:44 | x [element] | semmle.label | x [element] |
+| test.ps1:13:14:13:16 | x | semmle.label | x |
+| test.ps1:17:1:17:8 | produce [element] | semmle.label | produce [element] |
+| test.ps1:19:6:19:17 | Source | semmle.label | Source |
+| test.ps1:20:6:20:17 | Source | semmle.label | Source |
+| test.ps1:21:1:21:3 | x | semmle.label | x |
+| test.ps1:21:1:21:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
+| test.ps1:21:1:21:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
+| test.ps1:21:1:21:7 | ...,... [element 1] | semmle.label | ...,... [element 1] |
+| test.ps1:21:1:21:7 | ...,... [element 1] | semmle.label | ...,... [element 1] |
+| test.ps1:21:5:21:7 | y | semmle.label | y |
+| test.ps1:25:14:25:16 | _ | semmle.label | _ |
+| test.ps1:25:14:25:16 | _ [element 0] | semmle.label | _ [element 0] |
+| test.ps1:25:14:25:16 | _ [element 1] | semmle.label | _ [element 1] |
+| test.ps1:29:6:29:17 | Source | semmle.label | Source |
+| test.ps1:30:6:30:17 | Source | semmle.label | Source |
+| test.ps1:31:1:31:3 | x | semmle.label | x |
+| test.ps1:31:1:31:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
+| test.ps1:31:1:31:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
+| test.ps1:31:1:31:7 | ...,... [element 1] | semmle.label | ...,... [element 1] |
+| test.ps1:31:1:31:7 | ...,... [element 1] | semmle.label | ...,... [element 1] |
+| test.ps1:31:5:31:7 | y | semmle.label | y |
+subpaths
+testFailures
+#select
+| test.ps1:13:14:13:16 | x | test.ps1:2:10:2:21 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:2:10:2:21 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:3:10:3:21 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:3:10:3:21 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:4:10:4:21 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:4:10:4:21 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:19:6:19:17 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:19:6:19:17 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:20:6:20:17 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:20:6:20:17 | Source | Source |
+| test.ps1:25:14:25:16 | _ | test.ps1:29:6:29:17 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:29:6:29:17 | Source | Source |
+| test.ps1:25:14:25:16 | _ | test.ps1:30:6:30:17 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:30:6:30:17 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
@@ -1,0 +1,31 @@
+function produce {
+    $x = Source "16"
+    $y = Source "17"
+    $z = Source "18"
+    $x
+    $y, $z
+}
+
+function consume {
+    Param([Parameter(ValueFromPipeline)] $x)
+
+    process {
+        Sink $x # $ hasValueFlow=16 hasValueFlow=17 hasValueFlow=18 hasValueFlow=19 hasValueFlow=20
+    }
+}
+
+produce | consume
+
+$x = Source "19"
+$y = Source "20"
+$x, $y | consume
+
+function consume2 {
+    process {
+        Sink $_ # $ hasValueFlow=21 hasValueFlow=22
+    }
+}
+
+$x = Source "21"
+$y = Source "22"
+$x, $y | consume2

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ql
@@ -1,0 +1,13 @@
+/**
+ * @kind path-problem
+ */
+
+import powershell
+import semmle.code.powershell.dataflow.DataFlow
+private import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
+
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/powershell/ql/test/library-tests/dataflow/returns/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.expected
@@ -2,39 +2,68 @@ models
 edges
 | test.ps1:2:5:2:15 | Source | test.ps1:5:6:5:20 | callSourceOnce | provenance |  |
 | test.ps1:5:6:5:20 | callSourceOnce | test.ps1:6:6:6:8 | x | provenance |  |
-| test.ps1:9:5:9:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
-| test.ps1:10:5:10:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
-| test.ps1:13:6:13:21 | callSourceTwice | test.ps1:14:6:14:8 | x | provenance |  |
-| test.ps1:17:12:17:22 | Source | test.ps1:20:6:20:19 | returnSource1 | provenance |  |
-| test.ps1:20:6:20:19 | returnSource1 | test.ps1:21:6:21:8 | x | provenance |  |
-| test.ps1:24:10:24:20 | Source | test.ps1:25:5:25:7 | x | provenance |  |
-| test.ps1:25:5:25:7 | x | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
-| test.ps1:26:10:26:20 | Source | test.ps1:27:12:27:14 | y | provenance |  |
-| test.ps1:27:12:27:14 | y | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
-| test.ps1:30:6:30:19 | returnSource2 | test.ps1:31:6:31:8 | x | provenance |  |
+| test.ps1:9:5:9:15 | Source | test.ps1:13:6:13:21 | callSourceTwice [element] | provenance |  |
+| test.ps1:10:5:10:15 | Source | test.ps1:13:6:13:21 | callSourceTwice [element] | provenance |  |
+| test.ps1:13:6:13:21 | callSourceTwice [element] | test.ps1:15:6:15:8 | x [element] | provenance |  |
+| test.ps1:13:6:13:21 | callSourceTwice [element] | test.ps1:16:6:16:8 | x [element] | provenance |  |
+| test.ps1:15:6:15:8 | x [element] | test.ps1:15:6:15:11 | ...[...] | provenance |  |
+| test.ps1:16:6:16:8 | x [element] | test.ps1:16:6:16:11 | ...[...] | provenance |  |
+| test.ps1:19:12:19:22 | Source | test.ps1:22:6:22:19 | returnSource1 | provenance |  |
+| test.ps1:22:6:22:19 | returnSource1 | test.ps1:23:6:23:8 | x | provenance |  |
+| test.ps1:26:10:26:20 | Source | test.ps1:27:5:27:7 | x | provenance |  |
+| test.ps1:27:5:27:7 | x | test.ps1:32:6:32:19 | returnSource2 [element] | provenance |  |
+| test.ps1:28:10:28:20 | Source | test.ps1:29:12:29:14 | y | provenance |  |
+| test.ps1:29:12:29:14 | y | test.ps1:32:6:32:19 | returnSource2 [element] | provenance |  |
+| test.ps1:32:6:32:19 | returnSource2 [element] | test.ps1:33:6:33:8 | x [element] | provenance |  |
+| test.ps1:32:6:32:19 | returnSource2 [element] | test.ps1:34:6:34:8 | x [element] | provenance |  |
+| test.ps1:33:6:33:8 | x [element] | test.ps1:33:6:33:11 | ...[...] | provenance |  |
+| test.ps1:34:6:34:8 | x [element] | test.ps1:34:6:34:11 | ...[...] | provenance |  |
+| test.ps1:38:9:38:19 | Source | test.ps1:42:6:42:22 | callSourceInLoop [element] | provenance |  |
+| test.ps1:42:6:42:22 | callSourceInLoop [element] | test.ps1:43:6:43:8 | x [element] | provenance |  |
+| test.ps1:42:6:42:22 | callSourceInLoop [element] | test.ps1:44:6:44:8 | x [element] | provenance |  |
+| test.ps1:43:6:43:8 | x [element] | test.ps1:43:6:43:11 | ...[...] | provenance |  |
+| test.ps1:44:6:44:8 | x [element] | test.ps1:44:6:44:11 | ...[...] | provenance |  |
 nodes
 | test.ps1:2:5:2:15 | Source | semmle.label | Source |
 | test.ps1:5:6:5:20 | callSourceOnce | semmle.label | callSourceOnce |
 | test.ps1:6:6:6:8 | x | semmle.label | x |
 | test.ps1:9:5:9:15 | Source | semmle.label | Source |
 | test.ps1:10:5:10:15 | Source | semmle.label | Source |
-| test.ps1:13:6:13:21 | callSourceTwice | semmle.label | callSourceTwice |
-| test.ps1:14:6:14:8 | x | semmle.label | x |
-| test.ps1:17:12:17:22 | Source | semmle.label | Source |
-| test.ps1:20:6:20:19 | returnSource1 | semmle.label | returnSource1 |
-| test.ps1:21:6:21:8 | x | semmle.label | x |
-| test.ps1:24:10:24:20 | Source | semmle.label | Source |
-| test.ps1:25:5:25:7 | x | semmle.label | x |
+| test.ps1:13:6:13:21 | callSourceTwice [element] | semmle.label | callSourceTwice [element] |
+| test.ps1:15:6:15:8 | x [element] | semmle.label | x [element] |
+| test.ps1:15:6:15:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:16:6:16:8 | x [element] | semmle.label | x [element] |
+| test.ps1:16:6:16:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:19:12:19:22 | Source | semmle.label | Source |
+| test.ps1:22:6:22:19 | returnSource1 | semmle.label | returnSource1 |
+| test.ps1:23:6:23:8 | x | semmle.label | x |
 | test.ps1:26:10:26:20 | Source | semmle.label | Source |
-| test.ps1:27:12:27:14 | y | semmle.label | y |
-| test.ps1:30:6:30:19 | returnSource2 | semmle.label | returnSource2 |
-| test.ps1:31:6:31:8 | x | semmle.label | x |
+| test.ps1:27:5:27:7 | x | semmle.label | x |
+| test.ps1:28:10:28:20 | Source | semmle.label | Source |
+| test.ps1:29:12:29:14 | y | semmle.label | y |
+| test.ps1:32:6:32:19 | returnSource2 [element] | semmle.label | returnSource2 [element] |
+| test.ps1:33:6:33:8 | x [element] | semmle.label | x [element] |
+| test.ps1:33:6:33:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:34:6:34:8 | x [element] | semmle.label | x [element] |
+| test.ps1:34:6:34:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:38:9:38:19 | Source | semmle.label | Source |
+| test.ps1:42:6:42:22 | callSourceInLoop [element] | semmle.label | callSourceInLoop [element] |
+| test.ps1:43:6:43:8 | x [element] | semmle.label | x [element] |
+| test.ps1:43:6:43:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:44:6:44:8 | x [element] | semmle.label | x [element] |
+| test.ps1:44:6:44:11 | ...[...] | semmle.label | ...[...] |
 subpaths
 testFailures
 #select
 | test.ps1:6:6:6:8 | x | test.ps1:2:5:2:15 | Source | test.ps1:6:6:6:8 | x | $@ | test.ps1:2:5:2:15 | Source | Source |
-| test.ps1:14:6:14:8 | x | test.ps1:9:5:9:15 | Source | test.ps1:14:6:14:8 | x | $@ | test.ps1:9:5:9:15 | Source | Source |
-| test.ps1:14:6:14:8 | x | test.ps1:10:5:10:15 | Source | test.ps1:14:6:14:8 | x | $@ | test.ps1:10:5:10:15 | Source | Source |
-| test.ps1:21:6:21:8 | x | test.ps1:17:12:17:22 | Source | test.ps1:21:6:21:8 | x | $@ | test.ps1:17:12:17:22 | Source | Source |
-| test.ps1:31:6:31:8 | x | test.ps1:24:10:24:20 | Source | test.ps1:31:6:31:8 | x | $@ | test.ps1:24:10:24:20 | Source | Source |
-| test.ps1:31:6:31:8 | x | test.ps1:26:10:26:20 | Source | test.ps1:31:6:31:8 | x | $@ | test.ps1:26:10:26:20 | Source | Source |
+| test.ps1:15:6:15:11 | ...[...] | test.ps1:9:5:9:15 | Source | test.ps1:15:6:15:11 | ...[...] | $@ | test.ps1:9:5:9:15 | Source | Source |
+| test.ps1:15:6:15:11 | ...[...] | test.ps1:10:5:10:15 | Source | test.ps1:15:6:15:11 | ...[...] | $@ | test.ps1:10:5:10:15 | Source | Source |
+| test.ps1:16:6:16:11 | ...[...] | test.ps1:9:5:9:15 | Source | test.ps1:16:6:16:11 | ...[...] | $@ | test.ps1:9:5:9:15 | Source | Source |
+| test.ps1:16:6:16:11 | ...[...] | test.ps1:10:5:10:15 | Source | test.ps1:16:6:16:11 | ...[...] | $@ | test.ps1:10:5:10:15 | Source | Source |
+| test.ps1:23:6:23:8 | x | test.ps1:19:12:19:22 | Source | test.ps1:23:6:23:8 | x | $@ | test.ps1:19:12:19:22 | Source | Source |
+| test.ps1:33:6:33:11 | ...[...] | test.ps1:26:10:26:20 | Source | test.ps1:33:6:33:11 | ...[...] | $@ | test.ps1:26:10:26:20 | Source | Source |
+| test.ps1:33:6:33:11 | ...[...] | test.ps1:28:10:28:20 | Source | test.ps1:33:6:33:11 | ...[...] | $@ | test.ps1:28:10:28:20 | Source | Source |
+| test.ps1:34:6:34:11 | ...[...] | test.ps1:26:10:26:20 | Source | test.ps1:34:6:34:11 | ...[...] | $@ | test.ps1:26:10:26:20 | Source | Source |
+| test.ps1:34:6:34:11 | ...[...] | test.ps1:28:10:28:20 | Source | test.ps1:34:6:34:11 | ...[...] | $@ | test.ps1:28:10:28:20 | Source | Source |
+| test.ps1:43:6:43:11 | ...[...] | test.ps1:38:9:38:19 | Source | test.ps1:43:6:43:11 | ...[...] | $@ | test.ps1:38:9:38:19 | Source | Source |
+| test.ps1:44:6:44:11 | ...[...] | test.ps1:38:9:38:19 | Source | test.ps1:44:6:44:11 | ...[...] | $@ | test.ps1:38:9:38:19 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/returns/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.expected
@@ -1,48 +1,32 @@
 models
 edges
-| test.ps1:1:25:3:2 | return value for {...} | test.ps1:5:6:5:20 | callSourceOnce | provenance |  |
-| test.ps1:2:5:2:15 | Source | test.ps1:2:5:2:15 | implicit unwrapping of Source | provenance |  |
-| test.ps1:2:5:2:15 | implicit unwrapping of Source | test.ps1:1:25:3:2 | return value for {...} | provenance |  |
+| test.ps1:2:5:2:15 | Source | test.ps1:5:6:5:20 | callSourceOnce | provenance |  |
 | test.ps1:5:6:5:20 | callSourceOnce | test.ps1:6:6:6:8 | x | provenance |  |
-| test.ps1:8:26:11:2 | return value for {...} | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
-| test.ps1:9:5:9:15 | Source | test.ps1:9:5:9:15 | implicit unwrapping of Source | provenance |  |
-| test.ps1:9:5:9:15 | implicit unwrapping of Source | test.ps1:8:26:11:2 | return value for {...} | provenance |  |
-| test.ps1:10:5:10:15 | Source | test.ps1:10:5:10:15 | implicit unwrapping of Source | provenance |  |
-| test.ps1:10:5:10:15 | implicit unwrapping of Source | test.ps1:8:26:11:2 | return value for {...} | provenance |  |
+| test.ps1:9:5:9:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
+| test.ps1:10:5:10:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
 | test.ps1:13:6:13:21 | callSourceTwice | test.ps1:14:6:14:8 | x | provenance |  |
-| test.ps1:16:24:18:2 | return value for {...} | test.ps1:20:6:20:19 | returnSource1 | provenance |  |
-| test.ps1:17:12:17:22 | Source | test.ps1:17:12:17:22 | implicit unwrapping of Source | provenance |  |
-| test.ps1:17:12:17:22 | implicit unwrapping of Source | test.ps1:16:24:18:2 | return value for {...} | provenance |  |
+| test.ps1:17:12:17:22 | Source | test.ps1:20:6:20:19 | returnSource1 | provenance |  |
 | test.ps1:20:6:20:19 | returnSource1 | test.ps1:21:6:21:8 | x | provenance |  |
-| test.ps1:23:24:28:2 | return value for {...} | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
-| test.ps1:24:10:24:20 | Source | test.ps1:25:5:25:7 | implicit unwrapping of x | provenance |  |
-| test.ps1:25:5:25:7 | implicit unwrapping of x | test.ps1:23:24:28:2 | return value for {...} | provenance |  |
-| test.ps1:26:10:26:20 | Source | test.ps1:27:12:27:14 | implicit unwrapping of y | provenance |  |
-| test.ps1:27:12:27:14 | implicit unwrapping of y | test.ps1:23:24:28:2 | return value for {...} | provenance |  |
+| test.ps1:24:10:24:20 | Source | test.ps1:25:5:25:7 | x | provenance |  |
+| test.ps1:25:5:25:7 | x | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
+| test.ps1:26:10:26:20 | Source | test.ps1:27:12:27:14 | y | provenance |  |
+| test.ps1:27:12:27:14 | y | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
 | test.ps1:30:6:30:19 | returnSource2 | test.ps1:31:6:31:8 | x | provenance |  |
 nodes
-| test.ps1:1:25:3:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:2:5:2:15 | Source | semmle.label | Source |
-| test.ps1:2:5:2:15 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:5:6:5:20 | callSourceOnce | semmle.label | callSourceOnce |
 | test.ps1:6:6:6:8 | x | semmle.label | x |
-| test.ps1:8:26:11:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:9:5:9:15 | Source | semmle.label | Source |
-| test.ps1:9:5:9:15 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:10:5:10:15 | Source | semmle.label | Source |
-| test.ps1:10:5:10:15 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:13:6:13:21 | callSourceTwice | semmle.label | callSourceTwice |
 | test.ps1:14:6:14:8 | x | semmle.label | x |
-| test.ps1:16:24:18:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:17:12:17:22 | Source | semmle.label | Source |
-| test.ps1:17:12:17:22 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:20:6:20:19 | returnSource1 | semmle.label | returnSource1 |
 | test.ps1:21:6:21:8 | x | semmle.label | x |
-| test.ps1:23:24:28:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:24:10:24:20 | Source | semmle.label | Source |
-| test.ps1:25:5:25:7 | implicit unwrapping of x | semmle.label | implicit unwrapping of x |
+| test.ps1:25:5:25:7 | x | semmle.label | x |
 | test.ps1:26:10:26:20 | Source | semmle.label | Source |
-| test.ps1:27:12:27:14 | implicit unwrapping of y | semmle.label | implicit unwrapping of y |
+| test.ps1:27:12:27:14 | y | semmle.label | y |
 | test.ps1:30:6:30:19 | returnSource2 | semmle.label | returnSource2 |
 | test.ps1:31:6:31:8 | x | semmle.label | x |
 subpaths

--- a/powershell/ql/test/library-tests/dataflow/returns/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.expected
@@ -1,32 +1,48 @@
 models
 edges
-| test.ps1:2:5:2:15 | Source | test.ps1:5:6:5:20 | callSourceOnce | provenance |  |
+| test.ps1:1:25:3:2 | return value for {...} | test.ps1:5:6:5:20 | callSourceOnce | provenance |  |
+| test.ps1:2:5:2:15 | Source | test.ps1:2:5:2:15 | implicit unwrapping of Source | provenance |  |
+| test.ps1:2:5:2:15 | implicit unwrapping of Source | test.ps1:1:25:3:2 | return value for {...} | provenance |  |
 | test.ps1:5:6:5:20 | callSourceOnce | test.ps1:6:6:6:8 | x | provenance |  |
-| test.ps1:9:5:9:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
-| test.ps1:10:5:10:15 | Source | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
+| test.ps1:8:26:11:2 | return value for {...} | test.ps1:13:6:13:21 | callSourceTwice | provenance |  |
+| test.ps1:9:5:9:15 | Source | test.ps1:9:5:9:15 | implicit unwrapping of Source | provenance |  |
+| test.ps1:9:5:9:15 | implicit unwrapping of Source | test.ps1:8:26:11:2 | return value for {...} | provenance |  |
+| test.ps1:10:5:10:15 | Source | test.ps1:10:5:10:15 | implicit unwrapping of Source | provenance |  |
+| test.ps1:10:5:10:15 | implicit unwrapping of Source | test.ps1:8:26:11:2 | return value for {...} | provenance |  |
 | test.ps1:13:6:13:21 | callSourceTwice | test.ps1:14:6:14:8 | x | provenance |  |
-| test.ps1:17:12:17:22 | Source | test.ps1:20:6:20:19 | returnSource1 | provenance |  |
+| test.ps1:16:24:18:2 | return value for {...} | test.ps1:20:6:20:19 | returnSource1 | provenance |  |
+| test.ps1:17:12:17:22 | Source | test.ps1:17:12:17:22 | implicit unwrapping of Source | provenance |  |
+| test.ps1:17:12:17:22 | implicit unwrapping of Source | test.ps1:16:24:18:2 | return value for {...} | provenance |  |
 | test.ps1:20:6:20:19 | returnSource1 | test.ps1:21:6:21:8 | x | provenance |  |
-| test.ps1:24:10:24:20 | Source | test.ps1:25:5:25:7 | x | provenance |  |
-| test.ps1:25:5:25:7 | x | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
-| test.ps1:26:10:26:20 | Source | test.ps1:27:12:27:14 | y | provenance |  |
-| test.ps1:27:12:27:14 | y | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
+| test.ps1:23:24:28:2 | return value for {...} | test.ps1:30:6:30:19 | returnSource2 | provenance |  |
+| test.ps1:24:10:24:20 | Source | test.ps1:25:5:25:7 | implicit unwrapping of x | provenance |  |
+| test.ps1:25:5:25:7 | implicit unwrapping of x | test.ps1:23:24:28:2 | return value for {...} | provenance |  |
+| test.ps1:26:10:26:20 | Source | test.ps1:27:12:27:14 | implicit unwrapping of y | provenance |  |
+| test.ps1:27:12:27:14 | implicit unwrapping of y | test.ps1:23:24:28:2 | return value for {...} | provenance |  |
 | test.ps1:30:6:30:19 | returnSource2 | test.ps1:31:6:31:8 | x | provenance |  |
 nodes
+| test.ps1:1:25:3:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:2:5:2:15 | Source | semmle.label | Source |
+| test.ps1:2:5:2:15 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:5:6:5:20 | callSourceOnce | semmle.label | callSourceOnce |
 | test.ps1:6:6:6:8 | x | semmle.label | x |
+| test.ps1:8:26:11:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:9:5:9:15 | Source | semmle.label | Source |
+| test.ps1:9:5:9:15 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:10:5:10:15 | Source | semmle.label | Source |
+| test.ps1:10:5:10:15 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:13:6:13:21 | callSourceTwice | semmle.label | callSourceTwice |
 | test.ps1:14:6:14:8 | x | semmle.label | x |
+| test.ps1:16:24:18:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:17:12:17:22 | Source | semmle.label | Source |
+| test.ps1:17:12:17:22 | implicit unwrapping of Source | semmle.label | implicit unwrapping of Source |
 | test.ps1:20:6:20:19 | returnSource1 | semmle.label | returnSource1 |
 | test.ps1:21:6:21:8 | x | semmle.label | x |
+| test.ps1:23:24:28:2 | return value for {...} | semmle.label | return value for {...} |
 | test.ps1:24:10:24:20 | Source | semmle.label | Source |
-| test.ps1:25:5:25:7 | x | semmle.label | x |
+| test.ps1:25:5:25:7 | implicit unwrapping of x | semmle.label | implicit unwrapping of x |
 | test.ps1:26:10:26:20 | Source | semmle.label | Source |
-| test.ps1:27:12:27:14 | y | semmle.label | y |
+| test.ps1:27:12:27:14 | implicit unwrapping of y | semmle.label | implicit unwrapping of y |
 | test.ps1:30:6:30:19 | returnSource2 | semmle.label | returnSource2 |
 | test.ps1:31:6:31:8 | x | semmle.label | x |
 subpaths

--- a/powershell/ql/test/library-tests/dataflow/returns/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.ps1
@@ -11,7 +11,9 @@ function callSourceTwice {
 }
 
 $x = callSourceTwice
-Sink $x # $ hasValueFlow=2 hasValueFlow=3
+Sink $x # $ hasTaintFlow=2 hasTaintFlow=3
+Sink $x[0] # $ hasValueFlow=2 SPURIOUS: hasValueFlow=3
+Sink $x[1] # $ hasValueFlow=3 SPURIOUS: hasValueFlow=2
 
 function returnSource1 {
     return Source "4"
@@ -28,4 +30,15 @@ function returnSource2 {
 }
 
 $x = returnSource2
-Sink $x # $ hasValueFlow=5 hasValueFlow=6
+Sink $x[0] # $ hasValueFlow=5 SPURIOUS: hasValueFlow=6
+Sink $x[1] # $ hasValueFlow=6 SPURIOUS: hasValueFlow=5
+
+function callSourceInLoop {
+    for ($i = 0; $i -lt 2; $i++) {
+        Source "7"
+    }
+}
+
+$x = callSourceInLoop
+Sink $x[0] # $ hasValueFlow=7
+Sink $x[1] # $ hasValueFlow=7


### PR DESCRIPTION
This PR implements dataflow through Powershell pipelines. For example:
```powershell
function generate {
  Source "1"
  Source "2"
  Source "3"
}

function consume {
  Param([Parameter(ValueFromPipeline)] $x)

    process {
        Sink $x
    }
}

generate | consume
```

This ended up being a lot more complicated due to Powershell's rules for unwrapping of arrays when writing to a pipeline. For example, this function returns a pipeline with three elements: `1`, `2` and `3` and **not** a pipeline with two elements `1` and `[2, 3]` even though `1, 2` is an array:

```powershell
function f {
  1
  @(2, 3)
}

$x = f
```
In dataflow we usually model flow through arrays using `Content` flow (see [here](https://github.com/microsoft/codeql/pull/113) for my explanation of these). So the flow that arrives at `$x` should be a associated with an `ElementContent`.
To make matters even complicated, because we often track the precise index in which an array is tainted (i.e., `ElementContent[i]` means that the `i`'th element is tainted) we need to "forget" about this index when we return because the "returned array" is "flattened" from `[1, [2, 3]]` to `[1, 2, 3]`, and so any recording of the index when we were tracking `[2, 3]` is no longer correct as the elements has shifted by 1.

In its full glory, this means that in order to get flow from `Get-TaintedData` in something like:
```powershell
function f {
  $x = Get-TaintedData
  $pair = (2, $x)
  "Hello"
  $pair
}

$x = f
Sink $x[unknown]
```
the following needs to happen:
1. Flow from `Get-TaintedData` to `$x` in `(2, $x)`
2. A store step from `$x` to ` `(2, $x)`` that writes `ElementContent[1]`
3. Flow from `(2, $x)` to `$pair`
4. At this point we know that `$pair` is returned. We then need to adjust the `Content`. So we step from `$pair` to a "pre-return node"
5. We then perform a `readStep` from the pre-return node that reads `ElementContent[1]` to another node. Let's call this new node an implicit wrapping node.
6. A store step from the implicit wrapping node to the _actual_ return node that writes `ElementContent` with an unknown index.

That's a lot of steps! I've diagrammed the complete process here:
```mermaid
flowchart TD
    Pair[$pair] --> PreReturnFalse["PreReturn(false)"]
    Pair --> PreReturnTrue["PreReturn(true)"]
    Pair -->|unique return| ReturnNode
    PreReturnTrue -->|"readStep(known)"| ImplicitWrapTrue["ImplicitWrap(true)"]
    ImplicitWrapTrue -->|"storeStep(any)"| ReturnNode["return node"]
    PreReturnTrue --> ImplicitWrapFalse["ImplicitWrap(false)"]
    ImplicitWrapFalse --> ReturnNode
    PreReturnFalse -->|"storeStep(any)"| ReturnNode
```

The Boolean on `ImplicitWrapTrue` dictates whether a `storeStep` needs to be performed (i.e., whether it's already a node with an `ElelemtContent` with no specific index). The Boolean on `PreReturn` dictates whether the data being returned is an array or not (which, subsequently, determines whether we need to perform a `storeStep` to write an `ElementContent` or not).

In the implementation there are various places in the diagram where we check whether we are currently storing the correct `Content`. See `expectsContent` and `clearsContent` for these details.

All of the above means that _all_ functions will return their nodes with an `ElementContent`. However, not all functions return multiple values. When we can statically determine that only a single value is returned we skip all of the above logic and simply step from the returned expression to the return node. This is also reflected in the above diagram.