### PR TITLE
PS: Flow through conversions

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ConvertExpr.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ConvertExpr.qll
@@ -5,7 +5,7 @@ class ConvertExpr extends @convert_expression, Expr {
 
   override SourceLocation getLocation() { convert_expression_location(this, result) }
 
-  Expr getExpr() { convert_expression(this, _, result, _, _) }
+  Expr getBase() { convert_expression(this, _, result, _, _) }
 
   TypeConstraint getType() { convert_expression(this, _, _, result, _) }
 

--- a/powershell/ql/lib/semmle/code/powershell/ParenExpression.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ParenExpression.qll
@@ -1,7 +1,7 @@
 import powershell
 
 class ParenExpr extends @paren_expression, Expr {
-  PipelineBase getExpr() { paren_expression(this, result) }
+  PipelineBase getBase() { paren_expression(this, result) }
 
   override SourceLocation getLocation() { paren_expression_location(this, result) }
 

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -501,6 +501,20 @@ module ExprNodes {
 
     TypeConstraint getType() { result = e.getType() }
   }
+
+  class ParenExprChildMapping extends ExprChildMapping, ParenExpr {
+    override predicate relevantChild(Ast n) { n = this.getBase() }
+  }
+
+  class ParenCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "ParenExprCfgNode" }
+
+    override ParenExprChildMapping e;
+
+    override ParenExpr getExpr() { result = e }
+
+    final StmtCfgNode getBase() { e.hasCfgChild(e.getBase(), this, result) }
+  }
 }
 
 module StmtNodes {

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -485,6 +485,22 @@ module ExprNodes {
       )
     }
   }
