### PR TITLE
PS: Include parameter positions for top level functions

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowDispatch.qll
@@ -241,6 +241,13 @@ private module Cached {
         call = ns.getABindingCall() and
         exists(call.getArgument(pos))
       )
+      or
+      // Uncalled functions are never the target of a call returned by
+      // `ns.getABindingCall()`, but those parameters should still have
+      // positions since SSA depends on this.
+      // In particular, global scope is also an uncalled function.
+      any(Parameter p).getIndexExcludingPipelines() = pos and
+      ns.isEmpty()
     } or
     TPipelineParameter()
 }

--- a/powershell/ql/test/library-tests/dataflow/params/global.ps1
+++ b/powershell/ql/test/library-tests/dataflow/params/global.ps1
@@ -3,4 +3,4 @@ param([string]$Source1, [string]$Source2, [string]$Source3, [string]$Source4)
 Sink $Source1 # $ hasValueFlow=1
 Sink $Source2 # $ hasValueFlow=2
 Sink $Source3 # $ hasValueFlow=3
-Sink $Source4 # $ MISSING: hasValueFlow=4
+Sink $Source4 # $ hasValueFlow=4

--- a/powershell/ql/test/library-tests/dataflow/params/global.ps1
+++ b/powershell/ql/test/library-tests/dataflow/params/global.ps1
@@ -1,3 +1,6 @@
-param([string]$Source)
+param([string]$Source1, [string]$Source2, [string]$Source3, [string]$Source4)
 
-Sink $Source # $ hasValueFlow
+Sink $Source1 # $ hasValueFlow=1
+Sink $Source2 # $ hasValueFlow=2
+Sink $Source3 # $ hasValueFlow=3
+Sink $Source4 # $ MISSING: hasValueFlow=4

--- a/powershell/ql/test/library-tests/dataflow/params/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/params/test.expected
@@ -1,6 +1,8 @@
 models
 edges
-| global.ps1:1:7:1:22 | Source | global.ps1:3:6:3:13 | Source | provenance |  |
+| global.ps1:1:7:1:23 | Source1 | global.ps1:3:6:3:14 | Source1 | provenance |  |
+| global.ps1:1:25:1:41 | Source2 | global.ps1:4:6:4:14 | Source2 | provenance |  |
+| global.ps1:1:43:1:59 | Source3 | global.ps1:5:6:5:14 | Source3 | provenance |  |
 | test.ps1:1:14:1:16 | a | test.ps1:2:10:2:12 | a | provenance |  |
 | test.ps1:5:6:5:16 | Source | test.ps1:6:5:6:7 | x | provenance |  |
 | test.ps1:6:5:6:7 | x | test.ps1:1:14:1:16 | a | provenance |  |
@@ -140,8 +142,12 @@ edges
 | test.ps1:39:24:39:31 | second | test.ps1:8:24:8:26 | y | provenance |  |
 | test.ps1:39:32:39:38 | first | test.ps1:8:20:8:22 | x | provenance |  |
 nodes
-| global.ps1:1:7:1:22 | Source | semmle.label | Source |
-| global.ps1:3:6:3:13 | Source | semmle.label | Source |
+| global.ps1:1:7:1:23 | Source1 | semmle.label | Source1 |
+| global.ps1:1:25:1:41 | Source2 | semmle.label | Source2 |
+| global.ps1:1:43:1:59 | Source3 | semmle.label | Source3 |
+| global.ps1:3:6:3:14 | Source1 | semmle.label | Source1 |
+| global.ps1:4:6:4:14 | Source2 | semmle.label | Source2 |
+| global.ps1:5:6:5:14 | Source3 | semmle.label | Source3 |
 | test.ps1:1:14:1:16 | a | semmle.label | a |
 | test.ps1:2:10:2:12 | a | semmle.label | a |
 | test.ps1:5:6:5:16 | Source | semmle.label | Source |
@@ -224,7 +230,9 @@ nodes
 subpaths
 testFailures
 #select
