### PR TITLE
Microsoft Public Namespace Fix

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
@@ -5,7 +5,7 @@
  *              into account.
  * @kind problem
  * @problem.severity error
- * @id cpp/microsoft-public/leap-year/adding-365-days-per-year
+ * @id cpp/microsoft/microsoft-public/leap-year/adding-365-days-per-year
  * @precision medium
  * @tags leap-year
  *       correctness

--- a/cpp/ql/src/Likely Bugs/Leap Year/AntiPattern5InvalidLeapYearCheck.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/AntiPattern5InvalidLeapYearCheck.ql
@@ -3,7 +3,7 @@
  * @description An expression is used to check a year is presumably a leap year, but the conditions used are insufficient.
  * @kind problem
  * @problem.severity warning
- * @id cpp/microsoft-public/leap-year/invalid-leap-year-check
+ * @id cpp/microsoft/microsoft-public/leap-year/invalid-leap-year-check
  * @precision medium
  * @tags leap-year
  *       correctness

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYearConditionalLogic.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYearConditionalLogic.ql
@@ -3,7 +3,7 @@
  * @description Conditional logic is present for leap years and common years, potentially leading to untested code pathways.
  * @kind problem
  * @problem.severity warning
- * @id cpp/microsoft-public/leap-year/conditional-logic-branches
+ * @id cpp/microsoft/microsoft-public/leap-year/conditional-logic-branches
  * @precision medium
  * @tags leap-year
  *       correctness

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
@@ -3,7 +3,7 @@
  * @description A field that represents a year is being modified by an arithmetic operation, but no proper check for leap years can be detected afterwards.
  * @kind problem
  * @problem.severity warning
- * @id cpp/microsoft-public/leap-year/unchecked-after-arithmetic-year-modification
+ * @id cpp/microsoft/microsoft-public/leap-year/unchecked-after-arithmetic-year-modification
  * @precision medium
  * @tags leap-year
  *       correctness

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -5,7 +5,7 @@
  *              invalid dates.
  * @kind problem
  * @problem.severity warning
- * @id cpp/microsoft-public/leap-year/unchecked-return-value-for-time-conversion-function
+ * @id cpp/microsoft/microsoft-public/leap-year/unchecked-return-value-for-time-conversion-function
  * @precision medium
  * @tags leap-year
  *       correctness

--- a/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
@@ -4,7 +4,7 @@
  *              An access on a leap year could result in buffer overflow bugs.
  * @kind problem
  * @problem.severity warning
- * @id cpp/microsoft-public/leap-year/unsafe-array-for-days-of-the-year
+ * @id cpp/microsoft/microsoft-public/leap-year/unsafe-array-for-days-of-the-year
  * @precision low
  * @tags leap-year
  *       correctness

--- a/cpp/ql/src/Microsoft/Likely Bugs/Conversion/BadOverflowGuard.ql
+++ b/cpp/ql/src/Microsoft/Likely Bugs/Conversion/BadOverflowGuard.ql
@@ -9,7 +9,7 @@
  * @tags security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-191
- * @id cpp/microsoft-public/badoverflowguard
+ * @id cpp/microsoft/microsoft-public/badoverflowguard
  */
 
 import cpp

