### PR TITLE
PS: Extract source files found via `PSModulePath`

### DIFF
--- a/powershell/downgrades/c5191f89a6e3e8cea428b5c7326a06e335738533/old.dbscheme
+++ b/powershell/downgrades/c5191f89a6e3e8cea428b5c7326a06e335738533/old.dbscheme
@@ -1,0 +1,1652 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+is_in_psmodule_path(
+  int file: @file ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @command_base | @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/downgrades/c5191f89a6e3e8cea428b5c7326a06e335738533/semmlecode.powershell.dbscheme
+++ b/powershell/downgrades/c5191f89a6e3e8cea428b5c7326a06e335738533/semmlecode.powershell.dbscheme
@@ -1,0 +1,1648 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @command_base | @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/downgrades/c5191f89a6e3e8cea428b5c7326a06e335738533/upgrade.properties
+++ b/powershell/downgrades/c5191f89a6e3e8cea428b5c7326a06e335738533/upgrade.properties
@@ -1,0 +1,3 @@
+description: Add is_in_psmodule_path relation
+compatibility: full
+is_in_psmodule_path.rel: delete

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
@@ -77,7 +77,7 @@ namespace Semmle.Extraction.PowerShell.Standalone
         /// <summary>
         /// List of extensions to include.
         /// </summary>
-        public IList<string> Extensions { get; } = new List<string>() { ".ps1" };
+        public IList<string> Extensions { get; } = new List<string>() { ".ps1", ".psd1" };
 
         /// <summary>
         /// Files/patterns to exclude.

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
@@ -24,6 +24,9 @@ namespace Semmle.Extraction.PowerShell.Standalone
                 case "dry-run":
                     SkipExtraction = value;
                     return true;
+                case "skip-psmodulepath-files":
+                    SkipPSModulePathFiles = value;
+                    return true;
                 default:
                     return base.HandleFlag(key, value);
             }
@@ -128,6 +131,12 @@ namespace Semmle.Extraction.PowerShell.Standalone
         public bool SkipExtraction { get; private set; } = false;
 
         /// <summary>
+        /// Whether to extract files in the paths found in the `PSModulePath`
+        /// environment variable.
+        /// </summary>
+        public bool SkipPSModulePathFiles { get; private set; } = false;
+
+        /// <summary>
         /// Whether errors were encountered parsing the arguments.
         /// </summary>
         public bool Errors { get; private set; } = false;
@@ -158,13 +167,14 @@ namespace Semmle.Extraction.PowerShell.Standalone
                 "PowerShell# standalone extractor\n\nExtracts PowerShell scripts in the current directory.\n"
             );
             output.WriteLine("Additional options:\n");
-            output.WriteLine("    <path>           Use the provided path instead.");
+            output.WriteLine("    <path>                       Use the provided path instead.");
             output.WriteLine(
-                "    --exclude:xxx    Exclude a file or directory (can be specified multiple times)"
+                "    --exclude:xxx                Exclude a file or directory (can be specified multiple times)"
             );
-            output.WriteLine("    --dry-run        Stop before extraction");
-            output.WriteLine("    --threads:nnn    Specify number of threads (default=CPU cores)");
-            output.WriteLine("    --verbose        Produce more output");
+            output.WriteLine("    --dry-run                    Stop before extraction");
+            output.WriteLine("    --threads:nnn                Specify number of threads (default=CPU cores)");
+            output.WriteLine("    --verbose                    Produce more output");
+            output.WriteLine("    --skip-psmodulepath-files    Avoid extracting source files in paths specified by the PSModulePath environment variable.");
         }
 
         private Options() { }

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Program.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Program.cs
@@ -45,7 +45,8 @@ namespace Semmle.Extraction.PowerShell.Standalone
 
             output.Log(Severity.Info, "Running PowerShell standalone extractor");
             var sourceFiles = options