-| global.ps1:3:6:3:13 | Source | global.ps1:1:7:1:22 | Source | global.ps1:3:6:3:13 | Source | $@ | global.ps1:1:7:1:22 | Source | Source |
+| global.ps1:3:6:3:14 | Source1 | global.ps1:1:7:1:23 | Source1 | global.ps1:3:6:3:14 | Source1 | $@ | global.ps1:1:7:1:23 | Source1 | Source1 |
+| global.ps1:4:6:4:14 | Source2 | global.ps1:1:25:1:41 | Source2 | global.ps1:4:6:4:14 | Source2 | $@ | global.ps1:1:25:1:41 | Source2 | Source2 |
+| global.ps1:5:6:5:14 | Source3 | global.ps1:1:43:1:59 | Source3 | global.ps1:5:6:5:14 | Source3 | $@ | global.ps1:1:43:1:59 | Source3 | Source3 |
 | test.ps1:2:10:2:12 | a | test.ps1:5:6:5:16 | Source | test.ps1:2:10:2:12 | a | $@ | test.ps1:5:6:5:16 | Source | Source |
 | test.ps1:9:10:9:12 | x | test.ps1:14:10:14:20 | Source | test.ps1:9:10:9:12 | x | $@ | test.ps1:14:10:14:20 | Source | Source |
 | test.ps1:10:10:10:12 | y | test.ps1:15:11:15:21 | Source | test.ps1:10:10:10:12 | y | $@ | test.ps1:15:11:15:21 | Source | Source |

--- a/powershell/ql/test/library-tests/dataflow/params/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/params/test.expected
@@ -3,6 +3,7 @@ edges
 | global.ps1:1:7:1:23 | Source1 | global.ps1:3:6:3:14 | Source1 | provenance |  |
 | global.ps1:1:25:1:41 | Source2 | global.ps1:4:6:4:14 | Source2 | provenance |  |
 | global.ps1:1:43:1:59 | Source3 | global.ps1:5:6:5:14 | Source3 | provenance |  |
+| global.ps1:1:61:1:77 | Source4 | global.ps1:6:6:6:14 | Source4 | provenance |  |
 | test.ps1:1:14:1:16 | a | test.ps1:2:10:2:12 | a | provenance |  |
 | test.ps1:5:6:5:16 | Source | test.ps1:6:5:6:7 | x | provenance |  |
 | test.ps1:6:5:6:7 | x | test.ps1:1:14:1:16 | a | provenance |  |
@@ -145,9 +146,11 @@ nodes
 | global.ps1:1:7:1:23 | Source1 | semmle.label | Source1 |
 | global.ps1:1:25:1:41 | Source2 | semmle.label | Source2 |
 | global.ps1:1:43:1:59 | Source3 | semmle.label | Source3 |
+| global.ps1:1:61:1:77 | Source4 | semmle.label | Source4 |
 | global.ps1:3:6:3:14 | Source1 | semmle.label | Source1 |
 | global.ps1:4:6:4:14 | Source2 | semmle.label | Source2 |
 | global.ps1:5:6:5:14 | Source3 | semmle.label | Source3 |
+| global.ps1:6:6:6:14 | Source4 | semmle.label | Source4 |
 | test.ps1:1:14:1:16 | a | semmle.label | a |
 | test.ps1:2:10:2:12 | a | semmle.label | a |
 | test.ps1:5:6:5:16 | Source | semmle.label | Source |
@@ -233,6 +236,7 @@ testFailures
 | global.ps1:3:6:3:14 | Source1 | global.ps1:1:7:1:23 | Source1 | global.ps1:3:6:3:14 | Source1 | $@ | global.ps1:1:7:1:23 | Source1 | Source1 |
 | global.ps1:4:6:4:14 | Source2 | global.ps1:1:25:1:41 | Source2 | global.ps1:4:6:4:14 | Source2 | $@ | global.ps1:1:25:1:41 | Source2 | Source2 |
 | global.ps1:5:6:5:14 | Source3 | global.ps1:1:43:1:59 | Source3 | global.ps1:5:6:5:14 | Source3 | $@ | global.ps1:1:43:1:59 | Source3 | Source3 |
+| global.ps1:6:6:6:14 | Source4 | global.ps1:1:61:1:77 | Source4 | global.ps1:6:6:6:14 | Source4 | $@ | global.ps1:1:61:1:77 | Source4 | Source4 |
 | test.ps1:2:10:2:12 | a | test.ps1:5:6:5:16 | Source | test.ps1:2:10:2:12 | a | $@ | test.ps1:5:6:5:16 | Source | Source |
 | test.ps1:9:10:9:12 | x | test.ps1:14:10:14:20 | Source | test.ps1:9:10:9:12 | x | $@ | test.ps1:14:10:14:20 | Source | Source |
 | test.ps1:10:10:10:12 | y | test.ps1:15:11:15:21 | Source | test.ps1:10:10:10:12 | y | $@ | test.ps1:15:11:15:21 | Source | Source |


### PR DESCRIPTION
Follow up to https://github.com/microsoft/codeql/pull/125. In order to have parameter positions (which are used to model SSA for parameters) we need to handle the case where a parameter belongs to an uncalled function. In particular, this happens when a parameter is a top-level parameter.

This PR ensures that these parameters always have positions.