### PR TITLE
Shared: Refactor `DataFlowStack`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -255,27 +255,9 @@ class DataFlowCall extends Expr instanceof Call {
    */
   Expr getArgument(int n) { result = super.getArgument(n) }
 
-  /** Gets an argument to this call. */
-  Expr getAnArgument(){ result = super.getAnArgument() }
-
-  /** Gets an argument to this call as a Node. */
-  ArgumentNode getAnArgumentNode(){ result = this.getNode() }
-
   /** Gets the data flow node corresponding to this call. */
   ExprNode getNode() { result.getExpr() = this }
 
-  /** Gets the data flow node corresponding to this call. (Alias of `getNode()`) */
-  ExprNode getDataFlowNode() { result = this.getNode() }
-
-  /** Gets the target of the call, as best as makes sense for this kind of call.
-   * 
-   * The precise meaning depends on the kind of call it is:
-   *   - For a call to a function, it’s the function being called.
-   *   - For a C++ method call, it’s the statically resolved method.
-   *   - For an Objective C message expression, it’s the statically resolved method, and it might not exist.
-   *   - For a variable call, it never exists.
-   */
-  DataFlowCallable getARuntimeTarget(){ result = super.getTarget() }
   /** Gets the enclosing callable of this call. */
   DataFlowCallable getEnclosingCallable() { result = this.getEnclosingFunction() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1058,16 +1058,6 @@ class DataFlowCallable extends TDataFlowCallable {
     result = this.asSummarizedCallable() or // SummarizedCallable = Function (in CPP)
     result = this.asSourceCallable()
   }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
-        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
-      |
-        c order by file, startline, startcolumn
-      )
-  }
 }
 
 /**
@@ -1169,23 +1159,6 @@ class DataFlowCall extends TDataFlowCall {
    * Gets the location of this call.
    */
   Location getLocation() { none() }
-
-  // #43: Stub Implementation
-  /** Gets an argument to this call as a Node. */
-  ArgumentNode getAnArgumentNode(){ none() } // TODO: JB1 return an argument as a DataFlow ArgumentNode
-
-  // #43: Stub Implementation
-  /** Gets the target of the call, as a DataFlowCallable. */
-  DataFlowCallable getARuntimeTarget(){ none() } // TODO getCallTarget() returns `Instruction`
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCall c, int startline, int startcolumn |
-        c.getLocation().hasLocationInfo(_, startline, startcolumn, _, _)
-      |
-        c order by startline, startcolumn
-      )
-  }
 }
 
 /**
@@ -1280,15 +1253,6 @@ module IsUnreachableInCall {
     string toString() { result = "NodeRegion" }
 
     predicate contains(Node n) { this = n.getBasicBlock() }
-
-    int totalOrder() {
-      this =
-        rank[result](IRBlock b, int startline, int startcolumn |
-          b.getLocation().hasLocationInfo(_, startline, startcolumn, _, _)
-        |
-          b order by startline, startcolumn
-        )
-    }
   }
 
   predicate isUnreachableInCall(NodeRegion block, DataFlowCall call) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/DataFlowStack.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/DataFlowStack.qll
@@ -1,15 +1,36 @@
-
 import csharp
 private import codeql.dataflow.DataFlow
 private import semmle.code.csharp.dataflow.internal.DataFlowImplSpecific
-
 private import codeql.dataflowstack.DataFlowStack as DFS
 private import DFS::DataFlowStackMake<Location, CsharpDataFlow> as DataFlowStackFactory
 
-module DataFlowStackMake<DataFlowStackFactory::DataFlow::GlobalFlowSig Flow>{
-    import DataFlowStackFactory::FlowStack<Flow>
+private module DataFlowStackInput<DataFlowStackFactory::DataFlow::ConfigSig Config> implements
+  DFS::DataFlowStackSig<Location, CsharpDataFlow, Config>
+{
+  private module Flow = DataFlow::Global<Config>;
+
+  CsharpDataFlow::Node getNode(Flow::PathNode n) { result = n.getNode() }
+
+  predicate isSource(Flow::PathNode n) { n.isSource() }
+
+  Flow::PathNode getASuccessor(Flow::PathNode n) { result = n.getASuccessor() }
+
+  CsharpDataFlow::DataFlowCallable getARuntimeTarget(CsharpDataFlow::DataFlowCall call) {
+    result = call.getARuntimeTarget()
+  }
+
+  CsharpDataFlow::Node getAnArgumentNode(CsharpDataFlow::DataFlowCall call) {
+    result = call.getArgument(_)
+  }
 }
 
-module BiStackAnalysisMake<DataFlowStackFactory::DataFlow::GlobalFlowSig FlowA, DataFlowStackFactory::DataFlow::GlobalFlowSig FlowB>{
-    import DataFlowStackFactory::BiStackAnalysis<FlowA, FlowB>
+module DataFlowStackMake<DataFlowStackFactory::DataFlow::ConfigSig Config> {
+  import DataFlowStackFactory::FlowStack<Config, DataFlowStackInput<Config>>
+}
+
+module BiStackAnalysisMake<
+  DataFlowStackFactory::DataFlow::ConfigSig ConfigA,
+  DataFlowStackFactory::DataFlow::ConfigSig ConfigB>
+{
+  import DataFlowStackFactory::BiStackAnalysis<ConfigA, DataFlowStackInput<ConfigA>, ConfigB, DataFlowStackInput<ConfigB>>
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -288,16 +288,6 @@ class DataFlowCallable extends TDataFlowCallable {
     or
     result = this.asCapturedVariable().getLocation()
   }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
-        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
-      |
-        c order by file, startline, startcolumn
-      )
-  }
 }
 
 /** A call relevant for data flow. */
@@ -323,9 +313,6 @@ abstract class DataFlowCall extends TDataFlowCall {
   /** Gets the argument at position `pos` of this call. */
   final ArgumentNode getArgument(ArgumentPosition pos) { result.argumentOf(this, pos) }
 
-  /** Gets an argument of this call. */
-  final ArgumentNode getAnArgumentNode() { result.argumentOf(this, _) }
-
   /** Gets a textual representation of this call. */
   abstract string toString();
 
@@ -343,16 +330,6 @@ abstract class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCall c, int startline, int startcolumn |
-        c.hasLocationInfo(_, startline, startcolumn, _, _)
-      |
-        c order by startline, startcolumn
-      )
   }
 }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -315,16 +315,6 @@ class DataFlowCallable extends TDataFlowCallable {
     result = this.asFileScope().getLocation() or
     result = getCallableLocation(this.asSummarizedCallable())
   }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
-        c.hasLocationInfo(file, startline, startcolumn, _, _)
-      |
-        c order by file, startline, startcolumn
-      )
-  }
 }
 
 private Location getCallableLocation(Callable c) {
@@ -358,23 +348,6 @@ class DataFlowCall extends Expr {
 
   /** Gets the location of this call. */
   Location getLocation() { result = super.getLocation() }
-
-  // #45 - Stub Implementation
-  /** Gets an argument to this call as a Node. */
-  ArgumentNode getAnArgumentNode(){ result = this.getArgument(_) }
-
-  /** Gets the target of the call, as a DataFlowCallable. */
-  DataFlowCallable getARuntimeTarget(){ result.asCallable() = call.getACalleeIncludingExternals() }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCall c, int startline, int startcolumn |
-        c.getLocation().hasLocationInfo(_, startline, startcolumn, _, _)
-      |
-        c order by startline, startcolumn
-      )
-  }
 }
 
 /** Holds if `e` is an expression that always has the same Boolean value `val`. */
