### PR TITLE
Java: Update file that was forgotten in #157

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/DataFlowStack.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/DataFlowStack.qll
@@ -1,14 +1,36 @@
 import java
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.internal.DataFlowImplSpecific
-
 private import codeql.dataflowstack.DataFlowStack as DFS
 private import DFS::DataFlowStackMake<Location, JavaDataFlow> as DataFlowStackFactory
 
-module DataFlowStackMake<DataFlowStackFactory::DataFlow::GlobalFlowSig Flow>{
-    import DataFlowStackFactory::FlowStack<Flow>
+private module DataFlowStackInput<DataFlowStackFactory::DataFlow::ConfigSig Config> implements
+  DFS::DataFlowStackSig<Location, JavaDataFlow, Config>
+{
+  private module Flow = DataFlow::Global<Config>;
+
+  JavaDataFlow::Node getNode(Flow::PathNode n) { result = n.getNode() }
+
+  predicate isSource(Flow::PathNode n) { n.isSource() }
+
+  Flow::PathNode getASuccessor(Flow::PathNode n) { result = n.getASuccessor() }
+
+  JavaDataFlow::DataFlowCallable getARuntimeTarget(JavaDataFlow::DataFlowCall call) {
+    result.asCallable() = call.asCall().getCallee()
+  }
+
+  JavaDataFlow::Node getAnArgumentNode(JavaDataFlow::DataFlowCall call) {
+    result = JavaDataFlow::exprNode(call.asCall().getAnArgument())
+  }
 }
 
-module BiStackAnalysisMake<DataFlowStackFactory::DataFlow::GlobalFlowSig FlowA, DataFlowStackFactory::DataFlow::GlobalFlowSig FlowB>{
-    import DataFlowStackFactory::BiStackAnalysis<FlowA, FlowB>
+module DataFlowStackMake<DataFlowStackFactory::DataFlow::ConfigSig Config> {
+  import DataFlowStackFactory::FlowStack<Config, DataFlowStackInput<Config>>
+}
+
+module BiStackAnalysisMake<
+  DataFlowStackFactory::DataFlow::ConfigSig ConfigA,
+  DataFlowStackFactory::DataFlow::ConfigSig ConfigB>
+{
+  import DataFlowStackFactory::BiStackAnalysis<ConfigA, DataFlowStackInput<ConfigA>, ConfigB, DataFlowStackInput<ConfigB>>
 }

--- a/shared/dataflowstack/codeql/dataflowstack/DataFlowStack.qll
+++ b/shared/dataflowstack/codeql/dataflowstack/DataFlowStack.qll
@@ -236,7 +236,7 @@ module DataFlowStackMake<LocationSig Location, DF::InputSig<Location> Lang> {
         exists(Flow::PathNode source, Flow::PathNode sink |
           flowStack = TFlowStack(source, sink) and
           frame.getPathNode() = DataFlowStack::getASuccessor*(source) and
-          DataFlowStack::getASuccessor(frame.getPathNode()) = sink
+          DataFlowStack::getASuccessor*(frame.getPathNode()) = sink
         )
       }
 

--- a/shared/dataflowstack/codeql/dataflowstack/TaintTrackingStack.qll
+++ b/shared/dataflowstack/codeql/dataflowstack/TaintTrackingStack.qll
@@ -242,7 +242,7 @@ module TaintTrackingStackMake<
         exists(Flow::PathNode source, Flow::PathNode sink |
           flowStack = TFlowStack(source, sink) and
           frame.getPathNode() = TaintTrackingStack::getASuccessor*(source) and
-          TaintTrackingStack::getASuccessor(frame.getPathNode()) = sink
+          TaintTrackingStack::getASuccessor*(frame.getPathNode()) = sink
         )
       }
 


### PR DESCRIPTION
I forgot to update the Java version of this file when I did https://github.com/microsoft/codeql/pull/157 🤦 This should make the Java file equivalent (but not identical!) to the C# one.

Additionally, there was a missing transitive closure that I forgot in https://github.com/microsoft/codeql/pull/157. I've attached this fix to this PR as well