### PR TITLE
PS: Allow for `ValueFromPipelineByPropertyName` to also read off an `ElementContent`

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/NamedAttributeArgument.qll
+++ b/powershell/ql/lib/semmle/code/powershell/NamedAttributeArgument.qll
@@ -7,6 +7,8 @@ class NamedAttributeArgument extends @named_attribute_argument, Ast {
 
   string getName() { named_attribute_argument(this, result, _) }
 
+  predicate hasName(string s) { this.getName() = s }
+
   Expr getValue() { named_attribute_argument(this, _, result) }
 }
 

--- a/powershell/ql/lib/semmle/code/powershell/ScriptBlock.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ScriptBlock.qll
@@ -60,4 +60,12 @@ class ProcessBlock extends NamedBlock {
   ProcessBlock() { scriptBlock.getProcessBlock() = this }
 
   ScriptBlock getScriptBlock() { result = scriptBlock }
+
+  PipelineParameter getPipelineParameter() {
+    result = scriptBlock.getEnclosingFunction().getAParameter()
+  }
+
+  PipelineByPropertyNameParameter getAPipelineByPropertyNameParameter() {
+    result = scriptBlock.getEnclosingFunction().getAParameter()
+  }
 }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -198,7 +198,11 @@ class ProcessBlockCfgNode extends NamedBlockCfgNode {
 
   override ProcessBlock getBlock() { result = block }
 
-  PipelineParameter getPipelineParameter() { result = block.getEnclosingFunction().getAParameter() }
+  PipelineParameter getPipelineParameter() { result = block.getPipelineParameter() }
+
+  PipelineByPropertyNameParameter getAPipelineByPropertyNameParameter() {
+    result = block.getAPipelineByPropertyNameParameter()
+  }
 }
 
 private class StmtBlockChildMapping extends NonExprChildMapping, StmtBlock {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -86,7 +86,7 @@ module SsaFlow {
   predicate localFlowStep(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
     Impl::localFlowStep(def, asNode(nodeFrom), asNode(nodeTo), isUseStep) and
     // Flow out of property name parameter nodes are covered by `readStep`.
-    not nodeFrom instanceof PipelineByPropertyNameParameter
+    not nodeFrom instanceof PipelineByPropertyNameParameterNode
   }
 
   predicate localMustFlowStep(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo) {
@@ -501,8 +501,8 @@ private module ParameterNodes {
     override string toStringImpl() { result = parameter.toString() }
   }
 
-  class PipelineByPropertyNameParameter extends NormalParameterNode {
-    PipelineByPropertyNameParameter() { this.getParameter().isPipelineByPropertyName() }
+  class PipelineByPropertyNameParameterNode extends NormalParameterNode {
+    PipelineByPropertyNameParameterNode() { this.getParameter().isPipelineByPropertyName() }
 
     string getPropretyName() { result = this.getParameter().getName() }
   }
@@ -760,8 +760,8 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
   or
   exists(Content::KnownElementContent ec, SsaImpl::DefinitionExt def |
     c.isSingleton(ec) and
-    node1.(PipelineByPropertyNameParameter).getPropretyName() = ec.getIndex().asString() and
-    def.getSourceVariable() = node1.(PipelineByPropertyNameParameter).getParameter() and
+    node1.(PipelineByPropertyNameParameterNode).getPropretyName() = ec.getIndex().asString() and
+    def.getSourceVariable() = node1.(PipelineByPropertyNameParameterNode).getParameter() and
     SsaImpl::firstRead(def, node2.asExpr())
   )
 }
@@ -794,7 +794,7 @@ predicate expectsContent(Node n, ContentSet c) {
   c.isAnyElement()
   or
   exists(Content::KnownElementContent ec |
-    ec.getIndex().asString() = n.(PipelineByPropertyNameParameter).getPropretyName() and
+    ec.getIndex().asString() = n.(PipelineByPropertyNameParameterNode).getPropretyName() and
     c.isSingleton(ec)
   )
 }

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
@@ -1,8 +1,8 @@
 models
 edges
-| test.ps1:2:10:2:21 | Source | test.ps1:5:5:5:7 | x | provenance |  |
-| test.ps1:3:10:3:21 | Source | test.ps1:6:5:6:7 | y | provenance |  |
-| test.ps1:4:10:4:21 | Source | test.ps1:6:9:6:11 | z | provenance |  |
+| test.ps1:2:10:2:20 | Source | test.ps1:5:5:5:7 | x | provenance |  |
+| test.ps1:3:10:3:20 | Source | test.ps1:6:5:6:7 | y | provenance |  |
+| test.ps1:4:10:4:20 | Source | test.ps1:6:9:6:11 | z | provenance |  |
 | test.ps1:5:5:5:7 | x | test.ps1:17:1:17:8 | produce [element] | provenance |  |
 | test.ps1:6:5:6:7 | y | test.ps1:6:5:6:11 | ...,... [element 0] | provenance |  |
 | test.ps1:6:5:6:11 | ...,... [element 0] | test.ps1:17:1:17:8 | produce [element] | provenance |  |
@@ -12,8 +12,8 @@ edges
 | test.ps1:10:11:10:44 | x [element 1] | test.ps1:13:14:13:16 | x | provenance |  |
 | test.ps1:10:11:10:44 | x [element] | test.ps1:13:14:13:16 | x | provenance |  |
 | test.ps1:17:1:17:8 | produce [element] | test.ps1:10:11:10:44 | x [element] | provenance |  |
-| test.ps1:19:6:19:17 | Source | test.ps1:21:1:21:3 | x | provenance |  |
-| test.ps1:20:6:20:17 | Source | test.ps1:21:5:21:7 | y | provenance |  |
+| test.ps1:19:6:19:16 | Source | test.ps1:21:1:21:3 | x | provenance |  |
+| test.ps1:20:6:20:16 | Source | test.ps1:21:5:21:7 | y | provenance |  |
 | test.ps1:21:1:21:3 | x | test.ps1:21:1:21:7 | ...,... [element 0] | provenance |  |
 | test.ps1:21:1:21:7 | ...,... [element 0] | test.ps1:10:11:10:44 | x [element 0] | provenance |  |
 | test.ps1:21:1:21:7 | ...,... [element 0] | test.ps1:21:1:21:7 | ...,... [element 0] | provenance |  |
@@ -22,8 +22,8 @@ edges
 | test.ps1:21:5:21:7 | y | test.ps1:21:1:21:7 | ...,... [element 1] | provenance |  |
 | test.ps1:25:14:25:16 | _ [element 0] | test.ps1:25:14:25:16 | _ | provenance |  |
 | test.ps1:25:14:25:16 | _ [element 1] | test.ps1:25:14:25:16 | _ | provenance |  |
-| test.ps1:29:6:29:17 | Source | test.ps1:31:1:31:3 | x | provenance |  |
-| test.ps1:30:6:30:17 | Source | test.ps1:31:5:31:7 | y | provenance |  |
+| test.ps1:29:6:29:16 | Source | test.ps1:31:1:31:3 | x | provenance |  |
+| test.ps1:30:6:30:16 | Source | test.ps1:31:5:31:7 | y | provenance |  |
 | test.ps1:31:1:31:3 | x | test.ps1:31:1:31:7 | ...,... [element 0] | provenance |  |
 | test.ps1:31:1:31:7 | ...,... [element 0] | test.ps1:25:14:25:16 | _ [element 0] | provenance |  |
 | test.ps1:31:1:31:7 | ...,... [element 0] | test.ps1:31:1:31:7 | ...,... [element 0] | provenance |  |
@@ -31,14 +31,14 @@ edges
 | test.ps1:31:1:31:7 | ...,... [element 1] | test.ps1:31:1:31:7 | ...,... [element 1] | provenance |  |
 | test.ps1:31:5:31:7 | y | test.ps1:31:1:31:7 | ...,... [element 1] | provenance |  |
 | test.ps1:34:11:34:58 | x [element x] | test.ps1:36:10:36:12 | x | provenance |  |
-| test.ps1:39:6:39:17 | Source | test.ps1:40:23:40:25 | x | provenance |  |
+| test.ps1:39:6:39:16 | Source | test.ps1:40:23:40:25 | x | provenance |  |
 | test.ps1:40:1:40:26 | [...]... [element x] | test.ps1:34:11:34:58 | x [element x] | provenance |  |
 | test.ps1:40:17:40:26 | ${...} [element x] | test.ps1:40:1:40:26 | [...]... [element x] | provenance |  |
 | test.ps1:40:23:40:25 | x | test.ps1:40:17:40:26 | ${...} [element x] | provenance |  |
 nodes
-| test.ps1:2:10:2:21 | Source | semmle.label | Source |
-| test.ps1:3:10:3:21 | Source | semmle.label | Source |
-| test.ps1:4:10:4:21 | Source | semmle.label | Source |
+| test.ps1:2:10:2:20 | Source | semmle.label | Source |
+| test.ps1:3:10:3:20 | Source | semmle.label | Source |
+| test.ps1:4:10:4:20 | Source | semmle.label | Source |
 | test.ps1:5:5:5:7 | x | semmle.label | x |
 | test.ps1:6:5:6:7 | y | semmle.label | y |
 | test.ps1:6:5:6:11 | ...,... [element 0] | semmle.label | ...,... [element 0] |
@@ -49,8 +49,8 @@ nodes
 | test.ps1:10:11:10:44 | x [element] | semmle.label | x [element] |
 | test.ps1:13:14:13:16 | x | semmle.label | x |
 | test.ps1:17:1:17:8 | produce [element] | semmle.label | produce [element] |
-| test.ps1:19:6:19:17 | Source | semmle.label | Source |
-| test.ps1:20:6:20:17 | Source | semmle.label | Source |
+| test.ps1:19:6:19:16 | Source | semmle.label | Source |
+| test.ps1:20:6:20:16 | Source | semmle.label | Source |
 | test.ps1:21:1:21:3 | x | semmle.label | x |
 | test.ps1:21:1:21:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
 | test.ps1:21:1:21:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
@@ -60,8 +60,8 @@ nodes
 | test.ps1:25:14:25:16 | _ | semmle.label | _ |
 | test.ps1:25:14:25:16 | _ [element 0] | semmle.label | _ [element 0] |
 | test.ps1:25:14:25:16 | _ [element 1] | semmle.label | _ [element 1] |
-| test.ps1:29:6:29:17 | Source | semmle.label | Source |
-| test.ps1:30:6:30:17 | Source | semmle.label | Source |
+| test.ps1:29:6:29:16 | Source | semmle.label | Source |
+| test.ps1:30:6:30:16 | Source | semmle.label | Source |
 | test.ps1:31:1:31:3 | x | semmle.label | x |
 | test.ps1:31:1:31:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
 | test.ps1:31:1:31:7 | ...,... [element 0] | semmle.label | ...,... [element 0] |
@@ -70,18 +70,18 @@ nodes
 | test.ps1:31:5:31:7 | y | semmle.label | y |
 | test.ps1:34:11:34:58 | x [element x] | semmle.label | x [element x] |
 | test.ps1:36:10:36:12 | x | semmle.label | x |
-| test.ps1:39:6:39:17 | Source | semmle.label | Source |
+| test.ps1:39:6:39:16 | Source | semmle.label | Source |
 | test.ps1:40:1:40:26 | [...]... [element x] | semmle.label | [...]... [element x] |
 | test.ps1:40:17:40:26 | ${...} [element x] | semmle.label | ${...} [element x] |
 | test.ps1:40:23:40:25 | x | semmle.label | x |
 subpaths
 testFailures
 #select
-| test.ps1:13:14:13:16 | x | test.ps1:2:10:2:21 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:2:10:2:21 | Source | Source |
-| test.ps1:13:14:13:16 | x | test.ps1:3:10:3:21 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:3:10:3:21 | Source | Source |
-| test.ps1:13:14:13:16 | x | test.ps1:4:10:4:21 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:4:10:4:21 | Source | Source |
-| test.ps1:13:14:13:16 | x | test.ps1:19:6:19:17 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:19:6:19:17 | Source | Source |
-| test.ps1:13:14:13:16 | x | test.ps1:20:6:20:17 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:20:6:20:17 | Source | Source |
-| test.ps1:25:14:25:16 | _ | test.ps1:29:6:29:17 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:29:6:29:17 | Source | Source |
-| test.ps1:25:14:25:16 | _ | test.ps1:30:6:30:17 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:30:6:30:17 | Source | Source |
-| test.ps1:36:10:36:12 | x | test.ps1:39:6:39:17 | Source | test.ps1:36:10:36:12 | x | $@ | test.ps1:39:6:39:17 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:2:10:2:20 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:2:10:2:20 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:3:10:3:20 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:3:10:3:20 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:4:10:4:20 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:4:10:4:20 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:19:6:19:16 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:19:6:19:16 | Source | Source |
+| test.ps1:13:14:13:16 | x | test.ps1:20:6:20:16 | Source | test.ps1:13:14:13:16 | x | $@ | test.ps1:20:6:20:16 | Source | Source |
+| test.ps1:25:14:25:16 | _ | test.ps1:29:6:29:16 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:29:6:29:16 | Source | Source |
+| test.ps1:25:14:25:16 | _ | test.ps1:30:6:30:16 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:30:6:30:16 | Source | Source |
+| test.ps1:36:10:36:12 | x | test.ps1:39:6:39:16 | Source | test.ps1:36:10:36:12 | x | $@ | test.ps1:39:6:39:16 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
@@ -35,6 +35,24 @@ edges
 | test.ps1:40:1:40:26 | [...]... [element x] | test.ps1:34:11:34:58 | x [element x] | provenance |  |
 | test.ps1:40:17:40:26 | ${...} [element x] | test.ps1:40:1:40:26 | [...]... [element x] | provenance |  |
 | test.ps1:40:23:40:25 | x | test.ps1:40:17:40:26 | ${...} [element x] | provenance |  |
+| test.ps1:43:11:43:58 | x [element 0, element x] | test.ps1:46:14:46:16 | x | provenance |  |
+| test.ps1:43:11:43:58 | x [element 1, element x] | test.ps1:46:14:46:16 | x | provenance |  |
+| test.ps1:43:11:43:58 | x [element 2, element x] | test.ps1:46:14:46:16 | x | provenance |  |
+| test.ps1:50:1:50:34 | [...]... [element x] | test.ps1:50:1:50:106 | ...,... [element 0, element x] | provenance |  |
+| test.ps1:50:1:50:106 | ...,... [element 0, element x] | test.ps1:43:11:43:58 | x [element 0, element x] | provenance |  |
+| test.ps1:50:1:50:106 | ...,... [element 0, element x] | test.ps1:50:1:50:106 | ...,... [element 0, element x] | provenance |  |
+| test.ps1:50:1:50:106 | ...,... [element 1, element x] | test.ps1:43:11:43:58 | x [element 1, element x] | provenance |  |
+| test.ps1:50:1:50:106 | ...,... [element 1, element x] | test.ps1:50:1:50:106 | ...,... [element 1, element x] | provenance |  |
+| test.ps1:50:1:50:106 | ...,... [element 2, element x] | test.ps1:43:11:43:58 | x [element 2, element x] | provenance |  |
+| test.ps1:50:1:50:106 | ...,... [element 2, element x] | test.ps1:50:1:50:106 | ...,... [element 2, element x] | provenance |  |
+| test.ps1:50:17:50:34 | ${...} [element x] | test.ps1:50:1:50:34 | [...]... [element x] | provenance |  |
+| test.ps1:50:23:50:33 | Source | test.ps1:50:17:50:34 | ${...} [element x] | provenance |  |
+| test.ps1:50:36:50:70 | [...]... [element x] | test.ps1:50:1:50:106 | ...,... [element 1, element x] | provenance |  |
+| test.ps1:50:52:50:70 | ${...} [element x] | test.ps1:50:36:50:70 | [...]... [element x] | provenance |  |
+| test.ps1:50:58:50:69 | Source | test.ps1:50:52:50:70 | ${...} [element x] | provenance |  |
+| test.ps1:50:72:50:106 | [...]... [element x] | test.ps1:50:1:50:106 | ...,... [element 2, element x] | provenance |  |
+| test.ps1:50:88:50:106 | ${...} [element x] | test.ps1:50:72:50:106 | [...]... [element x] | provenance |  |
+| test.ps1:50:94:50:105 | Source | test.ps1:50:88:50:106 | ${...} [element x] | provenance |  |
 nodes
 | test.ps1:2:10:2:20 | Source | semmle.label | Source |
 | test.ps1:3:10:3:20 | Source | semmle.label | Source |
@@ -74,6 +92,25 @@ nodes
 | test.ps1:40:1:40:26 | [...]... [element x] | semmle.label | [...]... [element x] |
 | test.ps1:40:17:40:26 | ${...} [element x] | semmle.label | ${...} [element x] |
 | test.ps1:40:23:40:25 | x | semmle.label | x |
+| test.ps1:43:11:43:58 | x [element 0, element x] | semmle.label | x [element 0, element x] |
+| test.ps1:43:11:43:58 | x [element 1, element x] | semmle.label | x [element 1, element x] |
+| test.ps1:43:11:43:58 | x [element 2, element x] | semmle.label | x [element 2, element x] |
+| test.ps1:46:14:46:16 | x | semmle.label | x |
+| test.ps1:50:1:50:34 | [...]... [element x] | semmle.label | [...]... [element x] |
+| test.ps1:50:1:50:106 | ...,... [element 0, element x] | semmle.label | ...,... [element 0, element x] |
+| test.ps1:50:1:50:106 | ...,... [element 0, element x] | semmle.label | ...,... [element 0, element x] |
+| test.ps1:50:1:50:106 | ...,... [element 1, element x] | semmle.label | ...,... [element 1, element x] |
+| test.ps1:50:1:50:106 | ...,... [element 1, element x] | semmle.label | ...,... [element 1, element x] |
+| test.ps1:50:1:50:106 | ...,... [element 2, element x] | semmle.label | ...,... [element 2, element x] |
+| test.ps1:50:1:50:106 | ...,... [element 2, element x] | semmle.label | ...,... [element 2, element x] |
+| test.ps1:50:17:50:34 | ${...} [element x] | semmle.label | ${...} [element x] |
+| test.ps1:50:23:50:33 | Source | semmle.label | Source |
+| test.ps1:50:36:50:70 | [...]... [element x] | semmle.label | [...]... [element x] |
+| test.ps1:50:52:50:70 | ${...} [element x] | semmle.label | ${...} [element x] |
+| test.ps1:50:58:50:69 | Source | semmle.label | Source |
+| test.ps1:50:72:50:106 | [...]... [element x] | semmle.label | [...]... [element x] |
+| test.ps1:50:88:50:106 | ${...} [element x] | semmle.label | ${...} [element x] |
+| test.ps1:50:94:50:105 | Source | semmle.label | Source |
 subpaths
 testFailures
 #select
@@ -85,3 +122,6 @@ testFailures
 | test.ps1:25:14:25:16 | _ | test.ps1:29:6:29:16 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:29:6:29:16 | Source | Source |
 | test.ps1:25:14:25:16 | _ | test.ps1:30:6:30:16 | Source | test.ps1:25:14:25:16 | _ | $@ | test.ps1:30:6:30:16 | Source | Source |
 | test.ps1:36:10:36:12 | x | test.ps1:39:6:39:16 | Source | test.ps1:36:10:36:12 | x | $@ | test.ps1:39:6:39:16 | Source | Source |
+| test.ps1:46:14:46:16 | x | test.ps1:50:23:50:33 | Source | test.ps1:46:14:46:16 | x | $@ | test.ps1:50:23:50:33 | Source | Source |
+| test.ps1:46:14:46:16 | x | test.ps1:50:58:50:69 | Source | test.ps1:46:14:46:16 | x | $@ | test.ps1:50:58:50:69 | Source | Source |
+| test.ps1:46:14:46:16 | x | test.ps1:50:94:50:105 | Source | test.ps1:46:14:46:16 | x | $@ | test.ps1:50:94:50:105 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
@@ -1,40 +1,40 @@
 function produce {
-    $x = Source "16"
-    $y = Source "17"
-    $z = Source "18"
+    $x = Source "1"
+    $y = Source "2"
+    $z = Source "3"
     $x
     $y, $z
 }
 
-function consume {
+function consumeWithProcess {
     Param([Parameter(ValueFromPipeline)] $x)
 
     process {
-        Sink $x # $ hasValueFlow=16 hasValueFlow=17 hasValueFlow=18 hasValueFlow=19 hasValueFlow=20
+        Sink $x # $ hasValueFlow=1 hasValueFlow=2 hasValueFlow=3 hasValueFlow=4 hasValueFlow=5
     }
 }
 
-produce | consume
+produce | consumeWithProcess
 
-$x = Source "19"
-$y = Source "20"
-$x, $y | consume
+$x = Source "4"
+$y = Source "5"
+$x, $y | consumeWithProcess
 
-function consume2 {
+function consumeWithProcessAnonymous {
     process {
-        Sink $_ # $ hasValueFlow=21 hasValueFlow=22
+        Sink $_ # $ hasValueFlow=6 hasValueFlow=7
     }
 }
 
-$x = Source "21"
-$y = Source "22"
-$x, $y | consume2
+$x = Source "6"
+$y = Source "7"
+$x, $y | consumeWithProcessAnonymous
 
-function consumeValueFromPipelineByPropertyName {
+function consumeValueFromPipelineByPropertyNameWithoutProcess {
     Param([Parameter(ValueFromPipelineByPropertyName)] $x)
 
-    Sink $x # $ hasValueFlow=23
+    Sink $x # $ hasValueFlow=8
 }
 
-$x = Source "23"
-[pscustomobject]@{x = $x} | consumeValueFromPipelineByPropertyName
+$x = Source "8"
+[pscustomobject]@{x = $x} | consumeValueFromPipelineByPropertyNameWithoutProcess

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
@@ -43,7 +43,7 @@ function consumeValueFromPipelineByPropertyNameWithProcess {
     Param([Parameter(ValueFromPipelineByPropertyName)] $x)
 
     process {
-        Sink $x # $ MISSING: hasValueFlow=9 hasValueFlow=10 hasValueFlow=11
+        Sink $x # $ hasValueFlow=9 hasValueFlow=10 hasValueFlow=11
     }
 }
 

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
@@ -38,3 +38,13 @@ function consumeValueFromPipelineByPropertyNameWithoutProcess {
 
 $x = Source "8"
 [pscustomobject]@{x = $x} | consumeValueFromPipelineByPropertyNameWithoutProcess
+
+function consumeValueFromPipelineByPropertyNameWithProcess {
+    Param([Parameter(ValueFromPipelineByPropertyName)] $x)
+
+    process {
+        Sink $x # $ MISSING: hasValueFlow=9 hasValueFlow=10 hasValueFlow=11
+    }
+}
+
+[pscustomobject]@{x = Source "9"}, [pscustomobject]@{x = Source "10"}, [pscustomobject]@{x = Source "11"} | consumeValueFromPipelineByPropertyNameWithProcess


### PR DESCRIPTION
After merging https://github.com/microsoft/codeql/pull/123 I realized that `ValueFromPipelineByPropertyName` I learned that these variables can also be used to process a pipeline that's more than one element long. For example:
```powershell
function consume {
    Param([Parameter(ValueFromPipelineByPropertyName)] $x)

    process {
        Write-Output $x
    }
}

myArray | consume 
```
This outputs the property named `x` for each element in `myArray`.

In the previous PR I only allowed for `myArray` to be a single element.

Implementation-wise, this amounts to adding another `readStep` that reads off `ElementContent` before the `readstep` that reads off the `x` property.