@@ -417,15 +390,6 @@ class NodeRegion instanceof BasicBlock {
   string toString() { result = "NodeRegion" }
 
   predicate contains(Node n) { n.getBasicBlock() = this }
-
-  int totalOrder() {
-    this =
-      rank[result](BasicBlock b, int startline, int startcolumn |
-        b.hasLocationInfo(_, startline, startcolumn, _, _)
-      |
-        b order by startline, startcolumn
-      )
-  }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -423,21 +423,6 @@ predicate cloneStep(Node n1, Node n2) {
 bindingset[node1, node2]
 predicate validParameterAliasStep(Node node1, Node node2) { not cloneStep(node1, node2) }
 
-private predicate id_member(Member x, Member y) { x = y }
-
-private predicate idOf_member(Member x, int y) = equivalenceRelation(id_member/2)(x, y)
-
-private int summarizedCallableId(SummarizedCallable c) {
-  c =
-    rank[result](SummarizedCallable c0, int b, int i, string s |
-      b = 0 and idOf_member(c0.asCallable(), i) and s = ""
-      or
-      b = 1 and i = 0 and s = c0.asSyntheticCallable()
-    |
-      c0 order by b, i, s
-    )
-}
-
 private newtype TDataFlowCallable =
   TSrcCallable(Callable c) or
   TSummarizedCallable(SummarizedCallable c) or
@@ -471,27 +456,9 @@ class DataFlowCallable extends TDataFlowCallable {
     result = this.asSummarizedCallable().getLocation() or
     result = this.asFieldScope().getLocation()
   }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCallable c, int b, int i |
-        b = 0 and idOf_member(c.asCallable(), i)
-        or
-        b = 1 and i = summarizedCallableId(c.asSummarizedCallable())
-        or
-        b = 2 and idOf_member(c.asFieldScope(), i)
-      |
-        c order by b, i
-      )
-  }
 }
 
 class DataFlowExpr = Expr;
-
-private predicate id_call(Call x, Call y) { x = y }
-
-private predicate idOf_call(Call x, int y) = equivalenceRelation(id_call/2)(x, y)
 
 private newtype TDataFlowCall =
   TCall(Call c) or
@@ -524,29 +491,6 @@ class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-
-  /** Gets an argument to this call as a Node. */
-  ArgumentNode getAnArgumentNode(){
-    result = exprNode(this.asCall().getAnArgument())
-  }
-
-  /** Gets the target of the call, as a DataFlowCallable. */
-  DataFlowCallable getARuntimeTarget(){
-    result.asCallable() = this.asCall().getCallee()
-  }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCall c, int b, int i |
-        b = 0 and idOf_call(c.asCall(), i)
-        or
-        b = 1 and // not guaranteed to be total
-        exists(SummarizedCallable sc | c = TSummaryCall(sc, _) and i = summarizedCallableId(sc))
-      |
-        c order by b, i
-      )
   }
 }
 
@@ -582,16 +526,10 @@ class SummaryCall extends DataFlowCall, TSummaryCall {
   override Location getLocation() { result = c.getLocation() }
 }
 
-private predicate id(BasicBlock x, BasicBlock y) { x = y }
-
-private predicate idOf(BasicBlock x, int y) = equivalenceRelation(id/2)(x, y)
-
 class NodeRegion instanceof BasicBlock {
   string toString() { result = "NodeRegion" }
 
   predicate contains(Node n) { n.asExpr().getBasicBlock() = this }
-
-  int totalOrder() { idOf(this, result) }
 }
 
 /** Holds if `e` is an expression that always has the same Boolean value `val`. */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
@@ -347,16 +347,6 @@ abstract class DataFlowCallable extends TDataFlowCallable {
 
   /** Gets the location of this dataflow callable. */
   abstract Location getLocation();
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
-        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
-      |
-        c order by file, startline, startcolumn
-      )
-  }
 }
 
 /** A callable function. */
@@ -1438,23 +1428,6 @@ abstract class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-
-  // #47: Stubs below
-  /** Gets an argument to this call as a Node. */
-  ArgumentNode getAnArgumentNode(){ none() } // TODO: JB1 return an argument as a DataFlow ArgumentNode
-
-  /** Gets the target of the call, as a DataFlowCallable. */
-  DataFlowCallable getARuntimeTarget(){ none() } // TODO
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCall c, int startline, int startcolumn |
-        c.hasLocationInfo(_, startline, startcolumn, _, _)
-      |
-        c order by startline, startcolumn
-      )
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -93,14 +93,6 @@ module SsaFlow {
     result = TSelfToplevelParameterNode(p.asToplevelSelf())
   }
 
