### PR TITLE
PS: Flow through hash table creation, reads, and writes

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/BaseConstantExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/BaseConstantExpression.qll
@@ -1,3 +1,13 @@
 import powershell
 
-class BaseConstExpr extends @base_constant_expression, Expr { }
+/** The base class for constant expressions. */
+class BaseConstExpr extends @base_constant_expression, Expr {
+  /** Gets the type of this constant expression. */
+  string getType() { none() }
+
+  /** Gets a string literal of this constant expression. */
+  StringLiteral getValue() { none() }
+
+  /** Gets a string literal representing this constant expression. */
+  final override string toString() { result = this.getValue().toString() }
+}

--- a/powershell/ql/lib/semmle/code/powershell/ConstantExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ConstantExpression.qll
@@ -3,11 +3,9 @@ import powershell
 class ConstExpr extends @constant_expression, BaseConstExpr {
   override SourceLocation getLocation() { constant_expression_location(this, result) }
 
-  string getType() { constant_expression(this, result) }
+  override string getType() { constant_expression(this, result) }
 
-  StringLiteral getValue() { constant_expression_value(this, result) }
-
-  override string toString() { result = this.getValue().toString() }
+  override StringLiteral getValue() { constant_expression_value(this, result) }
 }
 
 private newtype TConstantValue =
@@ -97,7 +95,7 @@ class ConstString extends ConstantValue, TConstString {
     result = "\"" + this.asString().replaceAll("\"", "\\\"") + "\""
   }
 
-  final override ConstExpr getAnExpr() { result.getValue().getValue() = this.getValue() }
+  final override BaseConstExpr getAnExpr() { result.getValue().getValue() = this.getValue() }
 }
 
 /** A constant boolean value. */

