### PR TITLE
PS: Flow through arrays

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ArrayExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ArrayExpression.qll
@@ -5,5 +5,22 @@ class ArrayExpr extends @array_expression, Expr {
 
   StmtBlock getStmtBlock() { array_expression(this, result) }
 
+  /**
+   * Gets the i'th element of this `ArrayExpr`, if this can be determined statically.
+   *
+   * See `getStmtBlock` when the array elements are not known statically.
+   */
+  Expr getElement(int i) {
+    result =
+      unique( | | this.getStmtBlock().getAStmt()).(CmdExpr).getExpr().(ArrayLiteral).getElement(i)
+  }
+
+  /**
+   * Gets an element of this `ArrayExpr`, if this can be determined statically.
+   *
+   * See `getStmtBlock` when the array elements are not known statically.
+   */
+  Expr getAnElement() { result = this.getElement(_) }
+
   override string toString() { result = "@(...)" }
 }

--- a/powershell/ql/lib/semmle/code/powershell/StatementBlock.qll
+++ b/powershell/ql/lib/semmle/code/powershell/StatementBlock.qll
@@ -1,4 +1,12 @@
 import powershell
+private import semmle.code.powershell.internal.AstEscape::Private
+
+private module ReturnContainerInterpreter implements InterpretAstInputSig {
+  class T = Ast;
+
+  pragma[inline]
+  T interpret(Ast a) { result = a }
+}
 
 class StmtBlock extends @statement_block, Ast {
   override SourceLocation getLocation() { statement_block_location(this, result) }
@@ -16,4 +24,9 @@ class StmtBlock extends @statement_block, Ast {
   TrapStmt getATrapStmt() { result = this.getTrapStmt(_) }
 
   override string toString() { result = "{...}" }
+
+  /** Gets an element that may escape this `StmtBlock`. */
+  Ast getAnElement() {
+    result = this.(AstEscape<ReturnContainerInterpreter>::Element).getAnEscapingElement()
+  }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -201,6 +201,25 @@ class ProcessBlockCfgNode extends NamedBlockCfgNode {
   PipelineParameter getPipelineParameter() { result = block.getEnclosingFunction().getAParameter() }
 }
 
+private class StmtBlockChildMapping extends NonExprChildMapping, StmtBlock {
+  override predicate relevantChild(Ast n) { n = this.getAStmt() or n = this.getAnElement() }
+}
+
+class StmtBlockCfgNode extends AstCfgNode {
+  StmtBlockChildMapping block;
+
+  StmtBlockCfgNode() { this.getAstNode() = block }
+
+  StmtBlock getBlock() { result = block }
+
+  StmtCfgNode getStmt(int i) { block.hasCfgChild(block.getStmt(i), this, result) }
+
+  StmtCfgNode getAStmt() { block.hasCfgChild(block.getAStmt(), this, result) }
+
+  /** Gets an AST element that may be returned from this `StmtBlockCfgNode`. */
+  AstCfgNode getAnElement() { block.hasCfgChild(block.getAnElement(), this, result) }
+}
+
 /** Provides classes for control-flow nodes that wrap AST expressions. */
 module ExprNodes {
   private class VarAccessChildMapping extends ExprChildMapping, VarAccess {
@@ -417,6 +436,22 @@ module ExprNodes {
   /** A control-flow node that wraps a `MemberExpr` expression that is being read from. */
   class IndexCfgReadNode extends IndexCfgNode {
     IndexCfgReadNode() { this.getExpr() instanceof IndexExprRead }
+  }
+
+  class ArrayExprChildMapping extends ExprChildMapping, ArrayExpr {
+    override predicate relevantChild(Ast n) { n = this.getStmtBlock() or n = this.getAnElement() }
+  }
+
+  class ArrayExprCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "ArrayExprCfgNode" }
+
+    override ArrayExprChildMapping e;
+
+    ExprCfgNode getElement(int i) { e.hasCfgChild(e.getElement(i), this, result) }
+
+    ExprCfgNode getAnElement() { result = this.getElement(_) }
+
+    StmtBlockCfgNode getStmtBlock() { e.hasCfgChild(e.getStmtBlock(), this, result) }
   }
 }
 

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -102,6 +102,15 @@ module LocalFlow {
     or
     nodeFrom.asExpr() = nodeTo.asStmt().(CfgNodes::StmtNodes::CmdExprCfgNode).getExpr()
     or
+    exists(
+      CfgNodes::ExprNodes::ArrayExprCfgNode arrayExpr, EscapeContainer::EscapeContainer container
+    |
+      nodeTo.asExpr() = arrayExpr and
+      container = arrayExpr.getStmtBlock().getAstNode() and
+      nodeFrom.(AstNode).getCfgNode() = container.getAnEscapingElement() and
+      not container.mayBeMultiReturned(_)
+    )
+    or
     nodeFrom.(AstNode).getCfgNode() = nodeTo.(PreReturNodeImpl).getReturnedNode()
     or
     exists(CfgNode cfgNode |
@@ -665,6 +674,15 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
     node2.asExpr().(CfgNodes::ExprNodes::ArrayLiteralCfgNode).getElement(index) = node1.asExpr() and
     c.isKnownOrUnknownElement(ec) and
     index = ec.getIndex().asInt()
+  )
+  or
+  exists(
+    CfgNodes::ExprNodes::ArrayExprCfgNode arrayExpr, EscapeContainer::EscapeContainer container
+  |
+    node2.asExpr() = arrayExpr and
+    container = arrayExpr.getStmtBlock().getAstNode() and
+    node1.(AstNode).getCfgNode() = container.getAnEscapingElement() and
+    container.mayBeMultiReturned(_)
   )
   or
   c.isAnyElement() and

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -550,91 +550,36 @@ abstract class ReturnNode extends Node {
   abstract ReturnKind getKind();
 }
 
-private module ReturnNodes {
-  /** An AST element that may produce return values when evaluated. */
-  abstract private class ReturnContainer extends Ast {
-    /**
-     * Gets a direct node that will may be returned when evaluating this node.
-     */
-    CfgNode getANode() { none() }
+private module EscapeContainer {
+  private import semmle.code.powershell.internal.AstEscape::Private
 
-    /** Gets a child that may produce more nodes that may be returned. */
-    abstract ReturnContainer getAChild();
+  private module ReturnContainerInterpreter implements InterpretAstInputSig {
+    class T = CfgNodes::AstCfgNode;
 
-    /**
-     * Gets a (possibly transitive) node that may be returned when evaluating
-     * this node.
-     */
-    final CfgNode getAReturnedNode() {
-      result = this.getANode()
+    T interpret(Ast a) {
+      result.(CfgNodes::ExprCfgNode).getExpr() = a
       or
-      result = this.getAChild().getAReturnedNode()
+      result.(CfgNodes::StmtCfgNode).getStmt() = a.(Cmd)
     }
+  }
 
+  class EscapeContainer extends AstEscape<ReturnContainerInterpreter>::Element {
     /** Holds if `n` may be returned multiples times. */
     predicate mayBeMultiReturned(CfgNode n) {
       n = this.getANode() and
       n.getASuccessor+() = n
       or
-      this.getAChild().mayBeMultiReturned(n)
+      this.getAChild().(EscapeContainer).mayBeMultiReturned(n)
     }
   }
+}
 
-  class ScriptBlockReturnContainer extends ReturnContainer, ScriptBlock {
-    final override ReturnContainer getAChild() { result = this.getEndBlock() }
-  }
+private module ReturnNodes {
+  private import EscapeContainer
 
-  class NamedBlockReturnContainer extends ReturnContainer, NamedBlock {
-    final override ReturnContainer getAChild() { result = this.getAStmt() }
-  }
-
-  class CmdExprReturnContainer extends ReturnContainer, CmdExpr {
-    final override CfgNodes::ExprCfgNode getANode() { result.getExpr() = this.getExpr() }
-
-    final override ReturnContainer getAChild() { none() }
-  }
-
-  class LoopStmtReturnContainer extends ReturnContainer, LoopStmt {
-    final override ReturnContainer getAChild() { result = this.getBody() }
-  }
-
-  class StmtBlockReturnConainer extends ReturnContainer, StmtBlock {
-    final override ReturnContainer getAChild() { result = this.getAStmt() }
-  }
-
-  class TryStmtReturnContainer extends ReturnContainer, TryStmt {
-    final override ReturnContainer getAChild() {
-      result = this.getBody() or result = this.getACatchClause() or result = this.getFinally()
-    }
-  }
-
-  class ReturnStmtReturnContainer extends ReturnContainer, ReturnStmt {
-    final override ReturnContainer getAChild() { result = this.getPipeline() }
-  }
-
-  class CatchClausReturnContainer extends ReturnContainer, CatchClause {
-    final override ReturnContainer getAChild() { result = this.getBody() }
-  }
-
-  class SwitchStmtReturnContainer extends ReturnContainer, SwitchStmt {
-    final override ReturnContainer getAChild() { result = this.getACase() }
-  }
-
-  class CmdBaseReturnContainer extends ReturnContainer, CmdExpr {
-    final override CfgNodes::ExprCfgNode getANode() { result.getExpr() = this.getExpr() }
-
-    final override ReturnContainer getAChild() { none() }
-  }
-
-  class CmdReturnContainer extends ReturnContainer, Cmd {
-    final override CfgNodes::StmtCfgNode getANode() { result.getStmt() = this }
-
-    final override ReturnContainer getAChild() { none() }
-  }
-
-  private predicate isReturnedImpl(CfgNodes::AstCfgNode n, ReturnContainer container) {
+  private predicate isReturnedImpl(CfgNodes::AstCfgNode n, EscapeContainer container) {
     container = n.getScope() and
-    n = container.getAReturnedNode()
+    n = container.getAnEscapingElement()
   }
 
   /**
@@ -642,8 +587,8 @@ private module ReturnNodes {
    * more than one return value from the function.
    */
   predicate isMultiReturned(CfgNodes::AstCfgNode n) {
-    exists(ReturnContainer container | isReturnedImpl(n, container) |
-      strictcount(container.getAReturnedNode()) > 1
+    exists(EscapeContainer container | isReturnedImpl(n, container) |
+      strictcount(container.getAnEscapingElement()) > 1
       or
       container.mayBeMultiReturned(n)
     )

--- a/powershell/ql/lib/semmle/code/powershell/internal/AstEscape.qll
+++ b/powershell/ql/lib/semmle/code/powershell/internal/AstEscape.qll
@@ -1,0 +1,96 @@
+private import powershell as PS
+
+/**
+ * TODO: This whole computation cab be sped up by providing a set of "root"s and doing
+ * a forward/backwards traversal first.
+ */
+module Private {
+  signature module InterpretAstInputSig {
+    /** The type on which to translate `Ast` elements during escape calculations */
+    class T;
+
+    /** Interpret `a` into a `T` */
+    T interpret(PS::Ast a);
+  }
+
+  module AstEscape<InterpretAstInputSig Interpret> {
+    private import Interpret
+
+    /** An AST element that may produce a value which can escape from this `Ast` when evaluated. */
+    abstract private class ElementImpl instanceof PS::Ast {
+      string toString() { result = super.toString() }
+
+      /** Gets a direct node that will may escape when evaluating this element. */
+      T getANode() { none() }
+
+      /** Gets a child that may produce more elements that may escape. */
+      abstract Element getAChild();
+
+      /**
+       * Gets a (possibly transitive) element that may escape when evaluating
+       * this element.
+       */
+      final T getAnEscapingElement() {
+        result = this.getANode()
+        or
+        result = this.getAChild().getAnEscapingElement()
+      }
+    }
+
+    final class Element = ElementImpl;
+
+    private class ScriptBlockElement extends ElementImpl instanceof PS::ScriptBlock {
+      final override Element getAChild() { result = super.getEndBlock() }
+    }
+
+    private class NamedBlockElement extends ElementImpl instanceof PS::NamedBlock {
+      final override Element getAChild() { result = super.getAStmt() }
+    }
+
+    private class CmdExprElement extends ElementImpl instanceof PS::CmdExpr {
+      final override T getANode() { result = interpret(super.getExpr()) }
+
+      final override Element getAChild() { none() }
+    }
+
+    private class LoopStmtElement extends ElementImpl instanceof PS::LoopStmt {
+      final override Element getAChild() { result = super.getBody() }
+    }
+
+    private class StmtBlockElement extends ElementImpl instanceof PS::StmtBlock {
+      final override Element getAChild() { result = super.getAStmt() }
+    }
+
+    private class TryStmtElement extends ElementImpl instanceof PS::TryStmt {
+      final override Element getAChild() {
+        result = super.getBody() or result = super.getACatchClause() or result = super.getFinally()
+      }
+    }
+
+    private class ReturnStmtElement extends ElementImpl instanceof PS::ReturnStmt {
+      final override Element getAChild() { result = super.getPipeline() }
+    }
+
+    private class CatchClausElement extends ElementImpl instanceof PS::CatchClause {
+      final override Element getAChild() { result = super.getBody() }
+    }
+
+    private class SwitchStmtElement extends ElementImpl instanceof PS::SwitchStmt {
+      final override Element getAChild() { result = super.getACase() }
+    }
+
+    private class CmdBaseElement extends ElementImpl instanceof PS::CmdExpr {
+      final override T getANode() { result = interpret(super.getExpr()) }
+
+      final override Element getAChild() { none() }
+    }
+
+    private class CmdElement extends ElementImpl instanceof PS::Cmd {
+      final override T getANode() { result = interpret(this) }
+
+      final override Element getAChild() { none() }
+    }
+  }
+}
+
+module Public { }

--- a/powershell/ql/test/library-tests/dataflow/fields/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.expected
@@ -39,6 +39,12 @@ edges
 | test.ps1:35:15:35:17 | x | test.ps1:35:9:35:17 | ...,... [element 2] | provenance |  |
 | test.ps1:38:6:38:11 | arr8 [element 2] | test.ps1:38:6:38:14 | ...[...] | provenance |  |
 | test.ps1:39:6:39:11 | arr8 [element 2] | test.ps1:39:6:39:21 | ...[...] | provenance |  |
+| test.ps1:41:6:41:17 | Source | test.ps1:43:17:43:19 | y | provenance |  |
+| test.ps1:43:11:43:19 | ...,... [element 2] | test.ps1:46:6:46:11 | arr9 [element 2] | provenance |  |
+| test.ps1:43:11:43:19 | ...,... [element 2] | test.ps1:47:6:47:11 | arr9 [element 2] | provenance |  |
+| test.ps1:43:17:43:19 | y | test.ps1:43:11:43:19 | ...,... [element 2] | provenance |  |
+| test.ps1:46:6:46:11 | arr9 [element 2] | test.ps1:46:6:46:14 | ...[...] | provenance |  |
+| test.ps1:47:6:47:11 | arr9 [element 2] | test.ps1:47:6:47:21 | ...[...] | provenance |  |
 | test.ps1:52:22:54:6 | this [field] | test.ps1:53:14:53:19 | this [field] | provenance |  |
 | test.ps1:53:14:53:19 | this [field] | test.ps1:53:14:53:25 | field | provenance |  |
 | test.ps1:59:1:59:9 | [post] myClass [field] | test.ps1:61:1:61:9 | myClass [field] | provenance |  |
@@ -107,6 +113,13 @@ nodes
 | test.ps1:38:6:38:14 | ...[...] | semmle.label | ...[...] |
 | test.ps1:39:6:39:11 | arr8 [element 2] | semmle.label | arr8 [element 2] |
 | test.ps1:39:6:39:21 | ...[...] | semmle.label | ...[...] |
+| test.ps1:41:6:41:17 | Source | semmle.label | Source |
+| test.ps1:43:11:43:19 | ...,... [element 2] | semmle.label | ...,... [element 2] |
+| test.ps1:43:17:43:19 | y | semmle.label | y |
+| test.ps1:46:6:46:11 | arr9 [element 2] | semmle.label | arr9 [element 2] |
+| test.ps1:46:6:46:14 | ...[...] | semmle.label | ...[...] |
+| test.ps1:47:6:47:11 | arr9 [element 2] | semmle.label | arr9 [element 2] |
+| test.ps1:47:6:47:21 | ...[...] | semmle.label | ...[...] |
 | test.ps1:52:22:54:6 | this [field] | semmle.label | this [field] |
 | test.ps1:53:14:53:19 | this [field] | semmle.label | this [field] |
 | test.ps1:53:14:53:25 | field | semmle.label | field |
@@ -142,6 +155,8 @@ testFailures
 | test.ps1:31:6:31:33 | ...[...] | test.ps1:29:31:29:41 | Source | test.ps1:31:6:31:33 | ...[...] | $@ | test.ps1:29:31:29:41 | Source | Source |
 | test.ps1:38:6:38:14 | ...[...] | test.ps1:33:6:33:17 | Source | test.ps1:38:6:38:14 | ...[...] | $@ | test.ps1:33:6:33:17 | Source | Source |
 | test.ps1:39:6:39:21 | ...[...] | test.ps1:33:6:33:17 | Source | test.ps1:39:6:39:21 | ...[...] | $@ | test.ps1:33:6:33:17 | Source | Source |
+| test.ps1:46:6:46:14 | ...[...] | test.ps1:41:6:41:17 | Source | test.ps1:46:6:46:14 | ...[...] | $@ | test.ps1:41:6:41:17 | Source | Source |
+| test.ps1:47:6:47:21 | ...[...] | test.ps1:41:6:41:17 | Source | test.ps1:47:6:47:21 | ...[...] | $@ | test.ps1:41:6:41:17 | Source | Source |
 | test.ps1:53:14:53:25 | field | test.ps1:59:18:59:29 | Source | test.ps1:53:14:53:25 | field | $@ | test.ps1:59:18:59:29 | Source | Source |
 | test.ps1:72:6:72:11 | ...[...] | test.ps1:64:10:64:21 | Source | test.ps1:72:6:72:11 | ...[...] | $@ | test.ps1:64:10:64:21 | Source | Source |
 | test.ps1:72:6:72:11 | ...[...] | test.ps1:65:10:65:21 | Source | test.ps1:72:6:72:11 | ...[...] | $@ | test.ps1:65:10:65:21 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/fields/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.ps1
@@ -43,8 +43,8 @@ $y = Source "11"
 $arr9 = @(0, 1, $y)
 Sink $arr9[0] # clean
 Sink $arr9[1] # clean
-Sink $arr9[2] # $ MISSING: hasValueFlow=11
-Sink $arr9[$unknown] # MISSING: hasValueFlow=11
+Sink $arr9[2] # $ hasValueFlow=11
+Sink $arr9[$unknown] # $ hasValueFlow=11
 
 class MyClass {
     [string] $field


### PR DESCRIPTION
This PR adds flow through array expressions. That is, flow from `1` and `2` to this piece of syntax: `@(1, 2)`.

This is slightly harder than it looks because there can be an arbitrary set of statements inside `...` in `@(...)`. Luckily, we already have a way of computing which expressions are being returned from a list of statements. So this PR generalized that into a small parameterized module (internal for now) and reuses the logic to compute which expressions can end up in `@(...)`.

If it's clear which expressions this is, and in which order, we use an `ElementContent` with a specific index, and otherwise we use an `ElementContent` with an unknown index (see [here](https://github.com/microsoft/codeql/pull/113) for the terminology).