-  ParameterNodeImpl toParameterNodeImpl(SsaDefinitionExtNode node) {
-    exists(SsaImpl::WriteDefinition def, SsaImpl::ParameterExt p |
-      def = node.getDefinitionExt() and
-      result = toParameterNode(p) and
-      p.isInitializedBy(def)
-    )
-  }
-
   Impl::Node asNode(Node n) {
     n = TSsaNode(result)
     or
@@ -702,9 +694,7 @@ private module Cached {
 
   cached
   newtype TDataFlowType =
-    TModuleDataFlowType(Module m) or
     TLambdaDataFlowType(Callable c) { c = any(LambdaSelfReferenceNode n).getCallable() } or
-    TCollectionType() or
     TUnknownDataFlowType()
 }
 
@@ -1893,83 +1883,21 @@ predicate expectsContent(Node n, ContentSet c) {
 }
 
 class DataFlowType extends TDataFlowType {
-  string toString() {
-    exists(Module m |
-      this = TModuleDataFlowType(m) and
-      result = m.toString()
-    )
-    or
-    this = TLambdaDataFlowType(_) and result = "[lambda]"
-    or
-    this = TCollectionType() and result = "[collection]"
-    or
-    this = TUnknownDataFlowType() and
-    result = ""
-  }
-
-  predicate isUnknown() { this = TUnknownDataFlowType() }
-
-  Location getLocation() {
-    exists(Module m |
-      this = TModuleDataFlowType(m) and
-      result = m.getLocation()
-    )
-    or
-    exists(Callable c | this = TLambdaDataFlowType(c) and result = c.getLocation())
-  }
+  string toString() { result = "" }
 }
-
-pragma[nomagic]
-private predicate isProcClass(DataFlowType t) {
-  t = TModuleDataFlowType(any(TypeInference::ProcClass m))
-}
-
-pragma[nomagic]
-private predicate isArrayClass(DataFlowType t) {
-  t = TModuleDataFlowType(any(TypeInference::ArrayClass m).getADescendent())
-}
-
-pragma[nomagic]
-private predicate isHashClass(DataFlowType t) {
-  t = TModuleDataFlowType(any(TypeInference::HashClass m).getADescendent())
-}
-
-private predicate isCollectionClass(DataFlowType t) { isArrayClass(t) or isHashClass(t) }
 
 predicate typeStrongerThan(DataFlowType t1, DataFlowType t2) {
-  not t1.isUnknown() and
-  t2.isUnknown()
-  or
-  exists(Module m1, Module m2 |
-    t1 = TModuleDataFlowType(m1) and
-    t2 = TModuleDataFlowType(m2) and
-    m1.getAnImmediateAncestor+() = m2
-  )
-  or
-  t1 instanceof TLambdaDataFlowType and
-  isProcClass(t2)
+  t1 != TUnknownDataFlowType() and
+  t2 = TUnknownDataFlowType()
 }
 
-private predicate mustHaveLambdaType(Node n, Callable c) {
+private predicate mustHaveLambdaType(ExprNode n, Callable c) {
   exists(VariableCapture::ClosureExpr ce, CfgNodes::ExprCfgNode e |
     e = n.asExpr() and ce.hasBody(c)
   |
     e = ce or
     ce.hasAliasedAccess(e)
   )
-  or
-  n.(CaptureNode).getSynthesizedCaptureNode().isInstanceAccess() and
-  c = n.(CaptureNode).getSynthesizedCaptureNode().getEnclosingCallable()
-}
-
-private predicate mustHaveCollectionType(Node n, DataFlowType t) {
-  exists(ContentSet c | readStep(n, c, _) or storeStep(_, c, n) or expectsContent(n, c) |
-    c.isElement() and
-    t = TCollectionType()
-  ) and
-  not n instanceof SynthHashSplatOrSplatArgumentNode and
-  not n instanceof SynthHashSplatParameterNode and
-  not n instanceof SynthSplatParameterNode
 }
 
 predicate localMustFlowStep(Node node1, Node node2) { none() }
@@ -1983,40 +1911,15 @@ DataFlowType getNodeType(Node n) {
     result = TLambdaDataFlowType(c)
   )
   or
-  mustHaveCollectionType(n, result)
-  or
   not n instanceof LambdaSelfReferenceNode and
   not mustHaveLambdaType(n, _) and
-  not mustHaveCollectionType(n, _) and
-  (
-    TypeInference::hasModuleType(n, result)
-    or
-    not TypeInference::hasModuleType(n, _) and
-    result.isUnknown()
-  )
+  result = TUnknownDataFlowType()
 }
 
-pragma[nomagic]
+pragma[inline]
 private predicate compatibleTypesNonSymRefl(DataFlowType t1, DataFlowType t2) {
-  not t1.isUnknown() and
-  t2.isUnknown()
-  or
-  t1 instanceof TLambdaDataFlowType and
-  isProcClass(t2)
-  or
-  t1 instanceof TCollectionType and
-  isCollectionClass(t2)
-}
-
-pragma[nomagic]
-private predicate compatibleModuleTypes(TModuleDataFlowType t1, TModuleDataFlowType t2) {
-  exists(Module m1, Module m2, Module m3 |
-    t1 = TModuleDataFlowType(m1) and
-    t2 = TModuleDataFlowType(m2)
-  |
-    m3.getAnAncestor() = m1 and
-    m3.getAnAncestor() = m2
-  )
+  t1 != TUnknownDataFlowType() and
+  t2 = TUnknownDataFlowType()
 }
 
 /**
@@ -2029,8 +1932,6 @@ predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
   compatibleTypesNonSymRefl(t1, t2)
   or
   compatibleTypesNonSymRefl(t2, t1)
-  or
-  compatibleModuleTypes(t1, t2)
 }
 
 abstract class PostUpdateNodeImpl extends Node {
@@ -2090,11 +1991,7 @@ private import PostUpdateNodes
 
 /** A node that performs a type cast. */
 class CastNode extends Node {
-  CastNode() {
-    TypeInference::hasAdjacentTypeCheckedRead(this.asExpr(), _)
-    or
-    TypeInference::asModulePattern(this.(SsaDefinitionNode).getDefinition(), _)
-  }
+  CastNode() { none() }
 }
 
 /**
@@ -2122,8 +2019,6 @@ class NodeRegion instanceof Unit {
   string toString() { result = "NodeRegion" }
 
   predicate contains(Node n) { none() }
-
-  int totalOrder() { result = 1 }
 }
 
 /**
@@ -2295,246 +2190,4 @@ class AdditionalJumpStep extends Unit {
    * Holds if data can flow from `pred` to `succ` in a way that discards call contexts.
    */
   abstract predicate step(Node pred, Node succ);
-}
-
-/** Provides logic for assigning types to data flow nodes. */
-module TypeInference {
-  private import codeql.ruby.ast.internal.Module
-  private import DataFlowDispatch
-
-  /** The built-in `Proc` class. */
-  class ProcClass extends Module {
-    ProcClass() { this = TResolved("Proc") }
-  }
-
-  /** The built-in `Array` class. */
-  class ArrayClass extends Module {
-    ArrayClass() { this = TResolved("Array") }
-  }
-
-  /** The built-in `Hash` class. */
-  class HashClass extends Module {
-    HashClass() { this = TResolved("Hash") }
-  }
-
-  /** The built-in `String` class. */
-  class StringClass extends Module {
-    StringClass() { this = TResolved("String") }
-  }
-
-  /** Holds if `self` belongs to the top-level. */
-  pragma[nomagic]
-  private predicate selfInToplevel(SelfVariable self, Module m) {
-    ViewComponentRenderModeling::selfInErbToplevel(self, m)
-    or
-    not ViewComponentRenderModeling::selfInErbToplevel(self, _) and
-    self.getDeclaringScope() instanceof Toplevel and
-    m = TResolved("Object")
-  }
-
-  /**
-   * Holds if SSA definition `def` belongs to a variable introduced via pattern
-   * matching on type `m`. For example, in
-   *
-   * ```rb
-   * case object
-   *   in C => c then c.foo
-   * end
-   * ```
-   *
-   * the SSA definition for `c` is introduced by matching on `C`.
-   */
-  predicate asModulePattern(Ssa::WriteDefinition def, Module m) {
-    exists(AsPattern ap |
-      m = resolveConstantReadAccess(ap.getPattern()) and
-      def.getWriteAccess().getAstNode() = ap.getVariableAccess()
-    )
-  }
-
-  /**
-   * Holds if `caseRead` and `read` are reads of SSA definition `def`,
-   * and `read` is checked to have type `m`. For example, in
-   *
-   * ```rb
-   * case object
-   *   when C then object.foo
-   * end
-   * ```
-   *
-   * the second read of `object` is known to have type `C`.
-   */
-  private predicate hasTypeCheckedRead(
-    Ssa::Definition def, CfgNodes::ExprCfgNode caseRead, CfgNodes::ExprCfgNode read, Module m
-  ) {
-    exists(
-      CfgNodes::ExprCfgNode pattern, ConditionBlock cb, CfgNodes::ExprNodes::CaseExprCfgNode case
-    |
-      m = resolveConstantReadAccess(pattern.getExpr()) and
-      cb.getLastNode() = pattern and
-      cb.controls(read.getBasicBlock(),
-        any(SuccessorTypes::MatchingSuccessor match | match.getValue() = true)) and
-      caseRead = def.getARead() and
-      read = def.getARead() and
-      case.getValue() = caseRead
-    |
-      pattern = case.getBranch(_).(CfgNodes::ExprNodes::WhenClauseCfgNode).getPattern(_)
-      or
-      pattern = case.getBranch(_).(CfgNodes::ExprNodes::InClauseCfgNode).getPattern()
-    )
-  }
-
-  predicate hasAdjacentTypeCheckedRead(CfgNodes::ExprCfgNode read, Module m) {
-    exists(Ssa::Definition def, CfgNodes::ExprCfgNode caseRead |
-      hasTypeCheckedRead(def, caseRead, read, m) and
-      def.hasAdjacentReads(caseRead, read)
-    )
-  }
-
-  private predicate isTypeCheckedRead(CfgNodes::ExprCfgNode read, Module m) {
-    exists(Ssa::Definition def |
-      hasTypeCheckedRead(def, _, read, m) and
-      // could in principle be checked against a new type
-      not exists(CfgNodes::ExprCfgNode innerCaseRead |
-        hasTypeCheckedRead(def, _, innerCaseRead, m) and
-        hasTypeCheckedRead(def, innerCaseRead, read, _)
-      )
-    )
-  }
-
-  pragma[nomagic]
-  private predicate selfInMethodOrToplevelHasType(SelfVariable self, Module tp, boolean exact) {
-    exists(MethodBase m |
-      selfInMethod(self, m, tp) and
-      not m instanceof SingletonMethod and
-      if m.getEnclosingModule() instanceof Toplevel then exact = true else exact = false
-    )
-    or
-    selfInToplevel(self, tp) and
-    exact = true
-  }
-
-  pragma[nomagic]
-  private predicate parameterNodeHasType(ParameterNodeImpl p, Module tp, boolean exact) {
-    exists(ParameterPosition pos |
-      p.isParameterOf(_, pos) and
-      exact = true
-    |
-      (pos.isSplat(_) or pos.isSynthSplat(_)) and
-      tp instanceof ArrayClass
-      or
-      (pos.isHashSplat() or pos.isSynthHashSplat()) and
-      tp instanceof HashClass
-    )
-    or
-    selfInMethodOrToplevelHasType(p.(SelfParameterNodeImpl).getSelfVariable(), tp, exact)
-  }
-
-  pragma[nomagic]
-  private predicate ssaDefHasType(SsaDefinitionExtNode def, Module tp, boolean exact) {
-    exists(ParameterNodeImpl p |
-      parameterNodeHasType(p, tp, exact) and
-      p = SsaFlow::toParameterNodeImpl(def)
-    )
-    or
-    selfInMethodOrToplevelHasType(def.getVariable(), tp, exact)
-    or
-    asModulePattern(def.getDefinitionExt(), tp) and
-    exact = false
-  }
-
-  pragma[nomagic]
-  private predicate hasTypeNoCall(Node n, Module tp, boolean exact) {
-    n.asExpr().getExpr() instanceof NilLiteral and
-    tp = TResolved("NilClass") and
-    exact = true
-    or
-    n.asExpr().getExpr().(BooleanLiteral).isFalse() and
-    tp = TResolved("FalseClass") and
-    exact = true
-    or
-    n.asExpr().getExpr().(BooleanLiteral).isTrue() and
-    tp = TResolved("TrueClass") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof IntegerLiteral and
-    tp = TResolved("Integer") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof FloatLiteral and
-    tp = TResolved("Float") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof RationalLiteral and
-    tp = TResolved("Rational") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof ComplexLiteral and
-    tp = TResolved("Complex") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof StringlikeLiteral and
-    tp instanceof StringClass and
-    exact = true
-    or
-    (
-      n.asExpr() instanceof CfgNodes::ExprNodes::ArrayLiteralCfgNode or
-      n instanceof SynthSplatArgumentNode
-    ) and
-    tp instanceof ArrayClass and
-    exact = true
-    or
-    (
-      n.asExpr() instanceof CfgNodes::ExprNodes::HashLiteralCfgNode
-      or
-      n instanceof SynthHashSplatArgumentNode
-    ) and
-    tp instanceof HashClass and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof MethodBase and
-    tp = TResolved("Symbol") and
-    exact = true
-    or
-    (
-      n.asParameter() instanceof BlockParameter
-      or
-      n instanceof BlockParameterNode
-      or
-      n.asExpr().getExpr() instanceof Lambda
-    ) and
-    tp instanceof ProcClass and
-    exact = true
-    or
-    parameterNodeHasType(n, tp, exact)
-    or
-    exists(SsaDefinitionExtNode def | ssaDefHasType(def, tp, exact) |
-      n = def or
-      n.asExpr() =
-        any(CfgNodes::ExprCfgNode read |
-          read = def.getDefinitionExt().getARead() and
-          not isTypeCheckedRead(read, _) // could in principle be checked against a new type
-        )
-    )
-    or
-    // `case object when C then object.foo`
-    isTypeCheckedRead(n.asExpr(), tp) and
-    exact = false
-  }
-
-  pragma[nomagic]
-  private predicate hasTypeCall(Node n, Module tp, boolean exact) {
-    isStandardNewCall(n.asExpr(), tp, exact)
-  }
-
-  pragma[inline]
-  predicate hasType(Node n, Module tp, boolean exact) {
-    hasTypeNoCall(n, tp, exact)
-    or
-    hasTypeCall(n, tp, exact)
-  }
-
-  pragma[nomagic]
-  predicate hasModuleType(Node n, DataFlowType t) {
-    exists(Module tp | t = TModuleDataFlowType(tp) | hasType(n, tp, _))
-  }
 }

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -69,14 +69,6 @@ signature module InputSig<LocationSig Location> {
   Node exprNode(DataFlowExpr e);
 
   class DataFlowCall {
-
-    /**
-     * Gets a run-time target of this call. A target is always a source
-     * declaration, and if the callable has both CIL and source code, only
-     * the source code version is returned.
-     */
-    DataFlowCallable getARuntimeTarget();
-
     /** Gets a textual representation of this element. */
     string toString();
 
@@ -84,11 +76,6 @@ signature module InputSig<LocationSig Location> {
     Location getLocation();
 
     DataFlowCallable getEnclosingCallable();
-
-    ArgumentNode getAnArgumentNode();
-
-    /** Gets a best-effort total ordering. */
-    int totalorder();
   }
 
   class DataFlowCallable {
@@ -97,9 +84,6 @@ signature module InputSig<LocationSig Location> {
 
     /** Gets the location of this callable. */
     Location getLocation();
-
-    /** Gets a best-effort total ordering. */
-    int totalorder();
   }
 
   class ReturnKind {
@@ -274,8 +258,6 @@ signature module InputSig<LocationSig Location> {
   class NodeRegion {
     /** Holds if this region contains `n`. */
     predicate contains(Node n);
-
-    int totalOrder();
   }
 
   /**
@@ -460,6 +442,28 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
      * are used directly in a query result.
      */
     default predicate observeDiffInformedIncrementalMode() { none() }
+
+    /**
+     * Gets a location that will be associated with the given `source` in a
+     * diff-informed query that uses this configuration (see
+     * `observeDiffInformedIncrementalMode`). By default, this is the location
+     * of the source itself, but this predicate should include any locations
+     * that are reported as the primary-location of the query or as an
+     * additional location ("$@" interpolation). For a query that doesn't
+     * report the source at all, this predicate can be `none()`.
+     */
+    default Location getASelectedSourceLocation(Node source) { result = source.getLocation() }
+
+    /**
+     * Gets a location that will be associated with the given `sink` in a
+     * diff-informed query that uses this configuration (see
+     * `observeDiffInformedIncrementalMode`). By default, this is the location
+     * of the sink itself, but this predicate should include any locations
+     * that are reported as the primary-location of the query or as an
+     * additional location ("$@" interpolation). For a query that doesn't
+     * report the sink at all, this predicate can be `none()`.
+     */
+    default Location getASelectedSinkLocation(Node sink) { result = sink.getLocation() }
   }
 
   /** An input configuration for data flow using flow state. */
@@ -587,6 +591,28 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
      * are used directly in a query result.
      */
     default predicate observeDiffInformedIncrementalMode() { none() }
+
+    /**
+     * Gets a location that will be associated with the given `source` in a
+     * diff-informed query that uses this configuration (see
+     * `observeDiffInformedIncrementalMode`). By default, this is the location
+     * of the source itself, but this predicate should include any locations
+     * that are reported as the primary-location of the query or as an
+     * additional location ("$@" interpolation). For a query that doesn't
+     * report the source at all, this predicate can be `none()`.
+     */
+    default Location getASelectedSourceLocation(Node source) { result = source.getLocation() }
+
+    /**
+     * Gets a location that will be associated with the given `sink` in a
+     * diff-informed query that uses this configuration (see
+     * `observeDiffInformedIncrementalMode`). By default, this is the location
+     * of the sink itself, but this predicate should include any locations
+     * that are reported as the primary-location of the query or as an
+     * additional location ("$@" interpolation). For a query that doesn't
+     * report the sink at all, this predicate can be `none()`.
+     */
+    default Location getASelectedSinkLocation(Node sink) { result = sink.getLocation() }
   }
 }
 
@@ -633,16 +659,7 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
      * A `Node` augmented with a call context (except for sinks) and an access path.
      * Only those `PathNode`s that are reachable from a source, and which can reach a sink, are generated.
      */
-    class PathNode{
-      /** Gets the underlying Node. */
-      Node getNode();
-
-      /** Holds if this node is a source. */
-      predicate isSource();
-
-      /** Gets a successor of this node, if any. */
-      PathNode getASuccessor();
-    }
+    class PathNode;
 
     /**
      * Holds if data can flow from `source` to `sink`.
@@ -726,9 +743,6 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
     /** Gets the underlying `Node`. */
     Node getNode();
 
-    /** Holds if this node is a source. */
-    predicate isSource();
-
     /** Gets the location of this node. */
     Location getLocation();
   }
@@ -780,15 +794,6 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
         string filepath, int startline, int startcolumn, int endline, int endcolumn
       ) {
         this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-      }
