### PR TITLE
Powershell: Fix dataflow library after GitHub changes

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/FlowSummaryImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/FlowSummaryImpl.qll
@@ -10,7 +10,13 @@ private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
 
 module Input implements InputSig<Location, DataFlowImplSpecific::PowershellDataFlow> {
+  private import codeql.util.Void
+
   class SummarizedCallableBase = string;
+
+  class SourceBase = Void;
+
+  class SinkBase = Void;
 
   ArgumentPosition callbackSelfParameterPosition() { none() }
 
@@ -114,6 +120,10 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     or
     result.asCall().getAstNode() = sc.(LibraryCallable).getACallSimple()
   }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+
+  Node getSinkNode(Input::SinkBase source, Impl::Private::SummaryComponent sc) { none() }
 }
 
 module Private {

--- a/powershell/ql/lib/semmle/code/powershell/typetracking/TypeTracking.qll
+++ b/powershell/ql/lib/semmle/code/powershell/typetracking/TypeTracking.qll
@@ -3,5 +3,6 @@
  * for tracking types.
  */
 
+private import powershell
 private import semmle.code.powershell.typetracking.internal.TypeTrackingImpl as Impl
-import Impl::Shared::TypeTracking<Impl::TypeTrackingInput>
+import Impl::Shared::TypeTracking<Location, Impl::TypeTrackingInput>

--- a/powershell/ql/lib/semmle/code/powershell/typetracking/internal/TypeTrackingImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/typetracking/internal/TypeTrackingImpl.qll
@@ -157,7 +157,7 @@ private module TypeTrackerSummaryFlow = SummaryTypeTracker::SummaryFlow<SummaryT
 
 private newtype TContentFilter = MkElementFilter()
 
-module TypeTrackingInput implements Shared::TypeTrackingInput {
+module TypeTrackingInput implements Shared::TypeTrackingInput<Location> {
   class Node = DataFlowPublic::Node;
 
   class LocalSourceNode = DataFlowPublic::LocalSourceNode;
@@ -295,4 +295,4 @@ module TypeTrackingInput implements Shared::TypeTrackingInput {
   predicate hasFeatureBacktrackStoreTarget() { none() }
 }
 
-import SharedImpl::TypeTracking<TypeTrackingInput>
+import SharedImpl::TypeTracking<Location, TypeTrackingInput>


### PR DESCRIPTION
This was caused by two PRs on github/codeql:
- https://github.com/github/codeql/pull/18298
- https://github.com/github/codeql/pull/17787

On the GitHub side, it's the responsibility of the author of the changes to a shared library to make sure that the users of the shared library still works. However, as GitHub doesn't have PowerShell checks running in their CI it's not possible for them to do this. So we need to keep this up ourselves!

Luckily, such changes tend to be pretty trivial to fix. And indeed they are also easily fixable here.

Note that this PR will actually _not work_ until we bump our own fork as above PRs haven't been merged into our fork yet.

cc @dilanbhalla 