--- a/cpp/ql/src/Microsoft/Likely Bugs/Drivers/IncorrectUsageOfRtlCompareMemory.ql
+++ b/cpp/ql/src/Microsoft/Likely Bugs/Drivers/IncorrectUsageOfRtlCompareMemory.ql
@@ -1,5 +1,5 @@
 /**
- * @id cpp/microsoft-public/drivers/incorrect-usage-of-rtlcomparememory
+ * @id cpp/microsoft/microsoft-public/drivers/incorrect-usage-of-rtlcomparememory
  * @name Incorrect usage of RtlCompareMemory
  * @description `RtlCompareMemory` routine compares two blocks of memory and returns the number of bytes that match, not a boolean value indicating a full comparison like `RtlEqualMemory` does.
  *     This query detects the return value of `RtlCompareMemory` being handled as a boolean.

--- a/cpp/ql/src/Microsoft/Likely Bugs/SizeOfMisuse/ArgumentIsSizeofOrOperation.ql
+++ b/cpp/ql/src/Microsoft/Likely Bugs/SizeOfMisuse/ArgumentIsSizeofOrOperation.ql
@@ -1,5 +1,5 @@
 /**
- * @id cpp/microsoft-public/sizeof/sizeof-or-operation-as-argument
+ * @id cpp/microsoft/microsoft-public/sizeof/sizeof-or-operation-as-argument
  * @name Usage of an expression that is a binary operation, or sizeof call passed as an argument to a sizeof call
  * @description When the `expr` passed to `sizeof` is a binary operation, or a sizeof call, this is typically a sign that there is a confusion on the usage of sizeof.
  * @tags security

--- a/cpp/ql/src/Microsoft/Likely Bugs/SizeOfMisuse/SizeOfConstIntMacro.ql
+++ b/cpp/ql/src/Microsoft/Likely Bugs/SizeOfMisuse/SizeOfConstIntMacro.ql
@@ -1,5 +1,5 @@
 /**
- * @id cpp/microsoft-public/sizeof/const-int-argument
+ * @id cpp/microsoft/microsoft-public/sizeof/const-int-argument
  * @name Passing a constant integer macro to sizeof
  * @description The expression passed to sizeof is a macro that expands to an integer constant. A data type was likely intended instead.
  * @kind problem

--- a/cpp/ql/src/Microsoft/Security/Cryptography/BannedEncryption.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/BannedEncryption.ql
@@ -2,7 +2,7 @@
  * @name Weak cryptography
  * @description Finds explicit uses of symmetric encryption algorithms that are weak, obsolete, or otherwise unapproved.
  * @kind problem
- * @id cpp/microsoft-public/weak-crypto/banned-encryption-algorithms
+ * @id cpp/microsoft/microsoft-public/weak-crypto/banned-encryption-algorithms
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/Cryptography/BannedModesCAPI.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/BannedModesCAPI.ql
@@ -2,7 +2,7 @@
  * @name Weak cryptography
  * @description Finds explicit uses of block cipher chaining mode algorithms that are not approved. (CAPI)
  * @kind problem
- * @id cpp/microsoft-public/weak-crypto/capi/banned-modes
+ * @id cpp/microsoft/microsoft-public/weak-crypto/capi/banned-modes
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/Cryptography/BannedModesCNG.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/BannedModesCNG.ql
@@ -2,7 +2,7 @@
  * @name Weak cryptography
  * @description Finds explicit uses of block cipher chaining mode algorithms that are not approved. (CNG)
  * @kind problem
- * @id cpp/microsoft-public/weak-crypto/cng/banned-modes
+ * @id cpp/microsoft/microsoft-public/weak-crypto/cng/banned-modes
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/Cryptography/HardcodedIVCNG.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/HardcodedIVCNG.ql
@@ -2,7 +2,7 @@
  * @name Weak cryptography
  * @description Finds usage of a static (hardcoded) IV. (CNG)
  * @kind problem
- * @id cpp/microsoft-public/weak-crypto/cng/hardcoded-iv
+ * @id cpp/microsoft/microsoft-public/weak-crypto/cng/hardcoded-iv
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFBannedHashAlgorithm.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFBannedHashAlgorithm.ql
@@ -2,7 +2,7 @@
  * @name KDF may only use SHA256/384/512 in generating a key.
  * @description KDF may only use SHA256/384/512 in generating a key.
  * @kind problem
- * @id cpp/microsoft-public/kdf-insecure-hash
+ * @id cpp/microsoft/microsoft-public/kdf-insecure-hash
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFLowIterationCount.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFLowIterationCount.ql
@@ -7,7 +7,7 @@
  *      The rationale currently is that this query is meant to validate common uses of key derivation.
  *      Non-common uses (modifying the iteration count somehow or getting the count from outside sources) are assumed to be intentional.
  * @kind problem
- * @id cpp/microsoft-public/kdf-low-iteration-count
+ * @id cpp/microsoft/microsoft-public/kdf-low-iteration-count
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFSmallKeyLength.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFSmallKeyLength.ql
@@ -6,7 +6,7 @@
  *      The rationale currently is that this query is meant to validate common uses of key derivation.
  *      Non-common uses (modifying the values somehow or getting the count from outside sources) are assumed to be intentional.
  * @kind problem
- * @id cpp/microsoft-public/kdf-small-key-size
+ * @id cpp/microsoft/microsoft-public/kdf-small-key-size
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFSmallSaltSize.ql
+++ b/cpp/ql/src/Microsoft/Security/Cryptography/WeakKDFSmallSaltSize.ql
@@ -6,7 +6,7 @@
  *      The rationale currently is that this query is meant to validate common uses of key derivation.
  *      Non-common uses (modifying the values somehow or getting the count from outside sources) are assumed to be intentional.
  * @kind problem
- * @id cpp/microsoft-public/kdf-small-salt-size
+ * @id cpp/microsoft/microsoft-public/kdf-small-salt-size
  * @problem.severity error
  * @precision high
  * @tags security

--- a/cpp/ql/src/Microsoft/Security/MemoryAccess/EnumIndex/UncheckedBoundsEnumAsIndex.ql
+++ b/cpp/ql/src/Microsoft/Security/MemoryAccess/EnumIndex/UncheckedBoundsEnumAsIndex.ql
@@ -9,7 +9,7 @@
  * @kind problem
  * @problem.severity error
  * @precision high
- * @id cpp/microsoft-public/enum-index
+ * @id cpp/microsoft/microsoft-public/enum-index
  * @tags security
  *       external/cwe/cwe-125
  *       external/microsoft/c33010

--- a/cpp/ql/src/Microsoft/Security/Protocols/HardCodedSecurityProtocol.ql
+++ b/cpp/ql/src/Microsoft/Security/Protocols/HardCodedSecurityProtocol.ql
@@ -4,7 +4,7 @@
  *              risky because the protocol may become deprecated in future.
  * @kind problem
  * @problem.severity warning
- * @id cpp/microsoft-public/hardcoded-security-protocol
+ * @id cpp/microsoft/microsoft-public/hardcoded-security-protocol
  */
 
 import cpp