-
-      predicate isSource(){
-        this.asPathNode1().isSource() or
-        this.asPathNode2().isSource()
-      }
-
-      PathNode getASuccessor(){
-        none()
       }
     }
 
@@ -861,16 +866,6 @@ module DataFlowMake<LocationSig Location, InputSig<Location> Lang> {
 
       /** Gets the underlying `Node`. */
       Node getNode() { result = super.getNode() }
-
-      predicate isSource(){
-        this.asPathNode1().isSource() or
-        this.asPathNode2().isSource() or
-        this.asPathNode3().isSource()
-      }
-
-      PathNode getASuccessor(){
-        none()
-      }
 
       /** Gets the location of this node. */
       Location getLocation() { result = super.getLocation() }

--- a/shared/dataflowstack/codeql/dataflowstack/DataFlowStack.qll
+++ b/shared/dataflowstack/codeql/dataflowstack/DataFlowStack.qll
@@ -1,390 +1,386 @@
-
 private import codeql.dataflow.DataFlow as DF
 private import codeql.util.Location
 
-module DataFlowStackMake<LocationSig Location, DF::InputSig<Location> Lang>{
+module DataFlowStackMake<LocationSig Location, DF::InputSig<Location> Lang> {
+  import DF::DataFlowMake<Location, Lang> as DataFlow
 
-    import DF::DataFlowMake<Location,Lang> as DataFlow
+  module BiStackAnalysis<DataFlow::GlobalFlowSig FlowA, DataFlow::GlobalFlowSig FlowB> {
+    module FlowStackA = FlowStack<FlowA>;
 
-    module BiStackAnalysis<DataFlow::GlobalFlowSig FlowA, DataFlow::GlobalFlowSig FlowB>{
+    module FlowStackB = FlowStack<FlowB>;
 
-        module FlowStackA = FlowStack<FlowA>;
-        module FlowStackB = FlowStack<FlowB>;
-
-        /**
-         * Holds if either the Stack associated with `sourceNodeA` is a subset of the stack associated with `sourceNodeB`
-         * or vice-versa.
-         */
-        predicate eitherStackSubset(FlowA::PathNode sourceNodeA, FlowA::PathNode sinkNodeA, FlowB::PathNode sourceNodeB, FlowB::PathNode sinkNodeB){
-            FlowStackA::isSource(sourceNodeA) and
-            FlowStackB::isSource(sourceNodeB) and
-            FlowStackA::isSink(sinkNodeA) and
-            FlowStackB::isSink(sinkNodeB) and
-            exists(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB |
-                flowStackA  = FlowStackA::createFlowStack(sourceNodeA, sinkNodeA) and
-                flowStackB  = FlowStackB::createFlowStack(sourceNodeB, sinkNodeB) and (
-                    BiStackAnalysisImpl<FlowA, FlowB>::flowStackIsSubsetOf(flowStackA, flowStackB)
-                    or
-                    BiStackAnalysisImpl<FlowB, FlowA>::flowStackIsSubsetOf(flowStackB, flowStackA)
-                )
-
-            )
-        }
-
-        /**
-         * Holds if the stack associated with path `sourceNodeA` is a subset (and shares a common stack bottom) with
-         * the stack associated with path `sourceNodeB`, or vice-versa.
-         * 
-         * For the given pair of (source, sink) for two (potentially disparate) DataFlows,
-         * determine whether one Flow's Stack (at time of sink execution) is a subset of the other flow's Stack.
-         */
-        predicate eitherStackTerminatingSubset(FlowA::PathNode sourceNodeA, FlowA::PathNode sinkNodeA, FlowB::PathNode sourceNodeB, FlowB::PathNode sinkNodeB){
-            FlowStackA::isSource(sourceNodeA) and
-            FlowStackB::isSource(sourceNodeB) and
-            FlowStackA::isSink(sinkNodeA) and
-            FlowStackB::isSink(sinkNodeB) and
-            exists(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB |
-                flowStackA = FlowStackA::createFlowStack(sourceNodeA, sinkNodeA) and
-                flowStackB = FlowStackB::createFlowStack(sourceNodeB, sinkNodeB) and (
-                    BiStackAnalysisImpl<FlowA, FlowB>::flowStackIsConvergingTerminatingSubsetOf(flowStackA, flowStackB)
-                    or
-                    BiStackAnalysisImpl<FlowB, FlowA>::flowStackIsConvergingTerminatingSubsetOf(flowStackB, flowStackA)
-                )
-            )
-        }
-
-        /**
-         * Alias for BiStackAnalysisImpl<FlowA,FlowB>::flowStackIsSubsetOf
-         * 
-         * Holds if stackA is a subset of stackB,
-         * The top of stackA is in stackB and the bottom of stackA is then some successor further down stackB.
-         */
-        predicate flowStackIsSubsetOf(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB){
-            BiStackAnalysisImpl<FlowA,FlowB>::flowStackIsSubsetOf(flowStackA, flowStackB)
-        }
-
-        /**
-         * Alias for BiStackAnalysisImpl<FlowA,FlowB>::flowStackIsConvergingTerminatingSubsetOf
-         * 
-         * If the top of stackA is in stackB at any location, and the bottoms of the stack are the same call.
-         */
-        predicate flowStackIsConvergingTerminatingSubsetOf(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB){
-            BiStackAnalysisImpl<FlowA,FlowB>::flowStackIsConvergingTerminatingSubsetOf(flowStackA, flowStackB)
-        }
+    /**
+     * Holds if either the Stack associated with `sourceNodeA` is a subset of the stack associated with `sourceNodeB`
+     * or vice-versa.
+     */
+    predicate eitherStackSubset(
+      FlowA::PathNode sourceNodeA, FlowA::PathNode sinkNodeA, FlowB::PathNode sourceNodeB,
+      FlowB::PathNode sinkNodeB
+    ) {
+      FlowStackA::isSource(sourceNodeA) and
+      FlowStackB::isSource(sourceNodeB) and
+      FlowStackA::isSink(sinkNodeA) and
+      FlowStackB::isSink(sinkNodeB) and
+      exists(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB |
+        flowStackA = FlowStackA::createFlowStack(sourceNodeA, sinkNodeA) and
+        flowStackB = FlowStackB::createFlowStack(sourceNodeB, sinkNodeB) and
+        (
+          BiStackAnalysisImpl<FlowA, FlowB>::flowStackIsSubsetOf(flowStackA, flowStackB)
+          or
+          BiStackAnalysisImpl<FlowB, FlowA>::flowStackIsSubsetOf(flowStackB, flowStackA)
+        )
+      )
     }
 
-    private module BiStackAnalysisImpl<DataFlow::GlobalFlowSig FlowA, DataFlow::GlobalFlowSig FlowB>{
-
-        module FlowStackA = FlowStack<FlowA>;
-        module FlowStackB = FlowStack<FlowB>;
-
-        /**
-         * Holds if stackA is a subset of stackB,
-         * The top of stackA is in stackB and the bottom of stackA is then some successor further down stackB.
-         */
-        predicate flowStackIsSubsetOf(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB){
-            exists(FlowStackA::FlowStackFrame highestStackFrameA, FlowStackB::FlowStackFrame highestStackFrameB |
-                highestStackFrameA = flowStackA.getTopFrame() and
-                highestStackFrameB = flowStackB.getTopFrame() and
-                // Check if some intermediary frame `intStackFrameB`of StackB is in the stack of highestStackFrameA
-                exists(FlowStackB::FlowStackFrame intStackFrameB |
-                    intStackFrameB = highestStackFrameB.getASucceedingTerminalStateFrame*() and
-                    sharesCallWith(highestStackFrameA, intStackFrameB) and
-                    sharesCallWith(flowStackA.getTerminalFrame(), intStackFrameB.getASucceedingTerminalStateFrame*())
-                )
-            )
-        }
-
-        /**
-         * If the top of stackA is in stackB at any location, and the bottoms of the stack are the same call.
-         */
-        predicate flowStackIsConvergingTerminatingSubsetOf(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB){
-            flowStackA.getTerminalFrame().getCall() = flowStackB.getTerminalFrame().getCall() and
-            exists(FlowStackB::FlowStackFrame intStackFrameB |
-                intStackFrameB = flowStackB.getTopFrame().getASucceedingTerminalStateFrame*() and
-                sharesCallWith(flowStackA.getTopFrame(), intStackFrameB)
-            )
-        }
-
-        /**
-         * Holds if the given FlowStackFrames share the same call.
-         * i.e. they are both arguments of the same function call.
-         */
-        predicate sharesCallWith(FlowStackA::FlowStackFrame frameA, FlowStackB::FlowStackFrame frameB){
-            frameA.getCall() = frameB.getCall()
-        }
+    /**
+     * Holds if the stack associated with path `sourceNodeA` is a subset (and shares a common stack bottom) with
+     * the stack associated with path `sourceNodeB`, or vice-versa.
+     *
+     * For the given pair of (source, sink) for two (potentially disparate) DataFlows,
+     * determine whether one Flow's Stack (at time of sink execution) is a subset of the other flow's Stack.
+     */
+    predicate eitherStackTerminatingSubset(
+      FlowA::PathNode sourceNodeA, FlowA::PathNode sinkNodeA, FlowB::PathNode sourceNodeB,
+      FlowB::PathNode sinkNodeB
+    ) {
+      FlowStackA::isSource(sourceNodeA) and
+      FlowStackB::isSource(sourceNodeB) and
+      FlowStackA::isSink(sinkNodeA) and
+      FlowStackB::isSink(sinkNodeB) and
+      exists(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB |
+        flowStackA = FlowStackA::createFlowStack(sourceNodeA, sinkNodeA) and
+        flowStackB = FlowStackB::createFlowStack(sourceNodeB, sinkNodeB) and
+        (
+          BiStackAnalysisImpl<FlowA, FlowB>::flowStackIsConvergingTerminatingSubsetOf(flowStackA,
+            flowStackB)
+          or
+          BiStackAnalysisImpl<FlowB, FlowA>::flowStackIsConvergingTerminatingSubsetOf(flowStackB,
+            flowStackA)
+        )
+      )
     }
 
-    module FlowStack<DataFlow::GlobalFlowSig Flow>{
-
-        /** Determines whether or not the given PathNode is a source 
-         * TODO: Refactor to Flow::PathNode signature */
-        predicate isSource(Flow::PathNode node){
-            node.isSource()
-        }
-
-        /** Determines whether or not the given PathNode is a sink
-         * TODO: Refactor to Flow::PathNode signature */ 
-        predicate isSink(Flow::PathNode node){
-            not exists(node.getASuccessor())
-        }
-
-        /** A FlowStack encapsulates flows between a source and a sink, and all the pathways inbetween (possibly multiple) */
-        private newtype FlowStackType =
-            TFlowStack(Flow::PathNode source, Flow::PathNode sink){
-                source.isSource() and
-                not exists(sink.getASuccessor()) and
-                source.getASuccessor*() = sink
-            }
-
-        class FlowStack extends FlowStackType, TFlowStack{
-            string toString(){
-                result = "FlowStack"
-            }
-
-            /**
-             * Get the first frame in the DataFlowStack, irregardless of whether or not it has a parent.
-             */
-            FlowStackFrame getFirstFrame(){
-                exists(FlowStackFrame flowStackFrame, CallFrame frame |
-                    flowStackFrame = TFlowStackFrame(this, frame) and
-                    not exists(frame.getPredecessor()) and
-                    result = flowStackFrame
-                )
-            }
-
-            /**
-             * Get the top frame in the DataFlowStack, ie the frame that is the highest in the stack for the given flow.
-             */
-            FlowStackFrame getTopFrame(){
-                exists(FlowStackFrame flowStackFrame |
-                    flowStackFrame = TFlowStackFrame(this, _) and
-                    not exists(flowStackFrame.getParentStackFrame()) and
-                    result = flowStackFrame
-                )
-            }
-
-            /**
-             * Get the terminal frame in the DataFlowStack, ie the frame that is the end of the flow.
-             */
-            FlowStackFrame getTerminalFrame(){
-                exists(FlowStackFrame flowStackFrame, CallFrame frame |
-                    flowStackFrame = TFlowStackFrame(this, frame) and
-                    not exists(frame.getSuccessor()) and
-                    result = flowStackFrame
-                )
-            }
-        }
-
-        FlowStack createFlowStack(Flow::PathNode source, Flow::PathNode sink){
-            result = TFlowStack(source, sink)
-        }
-
-        /** A FlowStackFrame encapsulates a Stack frame that is bound between a given source and sink. */
-        private newtype FlowStackFrameType =
-            TFlowStackFrame(FlowStack flowStack, CallFrame frame){
-                exists(Flow::PathNode source, Flow::PathNode sink |
-                    flowStack = TFlowStack(source, sink) and
-                    frame.getPathNode() = source.getASuccessor*() and
-                    frame.getPathNode().getASuccessor*() = sink
-                )
-            }
-
-        class FlowStackFrame extends FlowStackFrameType, TFlowStackFrame{
-            string toString(){
-                result = "FlowStackFrame"
-            }
-
-            /**
-             * Get the next frame in the DataFlow Stack
-             */
-            FlowStackFrame getASuccessor(){
-                exists(FlowStack flowStack, CallFrame frame, CallFrame nextFrame |
-                    this = TFlowStackFrame(flowStack, frame) and
-                    nextFrame = frame.getSuccessor() and
-                    result = TFlowStackFrame(flowStack, nextFrame)
-                )
-            }
-
-            /**
-             * Gets the next FlowStackFrame from the direct descendents that is a frame in the end-state (terminal) stack.
-             */
-            FlowStackFrame getASucceedingTerminalStateFrame(){
-                result = this.getChildStackFrame() and
-                // There are no other direct children that are further in the flow
-                not result.getASuccessor+() = this.getChildStackFrame()
-            }
-
-            /**
-             * Gets a predecessor FlowStackFrame of this FlowStackFrame.
-             */
-            FlowStackFrame getAPredecessor(){
-                result.getASuccessor() = this
-            }
-
-            /**
-             * Gets a predecessor FlowStackFrame that is a parent in the stack.
-             */
-            FlowStackFrame getParentStackFrame(){
-                result.getChildStackFrame() = this
-            }
-
-            /**
-             * Gets the set of succeeding FlowStackFrame which are a direct descendant of this frame in the Stack.
-             */
-            FlowStackFrame getChildStackFrame(){
-                exists(FlowStackFrame transitiveSuccessor |
-                    transitiveSuccessor = this.getASuccessor+() and
-                    this.getCall().getARuntimeTarget() = transitiveSuccessor.getCall().getEnclosingCallable() and
-                    result = transitiveSuccessor
-                )
-            }
-
-            /**
-             * Unpacks the PathNode associated with this FlowStackFrame
-             */
-            Flow::PathNode getPathNode(){
-                exists(CallFrame callFrame |
-                    this = TFlowStackFrame(_, callFrame) and
-                    result = callFrame.getPathNode()
-                )
-            }
-
-            /**
-             * Unpacks the DataFlowCall associated with this FlowStackFrame
-             */
-            Lang::DataFlowCall getCall(){
-                result = this.getCallFrame().getCall()
-            }
-
-            /**
-             * Unpacks the CallFrame associated with this FlowStackFrame
-             */
-            CallFrame getCallFrame(){
-                this = TFlowStackFrame(_, result)
-            }
-        }
-
-
-        /**
-         * A CallFrame is a PathNode that represents a (DataFlowCall/Accessor).
-         */
-        private newtype TCallFrameType =
-            TCallFrame(Flow::PathNode node) {
-                exists(Lang::DataFlowCall c |
-                    c.getAnArgumentNode() = node.getNode()
-                )
-            }
-
-        /**
-         * The CallFrame is a PathNode that represents an argument to a Call.
-         */
-        private class CallFrame extends TCallFrameType, TCallFrame{
-            string toString(){
-                exists(Lang::DataFlowCall call |
-                    call = this.getCall() and
-                    result = call.toString()
-                )
-            }
-
-            /**
-             * Find the set of CallFrames that are immediate successors of this CallFrame.
-             */
-            CallFrame getSuccessor(){
-                result = TCallFrame(getSuccessorCall(this.getPathNode()))
-            }
-
-            /**
-             * Find the set of CallFrames that are an immediate predecessor of this CallFrame.
-             */
-            CallFrame getPredecessor(){
-                exists(CallFrame prior |
-                    prior.getSuccessor() = this and
-                    result = prior  
-                )
-            }
-
-            /**
-             * Unpack the CallFrame and retrieve the associated DataFlowCall.
-             */
-            Lang::DataFlowCall getCall(){
-                exists(Lang::DataFlowCall call, Flow::PathNode node |
-                    this = TCallFrame(node) and
-                    call.getAnArgumentNode() = node.getNode() and
-                    result = call
-                )
-            }
-
-            /**
-             * Unpack the CallFrame and retrieve the associated PathNode.
-             */
-            Flow::PathNode getPathNode(){
-                exists(Flow::PathNode n |
-                    this = TCallFrame(n) and
-                    result = n
-                )
-            }
-        }
-
-        /**
-         * From the given PathNode argument, find the set of successors that are an argument in a DataFlowCall,
-         * and return them as the result.
-         */
-        private Flow::PathNode getSuccessorCall(Flow::PathNode n){
-            exists(Flow::PathNode succ |
-                succ = n.getASuccessor() and
-                if exists(Lang::DataFlowCall c | c.getAnArgumentNode() = succ.getNode())
-                then result = succ
-                else result = getSuccessorCall(succ)
-            )
-        }
-
-        /**
-         * A user-supplied predicate which given a Stack Frame, returns some Node associated with it.
-         */
-        signature Lang::Node extractNodeFromFrame(Flow::PathNode pathNode);
-
-        /**
-         * Provides some higher-order predicates for analyzing Stacks
-         */
-        module StackFrameAnalysis<extractNodeFromFrame/1 customFrameCond>{
-
-            /**
-             * Find the highest stack frame that satisfies the given predicate,
-             * and return the Node(s) that the user-supplied predicate returns.
-             * 
-             * There should be no higher stack frame that satisfies the user-supplied predicate FROM the point that the
-             * argument .
-             */
-            Lang::Node extractingFromHighestStackFrame(FlowStack flowStack){
-                exists(FlowStackFrame topStackFrame, FlowStackFrame someStackFrame |
-                    topStackFrame = flowStack.getTopFrame() and
-                    someStackFrame = topStackFrame.getASuccessor*() and
-                    result = customFrameCond(someStackFrame.getPathNode()) and
-                    not exists(FlowStackFrame predecessor |
-                        predecessor = someStackFrame.getAPredecessor+() and
-                        // The predecessor is *not* prior to the user-given 'top' of the stack frame.
-                        not predecessor = topStackFrame.getAPredecessor+() and
-                        exists(customFrameCond(predecessor.getPathNode()))
-                    )
-                )
-            }
-
-            /**
-             * Find the lowest stack frame that satisfies the given predicate,
-             * and return the Node(s) that the user-supplied predicate returns.
-             */
-            Lang::Node extractingFromLowestStackFrame(FlowStack flowStack){
-                exists(FlowStackFrame topStackFrame, FlowStackFrame someStackFrame |
-                    topStackFrame = flowStack.getTopFrame() and
-                    someStackFrame = topStackFrame.getChildStackFrame*() and
-                    result = customFrameCond(someStackFrame.getPathNode()) and
-                    not exists(FlowStackFrame successor |
-                        successor = someStackFrame.getChildStackFrame+() and
-                        exists(customFrameCond(successor.getPathNode()))
-                    )
-                )
-            }
-        }
+    /**
+     * Alias for BiStackAnalysisImpl<FlowA,FlowB>::flowStackIsSubsetOf
+     *
+     * Holds if stackA is a subset of stackB,
+     * The top of stackA is in stackB and the bottom of stackA is then some successor further down stackB.
+     */
+    predicate flowStackIsSubsetOf(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB) {
+      BiStackAnalysisImpl<FlowA, FlowB>::flowStackIsSubsetOf(flowStackA, flowStackB)
     }
-} 
+
+    /**
+     * Alias for BiStackAnalysisImpl<FlowA,FlowB>::flowStackIsConvergingTerminatingSubsetOf
+     *
+     * If the top of stackA is in stackB at any location, and the bottoms of the stack are the same call.
+     */
+    predicate flowStackIsConvergingTerminatingSubsetOf(
+      FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB
+    ) {
+      BiStackAnalysisImpl<FlowA, FlowB>::flowStackIsConvergingTerminatingSubsetOf(flowStackA,
+        flowStackB)
+    }
+  }
+
+  private module BiStackAnalysisImpl<DataFlow::GlobalFlowSig FlowA, DataFlow::GlobalFlowSig FlowB> {
+    module FlowStackA = FlowStack<FlowA>;
+
+    module FlowStackB = FlowStack<FlowB>;
+
+    /**
+     * Holds if stackA is a subset of stackB,
+     * The top of stackA is in stackB and the bottom of stackA is then some successor further down stackB.
+     */
+    predicate flowStackIsSubsetOf(FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB) {
+      exists(
+        FlowStackA::FlowStackFrame highestStackFrameA, FlowStackB::FlowStackFrame highestStackFrameB
+      |
+        highestStackFrameA = flowStackA.getTopFrame() and
+        highestStackFrameB = flowStackB.getTopFrame() and
+        // Check if some intermediary frame `intStackFrameB`of StackB is in the stack of highestStackFrameA
+        exists(FlowStackB::FlowStackFrame intStackFrameB |
+          intStackFrameB = highestStackFrameB.getASucceedingTerminalStateFrame*() and
+          sharesCallWith(highestStackFrameA, intStackFrameB) and
+          sharesCallWith(flowStackA.getTerminalFrame(),
+            intStackFrameB.getASucceedingTerminalStateFrame*())
+        )
+      )
+    }
+
+    /**
+     * If the top of stackA is in stackB at any location, and the bottoms of the stack are the same call.
+     */
+    predicate flowStackIsConvergingTerminatingSubsetOf(
+      FlowStackA::FlowStack flowStackA, FlowStackB::FlowStack flowStackB
+    ) {
+      flowStackA.getTerminalFrame().getCall() = flowStackB.getTerminalFrame().getCall() and
+      exists(FlowStackB::FlowStackFrame intStackFrameB |
+        intStackFrameB = flowStackB.getTopFrame().getASucceedingTerminalStateFrame*() and
+        sharesCallWith(flowStackA.getTopFrame(), intStackFrameB)
+      )
+    }
+
+    /**
+     * Holds if the given FlowStackFrames share the same call.
+     * i.e. they are both arguments of the same function call.
+     */
+    predicate sharesCallWith(FlowStackA::FlowStackFrame frameA, FlowStackB::FlowStackFrame frameB) {
+      frameA.getCall() = frameB.getCall()
+    }
+  }
+
+  module FlowStack<DataFlow::GlobalFlowSig Flow> {
+    /**
+     * Determines whether or not the given PathNode is a source
+     * TODO: Refactor to Flow::PathNode signature
+     */
+    predicate isSource(Flow::PathNode node) { node.isSource() }
+
+    /**
+     * Determines whether or not the given PathNode is a sink
+     * TODO: Refactor to Flow::PathNode signature
+     */
+    predicate isSink(Flow::PathNode node) { not exists(node.getASuccessor()) }
+
+    /** A FlowStack encapsulates flows between a source and a sink, and all the pathways inbetween (possibly multiple) */
+    private newtype FlowStackType =
+      TFlowStack(Flow::PathNode source, Flow::PathNode sink) {
+        source.isSource() and
+        not exists(sink.getASuccessor()) and
+        source.getASuccessor*() = sink
+      }
+
+    class FlowStack extends FlowStackType, TFlowStack {
+      string toString() { result = "FlowStack" }
+
+      /**
+       * Get the first frame in the DataFlowStack, irregardless of whether or not it has a parent.
+       */
+      FlowStackFrame getFirstFrame() {
+        exists(FlowStackFrame flowStackFrame, CallFrame frame |
+          flowStackFrame = TFlowStackFrame(this, frame) and
+          not exists(frame.getPredecessor()) and
+          result = flowStackFrame
+        )
+      }
+
+      /**
+       * Get the top frame in the DataFlowStack, ie the frame that is the highest in the stack for the given flow.
+       */
+      FlowStackFrame getTopFrame() {
+        exists(FlowStackFrame flowStackFrame |
+          flowStackFrame = TFlowStackFrame(this, _) and
+          not exists(flowStackFrame.getParentStackFrame()) and
+          result = flowStackFrame
+        )
+      }
+
+      /**
+       * Get the terminal frame in the DataFlowStack, ie the frame that is the end of the flow.
+       */
+      FlowStackFrame getTerminalFrame() {
+        exists(FlowStackFrame flowStackFrame, CallFrame frame |
+          flowStackFrame = TFlowStackFrame(this, frame) and
+          not exists(frame.getSuccessor()) and
+          result = flowStackFrame
+        )
+      }
+    }
+
+    FlowStack createFlowStack(Flow::PathNode source, Flow::PathNode sink) {
+      result = TFlowStack(source, sink)
+    }
+
+    /** A FlowStackFrame encapsulates a Stack frame that is bound between a given source and sink. */
+    private newtype FlowStackFrameType =
+      TFlowStackFrame(FlowStack flowStack, CallFrame frame) {
+        exists(Flow::PathNode source, Flow::PathNode sink |
+          flowStack = TFlowStack(source, sink) and
+          frame.getPathNode() = source.getASuccessor*() and
+          frame.getPathNode().getASuccessor*() = sink
+        )
+      }
+
+    class FlowStackFrame extends FlowStackFrameType, TFlowStackFrame {
+      string toString() { result = "FlowStackFrame" }
+
+      /**
+       * Get the next frame in the DataFlow Stack
+       */
+      FlowStackFrame getASuccessor() {
+        exists(FlowStack flowStack, CallFrame frame, CallFrame nextFrame |
+          this = TFlowStackFrame(flowStack, frame) and
+          nextFrame = frame.getSuccessor() and
+          result = TFlowStackFrame(flowStack, nextFrame)
+        )
+      }
+
+      /**
+       * Gets the next FlowStackFrame from the direct descendents that is a frame in the end-state (terminal) stack.
+       */
+      FlowStackFrame getASucceedingTerminalStateFrame() {
+        result = this.getChildStackFrame() and
+        // There are no other direct children that are further in the flow
+        not result.getASuccessor+() = this.getChildStackFrame()
+      }
+
+      /**
+       * Gets a predecessor FlowStackFrame of this FlowStackFrame.
+       */
+      FlowStackFrame getAPredecessor() { result.getASuccessor() = this }
+
+      /**
+       * Gets a predecessor FlowStackFrame that is a parent in the stack.
+       */
+      FlowStackFrame getParentStackFrame() { result.getChildStackFrame() = this }
+
+      /**
+       * Gets the set of succeeding FlowStackFrame which are a direct descendant of this frame in the Stack.
+       */
+      FlowStackFrame getChildStackFrame() {
+        exists(FlowStackFrame transitiveSuccessor |
+          transitiveSuccessor = this.getASuccessor+() and
+          this.getCall().getARuntimeTarget() = transitiveSuccessor.getCall().getEnclosingCallable() and
+          result = transitiveSuccessor
+        )
+      }
+
+      /**
+       * Unpacks the PathNode associated with this FlowStackFrame
+       */
+      Flow::PathNode getPathNode() {
+        exists(CallFrame callFrame |
+          this = TFlowStackFrame(_, callFrame) and
+          result = callFrame.getPathNode()
+        )
+      }
+
+      /**
+       * Unpacks the DataFlowCall associated with this FlowStackFrame
+       */
+      Lang::DataFlowCall getCall() { result = this.getCallFrame().getCall() }
+
+      /**
+       * Unpacks the CallFrame associated with this FlowStackFrame
+       */
+      CallFrame getCallFrame() { this = TFlowStackFrame(_, result) }
+    }
+
+    /**
+     * A CallFrame is a PathNode that represents a (DataFlowCall/Accessor).
+     */
+    private newtype TCallFrameType =
+      TCallFrame(Flow::PathNode node) {
+        exists(Lang::DataFlowCall c | c.getAnArgumentNode() = node.getNode())
+      }
+
+    /**
+     * The CallFrame is a PathNode that represents an argument to a Call.
+     */
+    private class CallFrame extends TCallFrameType, TCallFrame {
+      string toString() {
+        exists(Lang::DataFlowCall call |
+          call = this.getCall() and
+          result = call.toString()
+        )
+      }
+
+      /**
+       * Find the set of CallFrames that are immediate successors of this CallFrame.
+       */
+      CallFrame getSuccessor() { result = TCallFrame(getSuccessorCall(this.getPathNode())) }
+
+      /**
+       * Find the set of CallFrames that are an immediate predecessor of this CallFrame.
+       */
+      CallFrame getPredecessor() {
+        exists(CallFrame prior |
+          prior.getSuccessor() = this and
+          result = prior
+        )
+      }
+
+      /**
+       * Unpack the CallFrame and retrieve the associated DataFlowCall.
+       */
+      Lang::DataFlowCall getCall() {
+        exists(Lang::DataFlowCall call, Flow::PathNode node |
+          this = TCallFrame(node) and
+          call.getAnArgumentNode() = node.getNode() and
+          result = call
+        )
+      }
+
+      /**
+       * Unpack the CallFrame and retrieve the associated PathNode.
+       */
+      Flow::PathNode getPathNode() {
+        exists(Flow::PathNode n |
+          this = TCallFrame(n) and
+          result = n
+        )
+      }
+    }
+
+    /**
+     * From the given PathNode argument, find the set of successors that are an argument in a DataFlowCall,
+     * and return them as the result.
+     */
+    private Flow::PathNode getSuccessorCall(Flow::PathNode n) {
+      exists(Flow::PathNode succ |
+        succ = n.getASuccessor() and
+        if exists(Lang::DataFlowCall c | c.getAnArgumentNode() = succ.getNode())
+        then result = succ
+        else result = getSuccessorCall(succ)
+      )
+    }
+
+    /**
+     * A user-supplied predicate which given a Stack Frame, returns some Node associated with it.
+     */
+    signature Lang::Node extractNodeFromFrame(Flow::PathNode pathNode);
+
+    /**
+     * Provides some higher-order predicates for analyzing Stacks
+     */
+    module StackFrameAnalysis<extractNodeFromFrame/1 customFrameCond> {
+      /**
+       * Find the highest stack frame that satisfies the given predicate,
+       * and return the Node(s) that the user-supplied predicate returns.
+       *
+       * There should be no higher stack frame that satisfies the user-supplied predicate FROM the point that the
+       * argument .
+       */
+      Lang::Node extractingFromHighestStackFrame(FlowStack flowStack) {
+        exists(FlowStackFrame topStackFrame, FlowStackFrame someStackFrame |
+          topStackFrame = flowStack.getTopFrame() and
+          someStackFrame = topStackFrame.getASuccessor*() and
+          result = customFrameCond(someStackFrame.getPathNode()) and
+          not exists(FlowStackFrame predecessor |
+            predecessor = someStackFrame.getAPredecessor+() and
+            // The predecessor is *not* prior to the user-given 'top' of the stack frame.
+            not predecessor = topStackFrame.getAPredecessor+() and
+            exists(customFrameCond(predecessor.getPathNode()))
+          )
+        )
+      }
+
+      /**
+       * Find the lowest stack frame that satisfies the given predicate,
+       * and return the Node(s) that the user-supplied predicate returns.
+       */
+      Lang::Node extractingFromLowestStackFrame(FlowStack flowStack) {
+        exists(FlowStackFrame topStackFrame, FlowStackFrame someStackFrame |
+          topStackFrame = flowStack.getTopFrame() and
+          someStackFrame = topStackFrame.getChildStackFrame*() and
+          result = customFrameCond(someStackFrame.getPathNode()) and
+          not exists(FlowStackFrame successor |
+            successor = someStackFrame.getChildStackFrame+() and
+            exists(customFrameCond(successor.getPathNode()))
+          )
+        )
+      }
+    }
+  }
+}

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
@@ -65,16 +65,6 @@ class DataFlowCallable extends TDataFlowCallable {
   Callable::TypeRange getUnderlyingCallable() {
     result = this.asSummarizedCallable() or result = this.asSourceCallable()
   }
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCallable c, string file, int startline, int startcolumn |
-        c.getLocation().hasLocationInfo(file, startline, startcolumn, _, _)
-      |
-        c order by file, startline, startcolumn
-      )
-  }
 }
 
 cached
@@ -129,23 +119,6 @@ class DataFlowCall extends TDataFlowCall {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-
-  // #48: Stubs Below
-  /** Gets an argument to this call as a Node. */
-  ArgumentNode getAnArgumentNode(){ none() } // TODO: JB1 return an argument as a DataFlow ArgumentNode
-
-  /** Gets the target of the call, as a DataFlowCallable. */
-  DataFlowCallable getARuntimeTarget(){ none() } // TODO getCallTarget() returns `Instruction`
-
-  /** Gets a best-effort total ordering. */
-  int totalorder() {
-    this =
-      rank[result](DataFlowCall c, int startline, int startcolumn |
-        c.hasLocationInfo(_, startline, startcolumn, _, _)
-      |
-        c order by startline, startcolumn
-      )
   }
 }
 


### PR DESCRIPTION
This changes the `DataFlowStack` library so that we don't depend on our own modifications to the shared dataflow library.

This has caused us quite a lot of pain in the past. Hopefully we can avoid doing such modifications in t he future.

Commit-by-commit review recommended:
- The first commit gets rid of the Microsoft modifications to the GitHub dataflow files. It turns out that we have resolved merge conflicts incorrect for some languages for almost 6 months. So many of the files were actually very very old that wasn't being kept up-to-date with the latest developments on the GitHub side 😅 Hopefully we should only have clean merges from now on!
- The second commit autoformats the `DataFlowStack` library to make the diff of the last file smaller
- The last commit does the actual refactoring. Sadly, I had to duplicate some of the code to handle both taint-tracking and dataflow configurations. We can revisit this in the future.