--- a/powershell/ql/lib/semmle/code/powershell/HashTable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/HashTable.qll
@@ -5,11 +5,11 @@ class HashTableExpr extends @hash_table, Expr {
 
   final override string toString() { result = "${...}" }
 
-  Stmt getExprWithKey(Expr key) { hash_table_key_value_pairs(this, _, key, result) } // TODO: Change @ast to @expr in db scheme
+  Stmt getElement(Expr key) { hash_table_key_value_pairs(this, _, key, result) } // TODO: Change @ast to @expr in db scheme
 
-  predicate hasKey(Expr key) { exists(this.getExprWithKey(key)) }
+  predicate hasKey(Expr key) { exists(this.getElement(key)) }
 
-  Stmt getAnExpr() { result = this.getExprWithKey(_) }
+  Stmt getAnElement() { result = this.getElement(_) }
 
   predicate hasEntry(int index, Expr key, Stmt value) {
     hash_table_key_value_pairs(this, index, key, value)

--- a/powershell/ql/lib/semmle/code/powershell/StringConstantExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/StringConstantExpression.qll
@@ -1,10 +1,10 @@
 import powershell
 
+/** A string constant. */
 class StringConstExpr extends @string_constant_expression, BaseConstExpr {
-  StringLiteral getValue() { string_constant_expression(this, result) }
+  override StringLiteral getValue() { string_constant_expression(this, result) }
 
-  /** Get the full string literal with all its parts concatenated */
-  override string toString() { result = this.getValue().toString() }
+  override string getType() { result = "String" }
 
   override SourceLocation getLocation() { string_constant_expression_location(this, result) }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -453,6 +453,38 @@ module ExprNodes {
 
     StmtBlockCfgNode getStmtBlock() { e.hasCfgChild(e.getStmtBlock(), this, result) }
   }
+
+  class HashTableChildMapping extends ExprChildMapping, HashTableExpr {
+    override predicate relevantChild(Ast n) { this.hasEntry(_, _, n) or this.hasEntry(_, n, _) }
+  }
+
+  class HashTableCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "HashMapCfgNode" }
+
+    override HashTableChildMapping e;
+
+    override HashTableExpr getExpr() { result = super.getExpr() }
+
+    StmtCfgNode getElement(ExprCfgNode key) {
+      exists(Expr eKey |
+        eKey = key.getAstNode() and
+        e.hasCfgChild(eKey, this, key) and
+        e.hasCfgChild(e.getElement(eKey), this, result)
+      )
+    }
+
+    predicate hasKey(ExprCfgNode key) { exists(this.getElement(key)) }
+
+    StmtCfgNode getAnElement() { result = this.getElement(_) }
+
+    predicate hasEntry(int index, ExprCfgNode key, StmtCfgNode value) {
+      exists(Expr eKey, Stmt sValue |
+        e.hasCfgChild(eKey, this, key) and
+        e.hasCfgChild(sValue, this, value) and
+        e.hasEntry(index, eKey, sValue)
+      )
+    }
+  }
 }
 
 module StmtNodes {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -660,10 +660,9 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
     node1.asStmt() = var.getAssignStmt().getRightHandSide() and
     e = var.getIndex()
   |
-    exists(int index, Content::KnownElementContent ec |
+    exists(Content::KnownElementContent ec |
       c.isKnownOrUnknownElement(ec) and
-      index = ec.getIndex().asInt() and
-      index = e.getValue().asInt()
+      e.getValue() = ec.getIndex()
     )
     or
     not exists(e.getValue().asInt()) and
@@ -674,6 +673,18 @@ predicate storeStep(Node node1, ContentSet c, Node node2) {
     node2.asExpr().(CfgNodes::ExprNodes::ArrayLiteralCfgNode).getElement(index) = node1.asExpr() and
     c.isKnownOrUnknownElement(ec) and
     index = ec.getIndex().asInt()
+  )
+  or
+  exists(CfgNodes::ExprCfgNode key |
+    node2.asExpr().(CfgNodes::ExprNodes::HashTableCfgNode).getElement(key) = node1.asStmt()
+  |
+    exists(Content::KnownElementContent ec |
+      c.isKnownOrUnknownElement(ec) and
+      ec.getIndex() = key.getValue()
+    )
+    or
+    not exists(key.getValue()) and
+    c.isAnyElement()
   )
   or
   exists(
@@ -714,13 +725,12 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
     node1.asExpr() = var.getBase() and
     e = var.getIndex()
   |
-    exists(int index, Content::KnownElementContent ec |
+    exists(Content::KnownElementContent ec |
       c.isKnownOrUnknownElement(ec) and
-      index = ec.getIndex().asInt() and
-      index = e.getValue().asInt()
+      e.getValue() = ec.getIndex()
     )
     or
-    not exists(e.getValue().asInt()) and
+    not exists(e.getValue()) and
     c.isAnyElement()
   )
   or

--- a/powershell/ql/test/library-tests/dataflow/fields/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.expected
@@ -64,6 +64,9 @@ edges
 | test.ps1:72:6:72:8 | x [element] | test.ps1:72:6:72:11 | ...[...] | provenance |  |
 | test.ps1:73:6:73:8 | x [element] | test.ps1:73:6:73:11 | ...[...] | provenance |  |
 | test.ps1:74:6:74:8 | x [element] | test.ps1:74:6:74:11 | ...[...] | provenance |  |
+| test.ps1:86:1:86:6 | [post] hash [b] | test.ps1:87:6:87:11 | hash [b] | provenance |  |
+| test.ps1:86:11:86:22 | Source | test.ps1:86:1:86:6 | [post] hash [b] | provenance |  |
+| test.ps1:87:6:87:11 | hash [b] | test.ps1:87:6:87:13 | b | provenance |  |
 nodes
 | test.ps1:1:1:1:3 | [post] a [f] | semmle.label | [post] a [f] |
 | test.ps1:1:8:1:18 | Source | semmle.label | Source |
@@ -141,6 +144,10 @@ nodes
 | test.ps1:73:6:73:11 | ...[...] | semmle.label | ...[...] |
 | test.ps1:74:6:74:8 | x [element] | semmle.label | x [element] |
 | test.ps1:74:6:74:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:86:1:86:6 | [post] hash [b] | semmle.label | [post] hash [b] |
+| test.ps1:86:11:86:22 | Source | semmle.label | Source |
+| test.ps1:87:6:87:11 | hash [b] | semmle.label | hash [b] |
+| test.ps1:87:6:87:13 | b | semmle.label | b |
 subpaths
 testFailures
 #select
@@ -167,3 +174,4 @@ testFailures
 | test.ps1:74:6:74:11 | ...[...] | test.ps1:64:10:64:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:64:10:64:21 | Source | Source |
 | test.ps1:74:6:74:11 | ...[...] | test.ps1:65:10:65:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:65:10:65:21 | Source | Source |
 | test.ps1:74:6:74:11 | ...[...] | test.ps1:66:10:66:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:66:10:66:21 | Source | Source |
+| test.ps1:87:6:87:13 | b | test.ps1:86:11:86:22 | Source | test.ps1:87:6:87:13 | b | $@ | test.ps1:86:11:86:22 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/fields/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.expected
@@ -4,25 +4,39 @@ edges
 | test.ps1:1:8:1:18 | Source | test.ps1:1:1:1:3 | [post] a [f] | provenance |  |
 | test.ps1:2:6:2:8 | a [f] | test.ps1:2:6:2:10 | f | provenance |  |
 | test.ps1:8:1:8:6 | [post] arr1 [element 3] | test.ps1:9:6:9:11 | arr1 [element 3] | provenance |  |
+| test.ps1:8:1:8:6 | [post] arr1 [element 3] | test.ps1:9:6:9:11 | arr1 [element 3] | provenance |  |
 | test.ps1:8:12:8:22 | Source | test.ps1:8:1:8:6 | [post] arr1 [element 3] | provenance |  |
+| test.ps1:8:12:8:22 | Source | test.ps1:8:1:8:6 | [post] arr1 [element 3] | provenance |  |
+| test.ps1:9:6:9:11 | arr1 [element 3] | test.ps1:9:6:9:14 | ...[...] | provenance |  |
 | test.ps1:9:6:9:11 | arr1 [element 3] | test.ps1:9:6:9:14 | ...[...] | provenance |  |
 | test.ps1:12:1:12:6 | [post] arr2 [element] | test.ps1:13:6:13:11 | arr2 [element] | provenance |  |
 | test.ps1:12:19:12:29 | Source | test.ps1:12:1:12:6 | [post] arr2 [element] | provenance |  |
 | test.ps1:13:6:13:11 | arr2 [element] | test.ps1:13:6:13:14 | ...[...] | provenance |  |
 | test.ps1:15:1:15:6 | [post] arr3 [element 3] | test.ps1:16:6:16:11 | arr3 [element 3] | provenance |  |
+| test.ps1:15:1:15:6 | [post] arr3 [element 3] | test.ps1:16:6:16:11 | arr3 [element 3] | provenance |  |
 | test.ps1:15:12:15:22 | Source | test.ps1:15:1:15:6 | [post] arr3 [element 3] | provenance |  |
+| test.ps1:15:12:15:22 | Source | test.ps1:15:1:15:6 | [post] arr3 [element 3] | provenance |  |
+| test.ps1:16:6:16:11 | arr3 [element 3] | test.ps1:16:6:16:21 | ...[...] | provenance |  |
 | test.ps1:16:6:16:11 | arr3 [element 3] | test.ps1:16:6:16:21 | ...[...] | provenance |  |
 | test.ps1:18:1:18:6 | [post] arr4 [element] | test.ps1:19:6:19:11 | arr4 [element] | provenance |  |
 | test.ps1:18:20:18:30 | Source | test.ps1:18:1:18:6 | [post] arr4 [element] | provenance |  |
 | test.ps1:19:6:19:11 | arr4 [element] | test.ps1:19:6:19:22 | ...[...] | provenance |  |
 | test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | test.ps1:22:6:22:11 | arr5 [element, element 1] | provenance |  |
+| test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | test.ps1:22:6:22:11 | arr5 [element, element 1] | provenance |  |
+| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | provenance |  |
 | test.ps1:21:1:21:17 | [post] ...[...] [element 1] | test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | provenance |  |
 | test.ps1:21:23:21:33 | Source | test.ps1:21:1:21:17 | [post] ...[...] [element 1] | provenance |  |
+| test.ps1:21:23:21:33 | Source | test.ps1:21:1:21:17 | [post] ...[...] [element 1] | provenance |  |
+| test.ps1:22:6:22:11 | arr5 [element, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
 | test.ps1:22:6:22:11 | arr5 [element, element 1] | test.ps1:22:6:22:22 | ...[...] [element 1] | provenance |  |
 | test.ps1:22:6:22:22 | ...[...] [element 1] | test.ps1:22:6:22:25 | ...[...] | provenance |  |
+| test.ps1:22:6:22:22 | ...[...] [element 1] | test.ps1:22:6:22:25 | ...[...] | provenance |  |
+| test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | test.ps1:26:6:26:11 | arr6 [element 1, element] | provenance |  |
 | test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | test.ps1:26:6:26:11 | arr6 [element 1, element] | provenance |  |
 | test.ps1:25:1:25:9 | [post] ...[...] [element] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | provenance |  |
+| test.ps1:25:1:25:9 | [post] ...[...] [element] | test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | provenance |  |
 | test.ps1:25:23:25:33 | Source | test.ps1:25:1:25:9 | [post] ...[...] [element] | provenance |  |
+| test.ps1:26:6:26:11 | arr6 [element 1, element] | test.ps1:26:6:26:14 | ...[...] [element] | provenance |  |
 | test.ps1:26:6:26:11 | arr6 [element 1, element] | test.ps1:26:6:26:14 | ...[...] [element] | provenance |  |
 | test.ps1:26:6:26:14 | ...[...] [element] | test.ps1:26:6:26:25 | ...[...] | provenance |  |
 | test.ps1:29:1:29:6 | [post] arr7 [element, element] | test.ps1:30:6:30:11 | arr7 [element, element] | provenance |  |
@@ -64,6 +78,11 @@ edges
 | test.ps1:72:6:72:8 | x [element] | test.ps1:72:6:72:11 | ...[...] | provenance |  |
 | test.ps1:73:6:73:8 | x [element] | test.ps1:73:6:73:11 | ...[...] | provenance |  |
 | test.ps1:74:6:74:8 | x [element] | test.ps1:74:6:74:11 | ...[...] | provenance |  |
+| test.ps1:76:9:79:2 | ${...} [element a] | test.ps1:81:6:81:11 | hash [element a] | provenance |  |
+| test.ps1:76:9:79:2 | ${...} [element a] | test.ps1:85:6:85:11 | hash [element a] | provenance |  |
+| test.ps1:77:7:77:18 | Source | test.ps1:76:9:79:2 | ${...} [element a] | provenance |  |
+| test.ps1:81:6:81:11 | hash [element a] | test.ps1:81:6:81:16 | ...[...] | provenance |  |
+| test.ps1:85:6:85:11 | hash [element a] | test.ps1:85:6:85:16 | ...[...] | provenance |  |
 | test.ps1:86:1:86:6 | [post] hash [b] | test.ps1:87:6:87:11 | hash [b] | provenance |  |
 | test.ps1:86:11:86:22 | Source | test.ps1:86:1:86:6 | [post] hash [b] | provenance |  |
 | test.ps1:87:6:87:11 | hash [b] | test.ps1:87:6:87:13 | b | provenance |  |
@@ -73,7 +92,9 @@ nodes
 | test.ps1:2:6:2:8 | a [f] | semmle.label | a [f] |
 | test.ps1:2:6:2:10 | f | semmle.label | f |
 | test.ps1:8:1:8:6 | [post] arr1 [element 3] | semmle.label | [post] arr1 [element 3] |
+| test.ps1:8:1:8:6 | [post] arr1 [element 3] | semmle.label | [post] arr1 [element 3] |
 | test.ps1:8:12:8:22 | Source | semmle.label | Source |
+| test.ps1:9:6:9:11 | arr1 [element 3] | semmle.label | arr1 [element 3] |
 | test.ps1:9:6:9:11 | arr1 [element 3] | semmle.label | arr1 [element 3] |
 | test.ps1:9:6:9:14 | ...[...] | semmle.label | ...[...] |
 | test.ps1:12:1:12:6 | [post] arr2 [element] | semmle.label | [post] arr2 [element] |
@@ -81,7 +102,9 @@ nodes
 | test.ps1:13:6:13:11 | arr2 [element] | semmle.label | arr2 [element] |
 | test.ps1:13:6:13:14 | ...[...] | semmle.label | ...[...] |
 | test.ps1:15:1:15:6 | [post] arr3 [element 3] | semmle.label | [post] arr3 [element 3] |
+| test.ps1:15:1:15:6 | [post] arr3 [element 3] | semmle.label | [post] arr3 [element 3] |
 | test.ps1:15:12:15:22 | Source | semmle.label | Source |
+| test.ps1:16:6:16:11 | arr3 [element 3] | semmle.label | arr3 [element 3] |
 | test.ps1:16:6:16:11 | arr3 [element 3] | semmle.label | arr3 [element 3] |
 | test.ps1:16:6:16:21 | ...[...] | semmle.label | ...[...] |
 | test.ps1:18:1:18:6 | [post] arr4 [element] | semmle.label | [post] arr4 [element] |
@@ -89,14 +112,20 @@ nodes
 | test.ps1:19:6:19:11 | arr4 [element] | semmle.label | arr4 [element] |
 | test.ps1:19:6:19:22 | ...[...] | semmle.label | ...[...] |
 | test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | semmle.label | [post] arr5 [element, element 1] |
+| test.ps1:21:1:21:6 | [post] arr5 [element, element 1] | semmle.label | [post] arr5 [element, element 1] |
+| test.ps1:21:1:21:17 | [post] ...[...] [element 1] | semmle.label | [post] ...[...] [element 1] |
 | test.ps1:21:1:21:17 | [post] ...[...] [element 1] | semmle.label | [post] ...[...] [element 1] |
 | test.ps1:21:23:21:33 | Source | semmle.label | Source |
 | test.ps1:22:6:22:11 | arr5 [element, element 1] | semmle.label | arr5 [element, element 1] |
+| test.ps1:22:6:22:11 | arr5 [element, element 1] | semmle.label | arr5 [element, element 1] |
+| test.ps1:22:6:22:22 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | test.ps1:22:6:22:22 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | test.ps1:22:6:22:25 | ...[...] | semmle.label | ...[...] |
 | test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | semmle.label | [post] arr6 [element 1, element] |
+| test.ps1:25:1:25:6 | [post] arr6 [element 1, element] | semmle.label | [post] arr6 [element 1, element] |
 | test.ps1:25:1:25:9 | [post] ...[...] [element] | semmle.label | [post] ...[...] [element] |
 | test.ps1:25:23:25:33 | Source | semmle.label | Source |
+| test.ps1:26:6:26:11 | arr6 [element 1, element] | semmle.label | arr6 [element 1, element] |
 | test.ps1:26:6:26:11 | arr6 [element 1, element] | semmle.label | arr6 [element 1, element] |
 | test.ps1:26:6:26:14 | ...[...] [element] | semmle.label | ...[...] [element] |
 | test.ps1:26:6:26:25 | ...[...] | semmle.label | ...[...] |
@@ -144,6 +173,12 @@ nodes
 | test.ps1:73:6:73:11 | ...[...] | semmle.label | ...[...] |
 | test.ps1:74:6:74:8 | x [element] | semmle.label | x [element] |
 | test.ps1:74:6:74:11 | ...[...] | semmle.label | ...[...] |
+| test.ps1:76:9:79:2 | ${...} [element a] | semmle.label | ${...} [element a] |
+| test.ps1:77:7:77:18 | Source | semmle.label | Source |
+| test.ps1:81:6:81:11 | hash [element a] | semmle.label | hash [element a] |
+| test.ps1:81:6:81:16 | ...[...] | semmle.label | ...[...] |
+| test.ps1:85:6:85:11 | hash [element a] | semmle.label | hash [element a] |
+| test.ps1:85:6:85:16 | ...[...] | semmle.label | ...[...] |
 | test.ps1:86:1:86:6 | [post] hash [b] | semmle.label | [post] hash [b] |
 | test.ps1:86:11:86:22 | Source | semmle.label | Source |
 | test.ps1:87:6:87:11 | hash [b] | semmle.label | hash [b] |
@@ -174,4 +209,6 @@ testFailures
 | test.ps1:74:6:74:11 | ...[...] | test.ps1:64:10:64:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:64:10:64:21 | Source | Source |
 | test.ps1:74:6:74:11 | ...[...] | test.ps1:65:10:65:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:65:10:65:21 | Source | Source |
 | test.ps1:74:6:74:11 | ...[...] | test.ps1:66:10:66:21 | Source | test.ps1:74:6:74:11 | ...[...] | $@ | test.ps1:66:10:66:21 | Source | Source |
+| test.ps1:81:6:81:16 | ...[...] | test.ps1:77:7:77:18 | Source | test.ps1:81:6:81:16 | ...[...] | $@ | test.ps1:77:7:77:18 | Source | Source |
+| test.ps1:85:6:85:16 | ...[...] | test.ps1:77:7:77:18 | Source | test.ps1:85:6:85:16 | ...[...] | $@ | test.ps1:77:7:77:18 | Source | Source |
 | test.ps1:87:6:87:13 | b | test.ps1:86:11:86:22 | Source | test.ps1:87:6:87:13 | b | $@ | test.ps1:86:11:86:22 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/fields/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.ps1
@@ -72,3 +72,16 @@ $x = produce
 Sink $x[0] # $ hasValueFlow=13 hasValueFlow=14 hasValueFlow=15
 Sink $x[1] # $ hasValueFlow=13 hasValueFlow=14 hasValueFlow=15
 Sink $x[2] # $ hasValueFlow=13 hasValueFlow=14 hasValueFlow=15
+
+$hash = @{
+  a = Source "16"
+  b = 2
+}
+
+Sink $hash["a"] # $ MISSING: hasValueFlow=16
+Sink $hash["b"] # clean
+
+$hash["a"] = 0
+Sink $hash["a"] # clean
+$hash.b = Source "17"
+Sink $hash.b # $ hasValueFlow=17

--- a/powershell/ql/test/library-tests/dataflow/fields/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.ps1
@@ -78,10 +78,10 @@ $hash = @{
   b = 2
 }
 
-Sink $hash["a"] # $ MISSING: hasValueFlow=16
+Sink $hash["a"] # $ hasValueFlow=16
 Sink $hash["b"] # clean
 
 $hash["a"] = 0
-Sink $hash["a"] # clean
+Sink $hash["a"] # $ SPURIOUS: hasValueFlow=16
 $hash.b = Source "17"
 Sink $hash.b # $ hasValueFlow=17


### PR DESCRIPTION
This PR adds flow through hash tables. That is, in situations like:
```powershell
$hash = @{
  a = Get-TaintedData
  b = 42
}

Sink $hash["a"]
```

This will be necessary for some upcoming work on supporting flow through `ValueFromPipelineByPropertyName` parameters.