--- a/cpp/ql/src/Microsoft/Security/Protocols/UseOfDeprecatedSecurityProtocol.ql
+++ b/cpp/ql/src/Microsoft/Security/Protocols/UseOfDeprecatedSecurityProtocol.ql
@@ -3,7 +3,7 @@
  * @description Using a deprecated security protocol rather than the system default is risky.
  * @kind problem
  * @problem.severity error
- * @id cpp/microsoft-public/use-of-deprecated-security-protocol
+ * @id cpp/microsoft/microsoft-public/use-of-deprecated-security-protocol
  */
 
 import cpp

--- a/powershell/ql/src/experimental/CommandInjection.ql
+++ b/powershell/ql/src/experimental/CommandInjection.ql
@@ -2,7 +2,7 @@
  * @name Command Injection
  * @description Variable expression executed as command
  * @kind problem
- * @id powershell/microsoft-public/tainted-command
+ * @id powershell/microsoft/microsoft-public/tainted-command
  * @problem.severity warning
  * @precision low
  * @tags security

--- a/powershell/ql/src/queries/security/cwe-078/CommandInjection.ql
+++ b/powershell/ql/src/queries/security/cwe-078/CommandInjection.ql
@@ -6,7 +6,7 @@
  * @problem.severity error
  * @security-severity 9.8
  * @precision high
- * @id powershell/microsoft-public/command-injection
+ * @id powershell/microsoft/microsoft-public/command-injection
  * @tags correctness
  *       security
  *       external/cwe/cwe-078

--- a/powershell/ql/src/queries/security/cwe-078/DoNotUseInvokeExpression.ql
+++ b/powershell/ql/src/queries/security/cwe-078/DoNotUseInvokeExpression.ql
@@ -5,7 +5,7 @@
  * @problem.severity error
  * @security-severity 9.8
  * @precision high
- * @id powershell/microsoft-public/do-not-use-invoke-expression
+ * @id powershell/microsoft/microsoft-public/do-not-use-invoke-expression
  * @tags security
  */
 import powershell


### PR DESCRIPTION
Changing from `<language>/microsoft-public` to `<language>/microsoft/microsoft-public` as we are updating our namespacing convention to distinguish between Microsoft queries and GitHub queries (<language>/<company>/<namespace>)