### PR TITLE
PS: #132 follow-up

### DIFF
--- a/powershell/codeql-extractor.yml
+++ b/powershell/codeql-extractor.yml
@@ -8,3 +8,10 @@ file_types:
     display_name: powershellscripts
     extensions:
       - .ps1
+      - .psd1
+options:
+  skip_psmodulepath_files:
+    title: Skip PSModulePath files.
+    description: Whether to avoid extracting source files in paths specified by the PSModulePath environment variable.
+    type: string
+    pattern: "^(false|true)$"

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Options.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -121,6 +122,24 @@ namespace Semmle.Extraction.PowerShell.Standalone
         }
 
         /// <summary>
+        /// Returns true if the extractor should skip files in the PSModulePath because the
+        /// environment variable CODEQL_EXTRACTOR_POWERSHELL_OPTION_SKIP_PSMODULEPATH_FILES
+        /// is set to a truthy value.
+        /// </summary>
+        private static bool GetDefaultSkipPSModulePathFiles()
+        {
+            var skip = System.Environment.GetEnvironmentVariable(
+                "CODEQL_EXTRACTOR_POWERSHELL_OPTION_SKIP_PSMODULEPATH_FILES"
+            );
+            bool b = skip != null && skip.ToLower() != "false";
+            if (b)
+            {
+                System.Console.WriteLine("Skipping files in PSModulePath");
+            }
+            return b;
+        }
+
+        /// <summary>
         /// The directory or file containing the source code;
         /// </summary>
         public FileInfo[] Files { get; set; } = GetDefaultFiles();
@@ -134,7 +153,7 @@ namespace Semmle.Extraction.PowerShell.Standalone
         /// Whether to extract files in the paths found in the `PSModulePath`
         /// environment variable.
         /// </summary>
-        public bool SkipPSModulePathFiles { get; private set; } = false;
+        public bool SkipPSModulePathFiles { get; private set; } = GetDefaultSkipPSModulePathFiles();
 
         /// <summary>
         /// Whether errors were encountered parsing the arguments.
@@ -172,9 +191,13 @@ namespace Semmle.Extraction.PowerShell.Standalone
                 "    --exclude:xxx                Exclude a file or directory (can be specified multiple times)"
             );
             output.WriteLine("    --dry-run                    Stop before extraction");
-            output.WriteLine("    --threads:nnn                Specify number of threads (default=CPU cores)");
+            output.WriteLine(
+                "    --threads:nnn                Specify number of threads (default=CPU cores)"
+            );
             output.WriteLine("    --verbose                    Produce more output");
-            output.WriteLine("    --skip-psmodulepath-files    Avoid extracting source files in paths specified by the PSModulePath environment variable.");
+            output.WriteLine(
+                "    --skip-psmodulepath-files    Avoid extracting source files in paths specified by the PSModulePath environment variable."
+            );
         }
 
         private Options() { }

--- a/powershell/tools/qltest.cmd
+++ b/powershell/tools/qltest.cmd
@@ -6,6 +6,7 @@ type NUL && "%CODEQL_DIST%\codeql.exe" database index-files ^
     --size-limit=5m ^
     --language=powershell ^
     --working-dir=. ^
+    --extractor-option="powershell.skip_psmodulepath_files=true" ^
     "%CODEQL_EXTRACTOR_POWERSHELL_WIP_DATABASE%"
 
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
This PR is a follow-up to https://github.com/microsoft/codeql/pull/132 which I merged earlier this morning. In that PR, we started extracting Powershell files found via the `PSModulePath` environment variable, and added a CLI parameter to selectively disable this feature.

However, I forgot to add an official "extractor option" to control this. Without this extractor option it's not possible to disable `PSModulePath` extraction when running `codeql test run`. We need to disable `PSModulePath` extraction when running `codeql test run` to ensure that the tests are independent of the environment in which the tests are run.