+
+  class ConvertExprChildMapping extends ExprChildMapping, ConvertExpr {
+    override predicate relevantChild(Ast n) { n = this.getBase() }
+  }
+
+  class ConvertCfgNode extends ExprCfgNode {
+    override string getAPrimaryQlClass() { result = "ConvertCfgNode" }
+
+    override ConvertExprChildMapping e;
+
+    override ConvertExpr getExpr() { result = e }
+
+    final ExprCfgNode getBase() { e.hasCfgChild(e.getBase(), this, result) }
+
+    TypeConstraint getType() { result = e.getType() }
+  }
 }
 
 module StmtNodes {

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
@@ -601,7 +601,7 @@ module Trees {
   }
 
   class ParenExprTree extends StandardPostOrderTree instanceof ParenExpr {
-    override AstNode getChildNode(int i) { i = 0 and result = super.getExpr() }
+    override AstNode getChildNode(int i) { i = 0 and result = super.getBase() }
   }
 
   class TypeNameExprTree extends LeafTree instanceof TypeNameExpr { }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
@@ -589,7 +589,7 @@ module Trees {
   class ScriptBlockExprTree extends LeafTree instanceof ScriptBlockExpr { }
 
   class ConvertExprTree extends StandardPostOrderTree instanceof ConvertExpr {
-    override AstNode getChildNode(int i) { i = 0 and result = super.getExpr() }
+    override AstNode getChildNode(int i) { i = 0 and result = super.getBase() }
   }
 
   class IndexExprTree extends StandardPostOrderTree instanceof IndexExpr {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -104,6 +104,8 @@ module LocalFlow {
     or
     nodeFrom.asExpr() = nodeTo.asExpr().(CfgNodes::ExprNodes::ConvertCfgNode).getBase()
     or
+    nodeFrom.asStmt() = nodeTo.asExpr().(CfgNodes::ExprNodes::ParenCfgNode).getBase()
+    or
     exists(
       CfgNodes::ExprNodes::ArrayExprCfgNode arrayExpr, EscapeContainer::EscapeContainer container
     |

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -102,6 +102,8 @@ module LocalFlow {
     or
     nodeFrom.asExpr() = nodeTo.asStmt().(CfgNodes::StmtNodes::CmdExprCfgNode).getExpr()
     or
+    nodeFrom.asExpr() = nodeTo.asExpr().(CfgNodes::ExprNodes::ConvertCfgNode).getBase()
+    or
     exists(
       CfgNodes::ExprNodes::ArrayExprCfgNode arrayExpr, EscapeContainer::EscapeContainer container
     |

--- a/powershell/ql/lib/semmle/code/powershell/internal/ExplicitWrite.qll
+++ b/powershell/ql/lib/semmle/code/powershell/internal/ExplicitWrite.qll
@@ -10,7 +10,7 @@ module Private {
   predicate isExplicitWrite(Expr e, AssignStmt assign) {
     e = assign.getLeftHandSide()
     or
-    e = any(ConvertExpr convert | isExplicitWrite(convert, assign)).getExpr()
+    e = any(ConvertExpr convert | isExplicitWrite(convert, assign)).getBase()
     or
     e = any(ArrayLiteral array | isExplicitWrite(array, assign)).getAnElement()
   }

--- a/powershell/ql/test/library-tests/dataflow/local/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/test.expected
@@ -31,6 +31,7 @@
 | test.ps1:13:6:13:10 | (...) | test.ps1:13:1:13:3 | d |
 | test.ps1:13:6:13:10 | (...) | test.ps1:13:1:13:10 | ...=... |
 | test.ps1:13:6:13:10 | (...) | test.ps1:13:6:13:10 | (...) |
+| test.ps1:13:7:13:9 | c | test.ps1:13:6:13:10 | (...) |
 | test.ps1:13:7:13:9 | c | test.ps1:13:7:13:9 | c |
 | test.ps1:14:1:14:8 | Sink | test.ps1:14:1:14:8 | pre-return value for Sink |
 | test.ps1:14:1:14:8 | Sink | test.ps1:14:1:14:8 | pre-return value for Sink |

--- a/powershell/ql/test/library-tests/dataflow/local/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/test.expected
@@ -3,15 +3,24 @@
 | test.ps1:1:7:1:13 | Source | test.ps1:1:1:1:13 | ...=... |
 | test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | pre-return value for Sink |
 | test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | pre-return value for Sink |
-| test.ps1:2:1:2:9 | implicit unwrapping of Sink | test.ps1:1:1:8:9 | return value for test.ps1 |
+| test.ps1:2:1:2:9 | implicit unwrapping of Sink | test.ps1:1:1:11:8 | return value for test.ps1 |
 | test.ps1:2:1:2:9 | pre-return value for Sink | test.ps1:2:1:2:9 | implicit unwrapping of Sink |
 | test.ps1:4:1:4:3 | b | test.ps1:5:4:5:6 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:3 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:13 | ...=... |
+| test.ps1:5:4:5:6 | b | test.ps1:10:14:10:16 | b |
 | test.ps1:6:5:6:8 | a2 | test.ps1:8:6:8:9 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:8 | a2 |
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:17 | ...=... |
 | test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | pre-return value for Sink |
 | test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | pre-return value for Sink |
-| test.ps1:8:1:8:9 | implicit unwrapping of Sink | test.ps1:1:1:8:9 | return value for test.ps1 |
+| test.ps1:8:1:8:9 | implicit unwrapping of Sink | test.ps1:1:1:11:8 | return value for test.ps1 |
 | test.ps1:8:1:8:9 | pre-return value for Sink | test.ps1:8:1:8:9 | implicit unwrapping of Sink |
+| test.ps1:10:1:10:3 | c | test.ps1:11:6:11:8 | c |
+| test.ps1:10:6:10:16 | [...]... | test.ps1:10:1:10:3 | c |
+| test.ps1:10:6:10:16 | [...]... | test.ps1:10:1:10:16 | ...=... |
+| test.ps1:10:6:10:16 | [...]... | test.ps1:10:6:10:16 | [...]... |
+| test.ps1:11:1:11:8 | Sink | test.ps1:11:1:11:8 | pre-return value for Sink |
+| test.ps1:11:1:11:8 | Sink | test.ps1:11:1:11:8 | pre-return value for Sink |
+| test.ps1:11:1:11:8 | implicit unwrapping of Sink | test.ps1:1:1:11:8 | return value for test.ps1 |
+| test.ps1:11:1:11:8 | pre-return value for Sink | test.ps1:11:1:11:8 | implicit unwrapping of Sink |

--- a/powershell/ql/test/library-tests/dataflow/local/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/test.expected
@@ -20,6 +20,7 @@
 | test.ps1:10:6:10:16 | [...]... | test.ps1:10:1:10:3 | c |
 | test.ps1:10:6:10:16 | [...]... | test.ps1:10:1:10:16 | ...=... |
 | test.ps1:10:6:10:16 | [...]... | test.ps1:10:6:10:16 | [...]... |
+| test.ps1:10:14:10:16 | b | test.ps1:10:6:10:16 | [...]... |
 | test.ps1:11:1:11:8 | Sink | test.ps1:11:1:11:8 | pre-return value for Sink |
 | test.ps1:11:1:11:8 | Sink | test.ps1:11:1:11:8 | pre-return value for Sink |
 | test.ps1:11:1:11:8 | implicit unwrapping of Sink | test.ps1:1:1:11:8 | return value for test.ps1 |

--- a/powershell/ql/test/library-tests/dataflow/local/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/test.expected
@@ -3,7 +3,7 @@
 | test.ps1:1:7:1:13 | Source | test.ps1:1:1:1:13 | ...=... |
 | test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | pre-return value for Sink |
 | test.ps1:2:1:2:9 | Sink | test.ps1:2:1:2:9 | pre-return value for Sink |
-| test.ps1:2:1:2:9 | implicit unwrapping of Sink | test.ps1:1:1:11:8 | return value for test.ps1 |
+| test.ps1:2:1:2:9 | implicit unwrapping of Sink | test.ps1:1:1:14:8 | return value for test.ps1 |
 | test.ps1:2:1:2:9 | pre-return value for Sink | test.ps1:2:1:2:9 | implicit unwrapping of Sink |
 | test.ps1:4:1:4:3 | b | test.ps1:5:4:5:6 | b |
 | test.ps1:4:6:4:13 | GetBool | test.ps1:4:1:4:3 | b |
@@ -14,7 +14,7 @@
 | test.ps1:6:11:6:17 | Source | test.ps1:6:5:6:17 | ...=... |
 | test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | pre-return value for Sink |
 | test.ps1:8:1:8:9 | Sink | test.ps1:8:1:8:9 | pre-return value for Sink |
-| test.ps1:8:1:8:9 | implicit unwrapping of Sink | test.ps1:1:1:11:8 | return value for test.ps1 |
+| test.ps1:8:1:8:9 | implicit unwrapping of Sink | test.ps1:1:1:14:8 | return value for test.ps1 |
 | test.ps1:8:1:8:9 | pre-return value for Sink | test.ps1:8:1:8:9 | implicit unwrapping of Sink |
 | test.ps1:10:1:10:3 | c | test.ps1:11:6:11:8 | c |
 | test.ps1:10:6:10:16 | [...]... | test.ps1:10:1:10:3 | c |
@@ -23,5 +23,16 @@
 | test.ps1:10:14:10:16 | b | test.ps1:10:6:10:16 | [...]... |
 | test.ps1:11:1:11:8 | Sink | test.ps1:11:1:11:8 | pre-return value for Sink |
 | test.ps1:11:1:11:8 | Sink | test.ps1:11:1:11:8 | pre-return value for Sink |
-| test.ps1:11:1:11:8 | implicit unwrapping of Sink | test.ps1:1:1:11:8 | return value for test.ps1 |
+| test.ps1:11:1:11:8 | implicit unwrapping of Sink | test.ps1:1:1:14:8 | return value for test.ps1 |
 | test.ps1:11:1:11:8 | pre-return value for Sink | test.ps1:11:1:11:8 | implicit unwrapping of Sink |
+| test.ps1:11:6:11:8 | [post] c | test.ps1:13:7:13:9 | c |
+| test.ps1:11:6:11:8 | c | test.ps1:13:7:13:9 | c |
+| test.ps1:13:1:13:3 | d | test.ps1:14:6:14:8 | d |
+| test.ps1:13:6:13:10 | (...) | test.ps1:13:1:13:3 | d |
+| test.ps1:13:6:13:10 | (...) | test.ps1:13:1:13:10 | ...=... |
+| test.ps1:13:6:13:10 | (...) | test.ps1:13:6:13:10 | (...) |
+| test.ps1:13:7:13:9 | c | test.ps1:13:7:13:9 | c |
+| test.ps1:14:1:14:8 | Sink | test.ps1:14:1:14:8 | pre-return value for Sink |
+| test.ps1:14:1:14:8 | Sink | test.ps1:14:1:14:8 | pre-return value for Sink |
+| test.ps1:14:1:14:8 | implicit unwrapping of Sink | test.ps1:1:1:14:8 | return value for test.ps1 |
+| test.ps1:14:1:14:8 | pre-return value for Sink | test.ps1:14:1:14:8 | implicit unwrapping of Sink |

--- a/powershell/ql/test/library-tests/dataflow/local/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/local/test.ps1
@@ -9,3 +9,6 @@ Sink $a2
 
 $c = [string]$b
 Sink $c
+
+$d = ($c)
+Sink $d

--- a/powershell/ql/test/library-tests/dataflow/local/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/local/test.ps1
@@ -6,3 +6,6 @@ if($b) {
     $a2 = Source
 }
 Sink $a2
+
+$c = [string]$b
+Sink $c


### PR DESCRIPTION
A pretty simple PR that adds flow through conversions (i.e., `$x = [string]42`) and parentheses (i.e., `$x = (42)`).