-                .Files.Where(d =>
+                .Files.Concat(GetPSModuleFiles(options))
+                .Where(d =>
                     options.Extensions.Contains(
                         d.Extension,
                         StringComparer.InvariantCultureIgnoreCase
@@ -85,6 +86,30 @@ namespace Semmle.Extraction.PowerShell.Standalone
             }
 
             return 0;
+        }
+
+        private static String[] GetPSModulePaths()
+        {
+            return Environment.GetEnvironmentVariable("PSModulePath")?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>();
+        }
+
+        private static IEnumerable<FileInfo> GetPSModuleFiles(Options options)
+        {
+            if(options.SkipPSModulePathFiles)
+            {
+                return Array.Empty<FileInfo>();
+            }
+            
+            return GetPSModulePaths()
+                .Where(d => Directory.Exists(d))
+                .SelectMany(d =>
+                {
+                    var di = new DirectoryInfo(d);
+                    return di.Exists
+                        ? di.GetFiles("*.*", SearchOption.AllDirectories)
+                        : new FileInfo[] { new(d) };
+                });
         }
 
         private class ExtractionProgress : IProgressMonitor

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/File.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/Base/File.cs
@@ -2,6 +2,7 @@ using Semmle.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Semmle.Extraction.PowerShell.Entities
 {
@@ -14,6 +15,18 @@ namespace Semmle.Extraction.PowerShell.Entities
         {
         }
 
+        private static string[] GetPSModulePaths()
+        {
+            return Environment.GetEnvironmentVariable("PSModulePath")?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>();
+        }
+
+        private bool PathIsInPSModulePath()
+        {
+            // Check if f's path is inside one of the paths in $Env:PSModulePath
+            return GetPSModulePaths().Any(originalPath.StartsWith);
+        }
+
         public override void Populate(TextWriter trapFile)
         {
             trapFile.files(this, TransformedPath.Value);
@@ -21,6 +34,11 @@ namespace Semmle.Extraction.PowerShell.Entities
             if (TransformedPath.ParentDirectory is PathTransformer.ITransformedPath dir)
             {
                 trapFile.containerparent(Extraction.Entities.Folder.Create(PowerShellContext, dir), this);
+            }
+
+            if(PathIsInPSModulePath())
+            {
+                trapFile.is_in_psmodule_path(this);
             }
 
             try

--- a/powershell/extractor/Semmle.Extraction/Tuples.cs
+++ b/powershell/extractor/Semmle.Extraction/Tuples.cs
@@ -32,5 +32,9 @@ namespace Semmle.Extraction
         {
             trapFile.WriteTuple("locations_default", label, file, startLine, startCol, endLine, endCol);
         }
+
+        public static void is_in_psmodule_path(this System.IO.TextWriter trapFile, Entities.File file) {
+            trapFile.WriteTuple("is_in_psmodule_path", file);
+        }
     }
 }

--- a/powershell/ql/lib/semmle/code/powershell/File.qll
+++ b/powershell/ql/lib/semmle/code/powershell/File.qll
@@ -209,6 +209,10 @@ class File extends Container, @file {
     not this.isStub()
   }
 
+  predicate isInPSModulePath() {
+    is_in_psmodule_path(this)
+  }
+
   /** Holds if this file is a library. */
   predicate fromLibrary() {
     not this.getBaseName() = "" and

--- a/powershell/ql/lib/semmlecode.powershell.dbscheme
+++ b/powershell/ql/lib/semmlecode.powershell.dbscheme
@@ -41,6 +41,10 @@ containerparent(
   unique int child: @container ref
 );
 
+is_in_psmodule_path(
+  int file: @file ref
+);
+
 /* Comments */
 comment_entity(
   unique int id: @comment_entity,

--- a/powershell/ql/lib/upgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/old.dbscheme
+++ b/powershell/ql/lib/upgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/old.dbscheme
@@ -1,0 +1,1648 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @command_base | @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/ql/lib/upgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/semmlecode.powershell.dbscheme
+++ b/powershell/ql/lib/upgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/semmlecode.powershell.dbscheme
@@ -1,0 +1,1652 @@
+/* Mandatory */
+sourceLocationPrefix(
+  varchar(900) prefix: string ref
+);
+
+/* Entity Locations */
+@location = @location_default;
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+/* File Metadata */
+
+numlines(
+  unique int element_id: @file ref,
+  int num_lines: int ref,
+  int num_code: int ref,
+  int num_comment: int ref
+);
+
+files(
+  unique int id: @file,
+  varchar(900) name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  varchar(900) name: string ref
+);
+
+@container = @folder | @file;
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+is_in_psmodule_path(
+  int file: @file ref
+);
+
+/* Comments */
+comment_entity(
+  unique int id: @comment_entity,
+  int text: @string_literal ref
+);
+
+comment_entity_location(
+  unique int id: @comment_entity ref,
+  int loc: @location ref
+);
+
+/* Messages */
+extractor_messages(
+  unique int id: @extractor_message,
+  int severity: int ref,
+  string origin : string ref,
+  string text : string ref,
+  string entity : string ref,
+  int location: @location_default ref,
+  string stack_trace : string ref
+);
+
+parent(
+  int child: @ast ref,
+  int parent: @ast ref
+);
+
+/* AST Nodes */
+// This is all the kinds of nodes that can inherit from Ast
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ast?view=powershellsdk-7.3.0
+@ast = @not_implemented | @attribute_base | @catch_clause | @command_element |
+@member | @named_block | @param_block | @parameter | @redirection | @script_block | @statement | @statement_block | @named_attribute_argument;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributebaseast?view=powershellsdk-7.2.0
+@attribute_base = @attribute | @type_constraint;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberast?view=powershellsdk-7.3.0
+@member = @function_member | @property_member;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandbaseast?view=powershellsdk-7.3.0
+@command_base = @command | @command_expression;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.chainableast?view=powershellsdk-7.3.0
+@chainable = @command_base | @pipeline | @pipeline_chain;
+//https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinebaseast?view=powershellsdk-7.3.0
+@pipeline_base = @chainable | @error_statement | @assignment_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementast?view=powershellsdk-7.3.0
+@statement = @block_statement 
+| @break_statement 
+| @command_base
+| @configuration_definition 
+| @continue_statement 
+| @data_statement 
+| @dynamic_keyword_statement 
+| @exit_statement 
+| @function_definition 
+| @if_statement 
+| @labeled_statement 
+| @pipeline_base
+| @return_statement 
+| @throw_statement 
+| @trap_statement 
+| @try_statement 
+| @type_definition
+| @using_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.loopstatementast?view=powershellsdk-7.3.0
+@loop_statement = @do_until_statement | @do_while_statement | @foreach_statement | @for_statement | @while_statement;
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.labeledstatementast?view=powershellsdk-7.3.0
+@labeled_statement = @loop_statement | @switch_statement;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+@attributed_expression_ast = @attributed_expression | @convert_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+@member_expression_base = @member_expression | @invoke_member_expression; // | @base_ctor_invoke_member_expression
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expressionast?view=powershellsdk-7.3.0
+@expression = @array_expression
+| @array_literal
+| @attributed_expression_ast
+| @binary_expression
+| @error_expression
+| @expandable_string_expression
+| @hash_table
+| @index_expression
+| @member_expression_base
+| @paren_expression
+| @script_block_expression
+| @sub_expression
+| @ternary_expression
+| @type_expression
+| @unary_expression
+| @using_expression
+| @variable_expression
+| @base_constant_expression;
+
+// Constant expression can both be instanced and extended by string constant expression
+@base_constant_expression = @constant_expression | @string_constant_expression;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandelementast?view=powershellsdk-7.3.0
+@command_element = @expression | @command_parameter;
+
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.redirectionast?view=powershellsdk-7.3.0
+@redirection = @file_redirection | @merging_redirection;
+
+/** 
+Entries in this table indicate visited C# powershell ast objects which don't have parsing implemented yet.  
+
+You can obtain the Type of the C# AST objects which don't yet have an associated entity to parse them
+ using this QL query on an extracted db:
+
+from string s
+where not_implemented(_, s)
+select s
+*/
+not_implemented(
+  unique int id: @not_implemented,
+  string name: string ref
+);
+
+not_implemented_location(
+  int id: @not_implemented ref,
+  int loc: @location ref
+);
+
+// ArrayExpressionAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayexpressionast?view=powershellsdk-7.3.0
+array_expression(
+  unique int id: @array_expression,
+  int subExpression: @statement_block ref
+)
+
+array_expression_location(
+  int id: @array_expression ref,
+  int loc: @location ref
+)
+
+// ArrayLiteralAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.arrayliteralast?view=powershellsdk-7.3.0
+array_literal(
+  unique int id: @array_literal
+)
+
+array_literal_location(
+  int id: @array_literal ref,
+  int loc: @location ref
+)
+
+array_literal_element(
+  int id: @array_literal ref,
+  int index: int ref,
+  int component: @expression ref
+)
+
+// AssignmentStatementAst 
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.assignmentstatementast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L983-L989
+assignment_statement(
+  unique int id: @assignment_statement,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @statement ref
+)
+
+assignment_statement_location(
+  int id: @assignment_statement ref,
+  int loc: @location ref
+)
+
+// NamedBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedblockast?view=powershellsdk-7.3.0
+named_block(
+  unique int id: @named_block,
+  int numStatements: int ref,
+  int numTraps: int ref
+)
+
+named_block_statement(
+  int id: @named_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+named_block_trap(
+  int id: @named_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+named_block_location(
+  int id: @named_block ref,
+  int loc: @location ref
+)
+
+// ScriptBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockast?view=powershellsdk-7.3.0
+script_block(
+  unique int id: @script_block,
+  int numUsings: int ref,
+  int numRequiredModules: int ref,
+  int numRequiredAssemblies: int ref,
+  int numRequiredPsEditions: int ref,
+  int numRequiredPsSnapins: int ref
+)
+
+script_block_param_block(
+  int id: @script_block ref,
+  int the_param_block: @param_block ref
+)
+
+script_block_begin_block(
+  int id: @script_block ref,
+  int begin_block: @named_block ref
+)
+
+script_block_clean_block(
+  int id: @script_block ref,
+  int clean_block: @named_block ref
+)
+
+script_block_dynamic_param_block(
+  int id: @script_block ref,
+  int dynamic_param_block: @named_block ref
+)
+
+script_block_end_block(
+  int id: @script_block ref,
+  int end_block: @named_block ref
+)
+
+script_block_process_block(
+  int id: @script_block ref,
+  int process_block: @named_block ref
+)
+
+script_block_using(
+  int id: @script_block ref,
+  int index: int ref,
+  int using: @ast ref
+)
+
+script_block_required_application_id(
+  int id: @script_block ref,
+  string application_id: string ref
+)
+
+script_block_requires_elevation(
+  int id: @script_block ref,
+  boolean requires_elevation: boolean ref
+)
+
+script_block_required_ps_version(
+  int id: @script_block ref,
+  string required_ps_version: string ref
+)
+
+script_block_required_module(
+  int id: @script_block ref,
+  int index: int ref,
+  int required_module: @module_specification ref
+)
+
+script_block_required_assembly(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_assembly: string ref
+)
+
+script_block_required_ps_edition(
+  int id: @script_block ref,
+  int index: int ref,
+  string required_ps_edition: string ref
+)
+
+script_block_requires_ps_snapin(
+  int id: @script_block ref,
+  int index: int ref,
+  string name: string ref,
+  string version: string ref
+)
+
+script_block_location(
+  int id: @script_block ref,
+  int loc: @location ref
+)
+
+// ModuleSpecification
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.3.0
+module_specification(
+  unique int id: @module_specification,
+  string name: string ref,
+  string guid: string ref,
+  string maxVersion: string ref,
+  string requiredVersion: string ref,
+  string version: string ref
+)
+
+// BinaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.binaryexpressionast?view=powershellsdk-7.3.0
+// https://github.com/PowerShell/PowerShell/blob/48c9d683565ed9402430a27e09410d56d52d4bfd/src/System.Management.Automation/engine/parser/Compiler.cs#L5675-L5947
+binary_expression(
+  unique int id: @binary_expression,
+  int kind: int ref, // @token_kind ref
+  int left: @expression ref,
+  int right: @expression ref
+)
+
+// @binary_expression_kind = @And | @Is | @IsNot | @As | @DotDot | @Multiply | @Divide | @Rem | @Plus | @Minus | @Format | @Xor | @Shl | @Shr | @Band | @Bor | @Bxor | @Join | @Ieq | @Ine | @Ige | @Igt | @Ilt | @Ile | @Ilike | @Inotlike | @Inotmatch | @Imatch | @Ireplace | @Inotcontains | @Icontains | @Iin | @Inotin | @Isplit | @Ceq | @Cge | @Cgt | @Clt | @Cle | @Clike | @Cnotlike | @Cnotmatch | @Cmatch | @Ccontains | @Creplace | @Cin | @Cnotin | @Csplit | @QuestionQuestion;
+
+binary_expression_location(
+  int id: @binary_expression ref,
+  int loc: @location ref
+)
+
+// ConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.constantexpressionast?view=powershellsdk-7.3.0
+constant_expression(
+  unique int id: @constant_expression,
+  string staticType: string ref
+)
+
+constant_expression_value(
+  int id: @constant_expression ref,
+  int value: @string_literal ref
+)
+
+constant_expression_location(
+  int id: @constant_expression ref,
+  int loc: @location ref
+)
+
+// ConvertExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.convertexpressionast?view=powershellsdk-7.3.0
+convert_expression(
+  unique int id: @convert_expression,
+  int the_attribute: @ast ref,
+  int child: @ast ref,
+  int object_type: @ast ref,
+  string staticType: string ref
+)
+
+convert_expression_location(
+  int id: @convert_expression ref,
+  int loc: @location ref
+)
+
+// IndexExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.indexexpressionast?view=powershellsdk-7.3.0
+index_expression(
+  unique int id: @index_expression,
+  int index: @ast ref,
+  int target: @ast ref,
+  boolean nullConditional: boolean ref
+)
+
+index_expression_location(
+  int id: @index_expression ref,
+  int loc: @location ref
+)
+
+// IfStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ifstatementast?view=powershellsdk-7.3.0
+if_statement(
+  unique int id: @if_statement
+)
+
+if_statement_clause(
+  int id: @if_statement ref,
+  int index: int ref,
+  int item1: @pipeline_base ref,
+  int item2: @statement_block ref
+)
+
+if_statement_else(
+  int id: @if_statement ref,
+  int elseItem: @statement_block ref 
+)
+
+if_statement_location(
+  int id: @if_statement ref,
+  int loc: @location ref
+)
+
+// MemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.memberexpressionast?view=powershellsdk-7.3.0
+member_expression(
+  unique int id: @member_expression,
+  int expression: @ast ref,
+  int member: @ast ref,
+  boolean nullConditional: boolean ref,
+  boolean isStatic: boolean ref
+)
+
+member_expression_location(
+  int id: @member_expression ref,
+  int loc: @location ref
+)
+
+// StatementBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.statementblockast?view=powershellsdk-7.3.0
+statement_block(
+  unique int id: @statement_block,
+  int numStatements: int ref,
+  int numTraps : int ref
+)
+
+statement_block_location(
+  int id: @statement_block ref,
+  int loc: @location ref
+)
+
+statement_block_statement(
+  int id: @statement_block ref,
+  int index: int ref,
+  int statement: @statement ref
+)
+
+statement_block_trap(
+  int id: @statement_block ref,
+  int index: int ref,
+  int trap: @trap_statement ref
+)
+
+// SubExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.subexpressionast?view=powershellsdk-7.3.0
+sub_expression(
+  unique int id: @sub_expression,
+  int subExpression: @statement_block ref
+)
+
+sub_expression_location(
+  int id: @sub_expression ref,
+  int loc: @location ref
+)
+
+// VariableExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.variableexpressionast?view=powershellsdk-7.3.0
+variable_expression(
+  unique int id: @variable_expression,
+  string userPath: string ref,
+  string driveName: string ref,
+  boolean isConstant: boolean ref,
+  boolean isGlobal: boolean ref,
+  boolean isLocal: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isScript: boolean ref,
+  boolean isUnqualified: boolean ref,
+  boolean isUnscoped: boolean ref,
+  boolean isVariable: boolean ref,
+  boolean isDriveQualified: boolean ref
+)
+
+variable_expression_location(
+  int id: @variable_expression ref,
+  int loc: @location ref
+)
+
+// CommandExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandexpressionast?view=powershellsdk-7.3.0
+command_expression(
+  unique int id: @command_expression,
+  int wrapped: @expression ref,
+  int numRedirections: int ref
+)
+
+command_expression_location(
+  int id: @command_expression ref,
+  int loc: @location ref
+)
+
+command_expression_redirection(
+  int id: @command_expression ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// StringConstantExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.stringconstantexpressionast?view=powershellsdk-7.3.0
+string_constant_expression(
+  unique int id: @string_constant_expression,
+  int value: @string_literal ref
+)
+
+string_constant_expression_location(
+  int id: @string_constant_expression ref,
+  int loc: @location ref
+)
+
+// PipelineAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelineast?view=powershellsdk-7.3.0
+pipeline(
+  unique int id: @pipeline,
+  int numComponents: int ref
+)
+
+pipeline_location(
+  int id: @pipeline ref,
+  int loc: @location ref
+)
+
+pipeline_component(
+  int id: @pipeline ref,
+  int index: int ref,
+  int component: @command_base ref
+)
+
+// CommandAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandast?view=powershellsdk-7.3.0
+command(
+  unique int id: @command,
+  string name: string ref,
+  int kind: int ref, // @token_kind ref
+  int numElements: int ref,
+  int numRedirections: int ref
+)
+
+command_location(
+  int id: @command ref,
+  int loc: @location ref
+)
+
+command_command_element(
+  int id: @command ref,
+  int index: int ref,
+  int component: @command_element ref
+)
+
+command_redirection(
+  int id: @command ref,
+  int index: int ref,
+  int redirection: @redirection ref
+)
+
+// InvokeMemberExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.invokememberexpressionast?view=powershellsdk-7.3.0
+invoke_member_expression(
+  unique int id: @invoke_member_expression,
+  int expression: @expression ref,
+  int member: @command_element ref
+)
+
+invoke_member_expression_location(
+  int id: @invoke_member_expression ref,
+  int loc: @location ref
+)
+
+invoke_member_expression_argument(
+  int id: @invoke_member_expression ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+// ParenExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parenexpressionast?view=powershellsdk-7.3.0
+paren_expression(
+  unique int id: @paren_expression,
+  int expression: @pipeline_base ref
+)
+
+paren_expression_location(
+  int id: @paren_expression ref,
+  int loc: @location ref
+)
+
+
+// TernaryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.ternaryexpressionast?view=powershellsdk-7.3.0
+ternary_expression(
+  unique int id: @ternary_expression, 
+  int condition: @expression ref,
+  int ifFalse: @expression ref,
+  int iftrue: @expression ref
+)
+
+ternary_expression_location(
+  int id: @ternary_expression ref,
+  int loc: @location ref
+)
+
+// ExitStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.exitstatementast?view=powershellsdk-7.3.0
+exit_statement(
+  unique int id: @exit_statement
+)
+
+exit_statement_pipeline(
+  int id: @exit_statement ref,
+  int expression: @pipeline_base ref
+)
+
+exit_statement_location(
+  int id: @exit_statement ref,
+  int loc: @location ref
+)
+
+
+// TypeExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeexpressionast?view=powershellsdk-7.3.0
+type_expression(
+  unique int id: @type_expression,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_expression_location(
+  int id: @type_expression ref,
+  int loc: @location ref
+)
+
+// CommandParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.commandparameterast?view=powershellsdk-7.3.0
+command_parameter(
+  unique int id: @command_parameter,
+  string name: string ref
+)
+
+command_parameter_location(
+  int id: @command_parameter ref,
+  int loc: @location ref
+)
+
+command_parameter_argument(
+  int id: @command_parameter ref,
+  int argument: @ast ref
+)
+
+// NamedAttributeArgumentAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.namedattributeargumentast?view=powershellsdk-7.3.0
+named_attribute_argument(
+  unique int id: @named_attribute_argument,
+  string name: string ref,
+  int argument: @expression ref
+)
+
+named_attribute_argument_location(
+  int id: @named_attribute_argument ref,
+  int loc: @location ref
+)
+
+// AttributeAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributeast?view=powershellsdk-7.3.0
+attribute(
+  unique int id: @attribute,
+  string name: string ref,
+  int numNamedArguments: int ref,
+  int numPositionalArguments: int ref
+)
+
+attribute_named_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @named_attribute_argument ref
+)
+
+attribute_positional_argument(
+  int id: @attribute ref,
+  int index: int ref,
+  int argument: @expression ref
+)
+
+attribute_location(
+  int id: @attribute ref,
+  int id: @location ref
+)
+
+// ParamBlockAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.paramblockast?view=powershellsdk-7.3.0
+param_block(
+  unique int id: @param_block,
+  int numAttributes: int ref,
+  int numParameters: int ref
+)
+
+param_block_attribute(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_attribute: @attribute ref
+)
+
+param_block_parameter(
+  int id: @param_block ref,
+  int index: int ref,
+  int the_parameter: @parameter ref
+)
+
+param_block_location(
+  int id: @param_block ref,
+  int id: @location ref
+)
+
+// ParameterAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.parameterast?view=powershellsdk-7.3.0
+parameter(
+  unique int id: @parameter,
+  int name: @variable_expression ref,
+  string staticType: string ref,
+  int numAttributes: int ref
+)
+
+parameter_attribute(
+  int id: @parameter ref,
+  int index: int ref,
+  int the_attribute: @attribute_base ref
+)
+
+parameter_location(
+  int id: @parameter ref,
+  int loc: @location ref
+)
+
+parameter_default_value(
+  int id: @parameter ref,
+  int default_value: @expression ref
+)
+
+// TypeConstraintAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typeconstraintast?view=powershellsdk-7.3.0
+type_constraint(
+  unique int id: @type_constraint,
+  string name: string ref,
+  string fullName: string ref
+)
+
+type_constraint_location(
+  int id: @type_constraint ref,
+  int loc: @location ref
+)
+
+// FunctionDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functiondefinitionast?view=powershellsdk-7.3.0
+function_definition(
+  unique int id: @function_definition,
+  int body: @script_block ref,
+  string name: string ref,
+  boolean isFilter: boolean ref,
+  boolean isWorkflow: boolean ref
+)
+
+function_definition_parameter(
+  int id: @function_definition ref,
+  int index: int ref,
+  int parameter: @parameter ref
+)
+
+function_definition_location(
+  int id: @function_definition ref,
+  int loc: @location ref
+)
+
+// BreakStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.breakstatementast?view=powershellsdk-7.3.0
+break_statement(
+  unique int id: @break_statement
+)
+
+break_statement_location(
+  int id: @break_statement ref,
+  int loc: @location ref
+)
+
+// ContinueStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.continuestatementast?view=powershellsdk-7.3.0
+continue_statement(
+  unique int id: @continue_statement
+)
+
+continue_statement_location(
+  int id: @continue_statement ref,
+  int loc: @location ref
+)
+@labelled_statement = @continue_statement | @break_statement;
+
+statement_label(
+  int id: @labelled_statement ref,
+  int label: @expression ref
+)
+
+// ReturnStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.returnstatementast?view=powershellsdk-7.3.0
+return_statement(
+  unique int id: @return_statement
+)
+
+return_statement_pipeline(
+  int id: @return_statement ref,
+  int pipeline: @pipeline_base ref
+)
+
+return_statement_location(
+  int id: @return_statement ref,
+  int loc: @location ref
+)
+
+// DoWhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dowhilestatementast?view=powershellsdk-7.3.0
+do_while_statement(
+  unique int id: @do_while_statement,
+  int body: @statement_block ref
+)
+
+do_while_statement_condition(
+  int id: @do_while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_while_statement_location(
+  int id: @do_while_statement ref,
+  int loc: @location ref
+)
+
+// DoUntilStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dountilstatementast?view=powershellsdk-7.3.0
+do_until_statement(
+  unique int id: @do_until_statement,
+  int body: @statement_block ref
+)
+
+do_until_statement_condition(
+  int id: @do_until_statement ref,
+  int condition: @pipeline_base ref
+)
+
+do_until_statement_location(
+  int id: @do_until_statement ref,
+  int loc: @location ref
+)
+
+// WhileStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.whilestatementast?view=powershellsdk-7.3.0
+while_statement(
+  unique int id: @while_statement,
+  int body: @statement_block ref
+)
+
+while_statement_condition(
+  int id: @while_statement ref,
+  int condition: @pipeline_base ref
+)
+
+while_statement_location(
+  int id: @while_statement ref,
+  int loc: @location ref
+)
+
+// ForEachStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.foreachstatementast?view=powershellsdk-7.3.0
+foreach_statement(
+  unique int id: @foreach_statement,
+  int variable: @variable_expression ref,
+  int condition: @pipeline_base ref,
+  int body: @statement_block ref,
+  int flags: int ref
+)
+
+foreach_statement_location(
+  int id: @foreach_statement ref,
+  int loc: @location ref
+)
+
+// ForStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.forstatementast?view=powershellsdk-7.3.0
+for_statement(
+  unique int id: @for_statement,
+  int body: @statement_block ref
+)
+
+for_statement_location(
+  int id: @for_statement ref,
+  int loc: @location ref
+)
+
+for_statement_condition(
+  int id: @for_statement ref,
+  int condition: @pipeline_base ref
+)
+
+for_statement_initializer(
+  int id: @for_statement ref,
+  int initializer: @pipeline_base ref
+)
+
+for_statement_iterator(
+  int id: @for_statement ref,
+  int iterator: @pipeline_base ref
+)
+
+// ExpandableStringExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.expandablestringexpressionast?view=powershellsdk-7.3.0
+expandable_string_expression(
+  unique int id: @expandable_string_expression,
+  int value: @string_literal ref,
+  int kind: int ref,
+  int numExpression: int ref
+)
+
+case @expandable_string_expression.kind of
+ 4 = @BareWord
+| 2 = @DoubleQuoted
+| 3 = @DoubleQuotedHereString
+| 0 = @SingleQuoted
+| 1 = @SingleQuotedHereString;
+
+expandable_string_expression_location(
+  int id: @expandable_string_expression ref,
+  int loc: @location ref
+)
+
+expandable_string_expression_nested_expression(
+  int id: @expandable_string_expression ref,
+  int index: int ref,
+  int nestedExression: @expression ref
+)
+
+// StringLiterals
+// Contains string literals broken into lines to prevent breaks in the trap from multiline strings
+string_literal(
+  unique int id: @string_literal
+)
+
+string_literal_location(
+  int id: @string_literal ref,
+  int loc: @location ref
+)
+
+string_literal_line(
+  int id: @string_literal ref,
+  int lineNum: int ref,
+  string line: string ref
+)
+
+// UnaryExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.unaryexpressionast?view=powershellsdk-7.3.0
+unary_expression(
+  unique int id: @unary_expression,
+  int child: @ast ref,
+  int kind: int ref,
+  string staticType: string ref
+)
+
+unary_expression_location(
+  int id: @unary_expression ref,
+  int loc: @location ref
+)
+
+// CatchClauseAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.catchclauseast?view=powershellsdk-7.3.0
+catch_clause(
+  unique int id: @catch_clause,
+  int body: @statement_block ref,
+  boolean isCatchAll: boolean ref
+)
+
+catch_clause_catch_type(
+  int id: @catch_clause ref,
+  int index: int ref,
+  int catch_type: @type_constraint ref
+)
+
+catch_clause_location(
+  int id: @catch_clause ref,
+  int loc: @location ref
+)
+
+// ThrowStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.throwstatementast?view=powershellsdk-7.3.0
+throw_statement(
+  unique int id: @throw_statement,
+  boolean isRethrow: boolean ref
+)
+
+throw_statement_location(
+  int id: @throw_statement ref,
+  int loc: @location ref
+)
+
+throw_statement_pipeline(
+  int id: @throw_statement ref,
+  int pipeline: @ast ref
+)
+
+// TryStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trystatementast?view=powershellsdk-7.3.0
+try_statement(
+  unique int id: @try_statement,
+  int body: @statement_block ref
+)
+
+try_statement_catch_clause(
+  int id: @try_statement ref,
+  int index: int ref,
+  int catch_clause: @catch_clause ref
+)
+
+
+try_statement_finally(
+  int id: @try_statement ref,
+  int finally: @ast ref
+)
+
+try_statement_location(
+  int id: @try_statement ref,
+  int loc: @location ref
+)
+
+// FileRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.fileredirectionast?view=powershellsdk-7.3.0
+file_redirection(
+  unique int id: @file_redirection,
+  int location: @ast ref,
+  boolean isAppend: boolean ref,
+  int redirectionType: int ref
+)
+
+case @file_redirection.redirectionType of
+ 0 = @All
+| 1 = @Output
+| 2 = @Error
+| 3 = @Warning
+| 4 = @Verbose
+| 5 = @Debug
+| 6 = @Information;
+
+file_redirection_location(
+  int id: @file_redirection ref,
+  int loc: @location ref
+)
+
+// BlockStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.blockstatementast?view=powershellsdk-7.3.0
+block_statement(
+  unique int id: @block_statement,
+  int body: @ast ref,
+  int token: @token ref
+)
+
+block_statement_location(
+  int id: @block_statement ref,
+  int loc: @location ref
+)
+
+// Token
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.token?view=powershellsdk-7.3.0
+token(
+  unique int id: @token,
+  boolean hasError: boolean ref,
+  int kind: int ref,
+  string text: string ref,
+  int tokenFlags: int ref
+)
+
+token_location(
+  int id: @token ref,
+  int loc: @location ref
+)
+
+// ConfigurationDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.configurationdefinitionast?view=powershellsdk-7.3.0
+configuration_definition(
+  unique int id: @configuration_definition,
+  int body: @script_block_expression ref,
+  int configurationType: int ref,
+  int name: @expression ref
+)
+
+configuration_definition_location(
+  int id: @configuration_definition ref,
+  int loc: @location ref
+)
+
+// DataStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.datastatementast?view=powershellsdk-7.3.0
+data_statement(
+  unique int id: @data_statement,
+  int body: @statement_block ref
+)
+
+data_statement_variable(
+  int id: @data_statement ref,
+  string variable: string ref
+)
+
+data_statement_commands_allowed(
+  int id: @data_statement ref,
+  int index: int ref,
+  int command_allowed: @ast ref
+)
+
+data_statement_location(
+  int id: @data_statement ref,
+  int loc: @location ref
+)
+
+// DynamicKeywordStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.dynamickeywordstatementast?view=powershellsdk-7.3.0
+dynamic_keyword_statement(
+  unique int id: @dynamic_keyword_statement
+)
+
+dynamic_keyword_statement_command_elements(
+  int id: @dynamic_keyword_statement ref,
+  int index: int ref,
+  int element: @command_element ref
+)
+
+dynamic_keyword_statement_location(
+  int id: @dynamic_keyword_statement ref,
+  int loc: @location ref
+)
+
+// ErrorExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorexpressionast?view=powershellsdk-7.3.0
+error_expression(
+  unique int id: @error_expression
+)
+
+error_expression_nested_ast(
+  int id: @error_expression ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_expression_location(
+  int id: @error_expression ref,
+  int loc: @location ref
+)
+
+// ErrorStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.errorstatementast?view=powershellsdk-7.3.0
+error_statement(
+  unique int id: @error_statement,
+  int token: @token ref
+)
+
+error_statement_location(
+  int id: @error_statement ref,
+  int loc: @location ref
+)
+
+error_statement_nested_ast(
+  int id: @error_statement ref,
+  int index: int ref,
+  int nested_ast: @ast ref
+)
+
+error_statement_conditions(
+  int id: @error_statement ref,
+  int index: int ref,
+  int condition: @ast ref
+)
+
+error_statement_bodies(
+  int id: @error_statement ref,
+  int index: int ref,
+  int body: @ast ref
+)
+
+error_statement_flag(
+  int id: @error_statement ref,
+  int index: int ref,
+  int k: string ref, // The key
+  int token: @token ref, // These two form a tuple of the value
+  int ast: @ast ref
+)
+
+// FunctionMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.functionmemberast?view=powershellsdk-7.3.0
+function_member(
+  unique int id: @function_member,
+  int body: @ast ref,
+  boolean isConstructor: boolean ref,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+function_member_location(
+  int id: @function_member ref,
+  int loc: @location ref
+)
+
+function_member_parameter(
+  int id: @function_member ref,
+  int index: int ref,
+  int parameter: @ast ref
+)
+
+function_member_attribute(
+  int id: @function_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+function_member_return_type(
+  int id: @function_member ref,
+  int return_type: @type_constraint ref
+)
+
+// MergingRedirectionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.mergingredirectionast?view=powershellsdk-7.3.0
+merging_redirection(
+  unique int id: @merging_redirection,
+  int from: int ref,
+  int to: int ref
+)
+
+merging_redirection_location(
+  int id: @merging_redirection ref,
+  int loc: @location ref
+)
+
+
+label(
+  int id: @labeled_statement ref,
+  string label: string ref
+)
+
+// TrapStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.trapstatementast?view=powershellsdk-7.3.0
+trap_statement(
+  unique int id: @trap_statement,
+  int body: @ast ref
+)
+
+trap_statement_type(
+  int id: @trap_statement ref,
+  int trap_type: @type_constraint ref
+)
+
+trap_statement_location(
+  int id: @trap_statement ref,
+  int loc: @location ref
+)
+
+// PipelineChainAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.pipelinechainast?view=powershellsdk-7.3.0
+pipeline_chain(
+  unique int id: @pipeline_chain,
+  boolean isBackground: boolean ref,
+  int kind: int ref,
+  int left: @ast ref,
+  int right: @ast ref
+)
+
+pipeline_chain_location(
+  int id: @pipeline_chain ref,
+  int loc: @location ref
+)
+
+// PropertyMemberAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.propertymemberast?view=powershellsdk-7.3.0
+property_member(
+  unique int id: @property_member,
+  boolean isHidden: boolean ref,
+  boolean isPrivate: boolean ref,
+  boolean isPublic: boolean ref,
+  boolean isStatic: boolean ref,
+  string name: string ref,
+  int methodAttributes: int ref
+)
+
+property_member_attribute(
+  int id: @property_member ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+property_member_property_type(
+  int id: @property_member ref,
+  int property_type: @type_constraint ref
+)
+
+property_member_initial_value(
+  int id: @property_member ref,
+  int initial_value: @ast ref
+)
+
+property_member_location(
+  int id: @property_member ref,
+  int loc: @location ref
+)
+
+// ScriptBlockExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptblockexpressionast?view=powershellsdk-7.3.0
+script_block_expression(
+  unique int id: @script_block_expression,
+  int body: @script_block ref
+)
+
+script_block_expression_location(
+  int id: @script_block_expression ref,
+  int loc: @location ref
+)
+
+// SwitchStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.switchstatementast?view=powershellsdk-7.3.0
+switch_statement(
+  unique int id: @switch_statement,
+  int condition: @ast ref,
+  int flags: int ref
+)
+
+switch_statement_clauses(
+  int id: @switch_statement ref,
+  int index: int ref,
+  int expression: @ast ref,
+  int statementBlock: @ast ref
+)
+
+switch_statement_location(
+  int id: @switch_statement ref,
+  int loc: @location ref
+)
+
+switch_statement_default(
+  int id: @switch_statement ref,
+  int default: @ast ref
+)
+
+// TypeDefinitionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.typedefinitionast?view=powershellsdk-7.3.0
+type_definition(
+  unique int id: @type_definition,
+  string name: string ref,
+  int flags: int ref,
+  boolean isClass: boolean ref,
+  boolean isEnum: boolean ref,
+  boolean isInterface: boolean ref
+)
+
+type_definition_attributes(
+  int id: @type_definition ref,
+  int index: int ref,
+  int attribute: @ast ref
+)
+
+type_definition_members(
+  int id: @type_definition ref,
+  int index: int ref,
+  int member: @ast ref
+)
+
+type_definition_location(
+  int id: @type_definition ref,
+  int loc: @location ref
+)
+
+type_definition_base_type(
+  int id: @type_definition ref,
+  int index: int ref,
+  int base_type: @type_constraint ref
+)
+
+// UsingExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingexpressionast?view=powershellsdk-7.3.0
+using_expression(
+  unique int id: @using_expression,
+  int subExpression: @ast ref
+)
+
+using_expression_location(
+  int id: @using_expression ref,
+  int loc: @location ref
+)
+
+// UsingStatementAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.usingstatementast?view=powershellsdk-7.3.0
+using_statement(
+  unique int id: @using_statement,
+  int kind: int ref
+)
+
+using_statement_location(
+  int id: @using_statement ref,
+  int loc: @location ref
+)
+
+using_statement_alias(
+  int id: @using_statement ref,
+  int alias: @ast ref
+)
+
+using_statement_module_specification(
+  int id: @using_statement ref,
+  int module_specification: @ast ref
+)
+
+using_statement_name(
+  int id: @using_statement ref,
+  int name: @ast ref
+)
+
+// HashTableAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.hashtableast?view=powershellsdk-7.3.0
+hash_table(
+  unique int id: @hash_table
+)
+
+hash_table_location(
+  int id: @hash_table ref,
+  int loc: @location ref
+)
+
+hash_table_key_value_pairs(
+  int id: @hash_table ref,
+  int index: int ref,
+  int k: @ast ref,
+  int v: @ast ref
+)
+
+// AttributedExpressionAst
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.attributedexpressionast?view=powershellsdk-7.3.0
+attributed_expression(
+  unique int id: @attributed_expression,
+  int attribute: @ast ref,
+  int expression: @ast ref
+)
+
+attributed_expression_location(
+  int id: @attributed_expression ref,
+  int loc: @location ref
+)
+
+// TokenKind
+// https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.tokenkind?view=powershellsdk-7.3.0
+token_kind_reference(
+  unique int id: @token_kind_reference,
+  string name: string ref,
+  int kind: int ref
+)
+
+@token_kind = @ampersand | @and | @andAnd | @as | @assembly | @atCurly | @atParen | @band | @base | @begin | @bnot | @bor | @break 
+| @bxor | @catch | @ccontains | @ceq | @cge | @cgt | @cin | @class | @cle | @clean | @clike | @clt | @cmatch | @cne | @cnotcontains 
+| @cnotin | @cnotlike | @cnotmatch | @colon | @colonColon | @comma | @command_token | @comment | @configuration | @continue | @creplace 
+| @csplit | @data | @default | @define | @divide | @divideEquals | @do | @dollarParen | @dot | @dotDot | @dynamicKeyword | @dynamicparam 
+| @else | @elseIf | @end | @endOfInput | @enum | @equals | @exclaim | @exit | @filter | @finally | @for | @foreach | @format | @from 
+| @function | @generic | @hereStringExpandable | @hereStringLiteral | @hidden | @icontains | @identifier | @ieq | @if | @ige | @igt 
+| @iin | @ile | @ilike | @ilt | @imatch | @in | @ine | @inlineScript | @inotcontains | @inotin | @inotlike | @inotmatch | @interface 
+| @ireplace | @is | @isNot | @isplit | @join | @label | @lBracket | @lCurly | @lineContinuation | @lParen | @minus | @minusEquals 
+| @minusMinus | @module | @multiply | @multiplyEquals | @namespace | @newLine | @not | @number | @or | @orOr | @parallel | @param 
+| @parameter_token | @pipe | @plus | @plusEquals | @plusPlus | @postfixMinusMinus | @postfixPlusPlus | @private | @process | @public 
+| @questionDot | @questionLBracket | @questionMark | @questionQuestion | @questionQuestionEquals | @rBracket | @rCurly | @redirectInStd 
+| @redirection_token | @rem | @remainderEquals | @return | @rParen | @semi | @sequence | @shl | @shr | @splattedVariable | @static 
+| @stringExpandable | @stringLiteral_token | @switch | @throw | @trap | @try | @type | @unknown | @until | @using | @var | @variable 
+| @while | @workflow | @xor;
+
+case @token_kind_reference.kind of
+28 = @ampersand // The invocation operator '&'.
+| 53 = @and // The logical and operator '-and'.
+| 26 = @andAnd // The (unimplemented) operator '&&'.
+| 94 = @as // The type conversion operator '-as'.
+| 165 = @assembly // The 'assembly' keyword
+| 23 = @atCurly // The opening token of a hash expression '@{'.
+| 22 = @atParen // The opening token of an array expression '@('.
+| 56 = @band // The bitwise and operator '-band'.
+| 168 = @base // The 'base' keyword
+| 119 = @begin // The 'begin' keyword.
+| 52 = @bnot // The bitwise not operator '-bnot'.
+| 57 = @bor // The bitwise or operator '-bor'.
+| 120 = @break // The 'break' keyword.
+| 58 = @bxor // The bitwise exclusive or operator '-xor'.
+| 121 = @catch // The 'catch' keyword.
+| 87 = @ccontains // The case sensitive contains operator '-ccontains'.
+| 76 = @ceq // The case sensitive equal operator '-ceq'.
+| 78 = @cge // The case sensitive greater than or equal operator '-cge'.
+| 79 = @cgt // The case sensitive greater than operator '-cgt'.
+| 89 = @cin // The case sensitive in operator '-cin'.
+| 122 = @class // The 'class' keyword.
+| 81 = @cle // The case sensitive less than or equal operator '-cle'.
+| 170 = @clean // The 'clean' keyword.
+| 82 = @clike // The case sensitive like operator '-clike'.
+| 80 = @clt // The case sensitive less than operator '-clt'.
+| 84 = @cmatch // The case sensitive match operator '-cmatch'.
+| 77 = @cne // The case sensitive not equal operator '-cne'.
+| 88 = @cnotcontains // The case sensitive not contains operator '-cnotcontains'.
+| 90 = @cnotin // The case sensitive not in operator '-notin'.
+| 83 = @cnotlike // The case sensitive notlike operator '-cnotlike'.
+| 85 = @cnotmatch // The case sensitive not match operator '-cnotmatch'.
+| 99 = @colon // The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.
+| 34 = @colonColon // The static member access operator '::'.
+| 30 = @comma // The unary or binary array operator ','.
+| 166 = @command_token // The 'command' keyword
+| 10 = @comment // A single line comment, or a delimited comment.
+| 155 = @configuration // The "configuration" keyword
+| 123 = @continue // The 'continue' keyword.
+| 86 = @creplace // The case sensitive replace operator '-creplace'.
+| 91 = @csplit // The case sensitive split operator '-csplit'.
+| 124 = @data // The 'data' keyword.
+| 169 = @default // The 'default' keyword
+| 125 = @define // The (unimplemented) 'define' keyword.
+| 38 = @divide // The division operator '/'.
+| 46 = @divideEquals // The division assignment operator '/='.
+| 126 = @do // The 'do' keyword.
+| 24 = @dollarParen // The opening token of a sub-expression '$('.
+| 35 = @dot // The instance member access or dot source invocation operator '.'.
+| 33 = @dotDot // The range operator '..'.
+| 156 = @dynamicKeyword // The token kind for dynamic keywords
+| 127 = @dynamicparam // The 'dynamicparam' keyword.
+| 128 = @else // The 'else' keyword.
+| 129 = @elseIf // The 'elseif' keyword.
+| 130 = @end // The 'end' keyword.
+| 11 = @endOfInput // Marks the end of the input script or file.
+| 161 = @enum // The 'enum' keyword
+| 42 = @equals // The assignment operator '='.
+| 36 = @exclaim // The logical not operator '!'.
+| 131 = @exit // The 'exit' keyword.
+| 132 = @filter // The 'filter' keyword.
+| 133 = @finally // The 'finally' keyword.
+| 134 = @for // The 'for' keyword.
+| 135 = @foreach // The 'foreach' keyword.
+| 50 = @format // The string format operator '-f'.
+| 136 = @from // The (unimplemented) 'from' keyword.
+| 137 = @function // The 'function' keyword.
+| 7 = @generic // A token that is only valid as a command name, command argument, function name, or configuration name. It may contain characters not allowed in identifiers. Tokens with this kind are always instances of StringLiteralToken or StringExpandableToken if the token contains variable references or subexpressions.
+| 15 = @hereStringExpandable // A double quoted here string literal. Tokens with this kind are always instances of StringExpandableToken. even if there are no nested tokens to expand.
+| 14 = @hereStringLiteral // A single quoted here string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 167 = @hidden // The 'hidden' keyword
+| 71 = @icontains // The case insensitive contains operator '-icontains' or '-contains'.
+| 6 = @identifier // A simple identifier, always begins with a letter or '', and is followed by letters, numbers, or ''.
+| 60 = @ieq // The case insensitive equal operator '-ieq' or '-eq'.
+| 138 = @if // The 'if' keyword.
+| 62 = @ige // The case insensitive greater than or equal operator '-ige' or '-ge'.
+| 63 = @igt // The case insensitive greater than operator '-igt' or '-gt'.
+| 73 = @iin // The case insensitive in operator '-iin' or '-in'.
+| 65 = @ile // The case insensitive less than or equal operator '-ile' or '-le'.
+| 66 = @ilike // The case insensitive like operator '-ilike' or '-like'.
+| 64 = @ilt // The case insensitive less than operator '-ilt' or '-lt'.
+| 68 = @imatch // The case insensitive match operator '-imatch' or '-match'.
+| 139 = @in // The 'in' keyword.
+| 61 = @ine // The case insensitive not equal operator '-ine' or '-ne'.
+| 154 = @inlineScript // The 'InlineScript' keyword
+| 72 = @inotcontains // The case insensitive notcontains operator '-inotcontains' or '-notcontains'.
+| 74 = @inotin // The case insensitive notin operator '-inotin' or '-notin'
+| 67 = @inotlike // The case insensitive not like operator '-inotlike' or '-notlike'.
+| 69 = @inotmatch // The case insensitive not match operator '-inotmatch' or '-notmatch'.
+| 160 = @interface // The 'interface' keyword
+| 70 = @ireplace // The case insensitive replace operator '-ireplace' or '-replace'.
+| 92 = @is // The type test operator '-is'.
+| 93 = @isNot // The type test operator '-isnot'.
+| 75 = @isplit // The case insensitive split operator '-isplit' or '-split'.
+| 59 = @join // The join operator '-join'.
+| 5 = @label // A label token - always begins with ':', followed by the label name. Tokens with this kind are always instances of LabelToken.
+| 20 = @lBracket // The opening square brace token '['.
+| 18 = @lCurly // The opening curly brace token '{'.
+| 9 = @lineContinuation // A line continuation (backtick followed by newline).
+| 16 = @lParen // The opening parenthesis token '('.
+| 41 = @minus // The substraction operator '-'.
+| 44 = @minusEquals // The subtraction assignment operator '-='.
+| 31 = @minusMinus // The pre-decrement operator '--'.
+| 163 = @module // The 'module' keyword
+| 37 = @multiply // The multiplication operator '*'.
+| 45 = @multiplyEquals // The multiplication assignment operator '*='.
+| 162 = @namespace // The 'namespace' keyword
+| 8 = @newLine // A newline (one of '\n', '\r', or '\r\n').
+| 51 = @not // The logical not operator '-not'.
+| 4 = @number // Any numerical literal token. Tokens with this kind are always instances of NumberToken.
+| 54 = @or // The logical or operator '-or'.
+| 27 = @orOr // The (unimplemented) operator '||'.
+| 152 = @parallel // The 'parallel' keyword.
+| 140 = @param // The 'param' keyword.
+| 3 = @parameter_token // A parameter to a command, always begins with a dash ('-'), followed by the parameter name. Tokens with this kind are always instances of ParameterToken.
+| 29 = @pipe // The pipe operator '|'.
+| 40 = @plus // The addition operator '+'.
+| 43 = @plusEquals // The addition assignment operator '+='.
+| 32 = @plusPlus // The pre-increment operator '++'.
+| 96 = @postfixMinusMinus // The post-decrement operator '--'.
+| 95 = @postfixPlusPlus // The post-increment operator '++'.
+| 158 = @private // The 'private' keyword
+| 141 = @process // The 'process' keyword.
+| 157 = @public // The 'public' keyword
+| 103 = @questionDot // The null conditional member access operator '?.'.
+| 104 = @questionLBracket // The null conditional index access operator '?[]'.
+| 100 = @questionMark // The ternary operator '?'.
+| 102 = @questionQuestion // The null coalesce operator '??'.
+| 101 = @questionQuestionEquals // The null conditional assignment operator '??='.
+| 21 = @rBracket // The closing square brace token ']'.
+| 19 = @rCurly // The closing curly brace token '}'.
+| 49 = @redirectInStd // The (unimplemented) stdin redirection operator '<'.
+| 48 = @redirection_token // A redirection operator such as '2>&1' or '>>'.
+| 39 = @rem // The modulo division (remainder) operator '%'.
+| 47 = @remainderEquals // The modulo division (remainder) assignment operator '%='.
+| 142 = @return // The 'return' keyword.
+| 17 = @rParen // The closing parenthesis token ')'.
+| 25 = @semi // The statement terminator ';'.
+| 153 = @sequence // The 'sequence' keyword.
+| 97 = @shl // The shift left operator.
+| 98 = @shr // The shift right operator.
+| 2 = @splattedVariable // A splatted variable token, always begins with '@' and followed by the variable name. Tokens with this kind are always instances of VariableToken.
+| 159 = @static // The 'static' keyword
+| 13 = @stringExpandable // A double quoted string literal. Tokens with this kind are always instances of StringExpandableToken even if there are no nested tokens to expand.
+| 12 = @stringLiteral_token // A single quoted string literal. Tokens with this kind are always instances of StringLiteralToken.
+| 143 = @switch // The 'switch' keyword.
+| 144 = @throw // The 'throw' keyword.
+| 145 = @trap // The 'trap' keyword.
+| 146 = @try // The 'try' keyword.
+| 164 = @type // The 'type' keyword
+| 0 = @unknown // An unknown token, signifies an error condition.
+| 147 = @until // The 'until' keyword.
+| 148 = @using // The (unimplemented) 'using' keyword.
+| 149 = @var // The (unimplemented) 'var' keyword.
+| 1 = @variable // A variable token, always begins with '$' and followed by the variable name, possibly enclose in curly braces. Tokens with this kind are always instances of VariableToken.
+| 150 = @while // The 'while' keyword.
+| 151 = @workflow // The 'workflow' keyword.
+| 55 = @xor; // The logical exclusive or operator '-xor'.

--- a/powershell/ql/lib/upgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/upgrade.properties
+++ b/powershell/ql/lib/upgrades/802d5b9f407fb0dac894df1c0b4584f2215e1512/upgrade.properties
@@ -1,0 +1,2 @@
+description: Add is_in_psmodule_path relation
+compatibility: full


### PR DESCRIPTION
PowerShell has a peculiar feature of "implicit module imports".

From https://learn.microsoft.com/en-us/powershell/scripting/developer/module/importing-a-powershell-module?view=powershell-7.4#implicitly-importing-a-module-powershell-30:

> [...] modules are imported automatically when any cmdlet or function in the module is used in a command. This feature works on any module in a directory that is included in the value of the PSModulePath environment variable.

So when we see an invocation such as:
```
Foo 42
```
this may refer to a command defined in a file totally outside the source directory, and will be implicitly loaded into the current Powershell session.

To handle such scenarios this PR does several things:
- It adds extraction of the files inside the directories pointed to by the `PSModulePath` environment variable. This can be disabled via a command-line argument to the extractor, but is enabled by default.
- It adds `.psd1` to the list of file extensions to extract, which are module manifest files. These module manifest files contain the information necessary to detect this "implicit loading"
- Finally, we add a new extensional to check whether a source file was found via the `PSModulePath` environment variable.