### PR TITLE
PS: Flow through `ValueFromPipelineByPropertyName` parameters

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/Function.qll
+++ b/powershell/ql/lib/semmle/code/powershell/Function.qll
@@ -51,10 +51,10 @@ abstract private class AbstractFunction extends Ast {
     result.getIndex() = i
   }
 
-  final Parameter getParameterExcludingPipline(int i) {
+  final Parameter getParameterExcludingPiplines(int i) {
     result = this.getFunctionParameter(i)
     or
-    result = this.getBody().getParamBlock().getParameterExcludingPipline(i)
+    result = this.getBody().getParamBlock().getParameterExcludingPiplines(i)
   }
 
   final Parameter getThisParameter() {

--- a/powershell/ql/lib/semmle/code/powershell/NamedAttributeArgument.qll
+++ b/powershell/ql/lib/semmle/code/powershell/NamedAttributeArgument.qll
@@ -13,3 +13,7 @@ class NamedAttributeArgument extends @named_attribute_argument, Ast {
 class ValueFromPipelineAttribute extends NamedAttributeArgument {
   ValueFromPipelineAttribute() { this.getName() = "ValueFromPipeline" }
 }
+
+class ValueFromPipelineByPropertyName extends NamedAttributeArgument {
+  ValueFromPipelineByPropertyName() { this.getName() = "ValueFromPipelineByPropertyName" }
+}

--- a/powershell/ql/lib/semmle/code/powershell/ParamBlock.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ParamBlock.qll
@@ -15,7 +15,7 @@ class ParamBlock extends @param_block, Ast {
 
   Parameter getParameter(int i) { result.hasParameterBlock(this, i) }
 
-  Parameter getParameterExcludingPipline(int i) { result.hasParameterBlockExcludingPipeline(this, i) }
+  Parameter getParameterExcludingPiplines(int i) { result.hasParameterBlockExcludingPipelines(this, i) }
 
   Parameter getAParameter() { result = this.getParameter(_) }
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -471,7 +471,7 @@ private module ParameterNodes {
         // keywords in S are specified.
         exists(int i, int j, string name, NamedSet ns, Function f |
           pos.isPositional(j, ns) and
-          parameter.getIndexExcludingPipeline() = i and
+          parameter.getIndexExcludingPipelines() = i and
           f = parameter.getFunction() and
           f = ns.getAFunction() and
           name = parameter.getName() and
@@ -480,7 +480,7 @@ private module ParameterNodes {
             i -
               count(int k, Parameter p |
                 k < i and
-                p = f.getParameterExcludingPipline(k) and
+                p = f.getParameterExcludingPiplines(k) and
                 p.getName() = ns.getAName()
               )
         )

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -749,7 +749,7 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
   exists(CfgNode cfgNode |
     node1 = TPreReturnNodeImpl(cfgNode, true) and
     node2 = TImplicitWrapNode(cfgNode, true) and
-    c.isSingleton(any(Content::KnownElementContent ec))
+    c.isSingleton(any(Content::KnownElementContent ec | exists(ec.getIndex().asInt())))
   )
   or
   c.isAnyElement() and
@@ -785,7 +785,7 @@ predicate clearsContent(Node n, ContentSet c) {
  */
 predicate expectsContent(Node n, ContentSet c) {
   n = TPreReturnNodeImpl(_, true) and
-  c.isKnownOrUnknownElement(_)
+  c.isKnownOrUnknownElement(any(Content::KnownElementContent ec | exists(ec.getIndex().asInt())))
   or
   n = TImplicitWrapNode(_, false) and
   c.isSingleton(any(Content::UnknownElementContent ec))

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
@@ -340,7 +340,7 @@ import Cached
  * Only intended for internal use.
  */
 class DefinitionExt extends Impl::DefinitionExt {
-  VarReadAccessCfgNode getARead() { result = getARead(this) }
+  AstCfgNode getARead() { result = getARead(this) }
 
   override string toString() { result = this.(Ssa::Definition).toString() }
 

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
@@ -30,6 +30,11 @@ edges
 | test.ps1:31:1:31:7 | ...,... [element 1] | test.ps1:25:14:25:16 | _ [element 1] | provenance |  |
 | test.ps1:31:1:31:7 | ...,... [element 1] | test.ps1:31:1:31:7 | ...,... [element 1] | provenance |  |
 | test.ps1:31:5:31:7 | y | test.ps1:31:1:31:7 | ...,... [element 1] | provenance |  |
+| test.ps1:34:11:34:58 | x [element x] | test.ps1:36:10:36:12 | x | provenance |  |
+| test.ps1:39:6:39:17 | Source | test.ps1:40:23:40:25 | x | provenance |  |
+| test.ps1:40:1:40:26 | [...]... [element x] | test.ps1:34:11:34:58 | x [element x] | provenance |  |
+| test.ps1:40:17:40:26 | ${...} [element x] | test.ps1:40:1:40:26 | [...]... [element x] | provenance |  |
+| test.ps1:40:23:40:25 | x | test.ps1:40:17:40:26 | ${...} [element x] | provenance |  |
 nodes
 | test.ps1:2:10:2:21 | Source | semmle.label | Source |
 | test.ps1:3:10:3:21 | Source | semmle.label | Source |
@@ -63,6 +68,12 @@ nodes
 | test.ps1:31:1:31:7 | ...,... [element 1] | semmle.label | ...,... [element 1] |
 | test.ps1:31:1:31:7 | ...,... [element 1] | semmle.label | ...,... [element 1] |
 | test.ps1:31:5:31:7 | y | semmle.label | y |
+| test.ps1:34:11:34:58 | x [element x] | semmle.label | x [element x] |
+| test.ps1:36:10:36:12 | x | semmle.label | x |
+| test.ps1:39:6:39:17 | Source | semmle.label | Source |
+| test.ps1:40:1:40:26 | [...]... [element x] | semmle.label | [...]... [element x] |
+| test.ps1:40:17:40:26 | ${...} [element x] | semmle.label | ${...} [element x] |
+| test.ps1:40:23:40:25 | x | semmle.label | x |
 subpaths
 testFailures
 #select
@@ -73,3 +84,4 @@ testFailures
 | test.ps1:13:14:13:16 | x | test.ps1:20:6:20:17 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:20:6:20:17 | Source | Source |
 | test.ps1:25:14:25:16 | _ | test.ps1:29:6:29:17 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:29:6:29:17 | Source | Source |
 | test.ps1:25:14:25:16 | _ | test.ps1:30:6:30:17 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:30:6:30:17 | Source | Source |
+| test.ps1:36:10:36:12 | x | test.ps1:39:6:39:17 | Source | test.ps1:36:10:36:12 | x | $@ | test.ps1:39:6:39:17 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
@@ -33,7 +33,7 @@ $x, $y | consume2
 function consumeValueFromPipelineByPropertyName {
     Param([Parameter(ValueFromPipelineByPropertyName)] $x)
 
-    Sink $x # $ MISSING: hasValueFlow=23
+    Sink $x # $ hasValueFlow=23
 }
 
 $x = Source "23"

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
@@ -29,3 +29,12 @@ function consume2 {
 $x = Source "21"
 $y = Source "22"
 $x, $y | consume2
+
+function consumeValueFromPipelineByPropertyName {
+    Param([Parameter(ValueFromPipelineByPropertyName)] $x)
+
+    Sink $x # $ MISSING: hasValueFlow=23
+}
+
+$x = Source "23"
+[pscustomobject]@{x = $x} | consumeValueFromPipelineByPropertyName


### PR DESCRIPTION
This PR implements flow from pipeline arguments to `ValueFromPipelineByPropertyName` parameters. For example:
```powershell
function Process-Input {
    Param([Parameter(ValueFromPipelineByPropertyName)] $x)
    Sink $x
}

$x = Get-TaintedData
[pscustomobject]@{x = $x} | Process-Input
```

This is fairly simple given the machinery from https://github.com/microsoft/codeql/pull/119, https://github.com/microsoft/codeql/pull/121, and https://github.com/microsoft/codeql/pull/122:
1. From https://github.com/microsoft/codeql/pull/121 we get flow from `$x` to `@{x = $x}` with a store step that remembers that `x` is tainted.
2. From https://github.com/microsoft/codeql/pull/122 there is a flow step from `@{x = $x}` to `[pscustomobject]@{x = $x}`
3. From https://github.com/microsoft/codeql/pull/119 we get flow from `[pscustomobject]@{x = $x}` and into the pipeline parameter in `Process-Input`

Now, the only thing this PR has to do is to change which parameter receives this flow, and provide a read step that reads `x` out of the parameter node ... and that's exactly what we do 😄