### PR TITLE
PS: Match the changes from #18696

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/controlflow/BasicBlocks.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/BasicBlocks.qll
@@ -86,6 +86,29 @@ final class BasicBlock extends BasicBlocksImpl::BasicBlock {
   BasicBlock getImmediateDominator() { result = super.getImmediateDominator() }
 
   /**
+   * Holds if the edge with successor type `s` out of this basic block is a
+   * dominating edge for `dominated`.
+   *
+   * That is, all paths reaching `dominated` from the entry point basic
+   * block must go through the `s` edge out of this basic block.
+   *
+   * Edge dominance is similar to node dominance except it concerns edges
+   * instead of nodes: A basic block is dominated by a _basic block_ `bb` if it
+   * can only be reached through `bb` and dominated by an _edge_ `s` if it can
+   * only be reached through `s`.
+   *
+   * Note that where all basic blocks (except the entry basic block) are
+   * strictly dominated by at least one basic block, a basic block may not be
+   * dominated by any edge. If an edge dominates a basic block `bb`, then
+   * both endpoints of the edge dominates `bb`. The converse is not the case,
+   * as there may be multiple paths between the endpoints with none of them
+   * dominating.
+   */
+  predicate edgeDominates(BasicBlock dominated, SuccessorType s) {
+    super.edgeDominates(dominated, s)
+  }
+
+  /**
    * Holds if this basic block strictly post-dominates basic block `bb`.
    *
    * That is, all paths reaching a normal exit point basic block from basic
@@ -133,23 +156,4 @@ final class JoinBlockPredecessor extends BasicBlock, BasicBlocksImpl::JoinPredec
  * A basic block that terminates in a condition, splitting the subsequent
  * control flow.
  */
-final class ConditionBlock extends BasicBlock, BasicBlocksImpl::ConditionBasicBlock {
-  /**
-   * Holds if basic block `succ` is immediately controlled by this basic
-   * block with conditional value `s`. That is, `succ` is an immediate
-   * successor of this block, and `succ` can only be reached from
-   * the callable entry point by going via the `s` edge out of this basic block.
-   */
-  predicate immediatelyControls(BasicBlock succ, ConditionalSuccessor s) {
-    super.immediatelyControls(succ, s)
-  }
-
-  /**
-   * Holds if basic block `controlled` is controlled by this basic block with
-   * conditional value `s`. That is, `controlled` can only be reached from the
-   * callable entry point by going via the `s` edge out of this basic block.
-   */
-  predicate controls(BasicBlock controlled, ConditionalSuccessor s) {
-    super.controls(controlled, s)
-  }
-}
+final class ConditionBlock extends BasicBlock, BasicBlocksImpl::ConditionBasicBlock { }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/SsaImpl.qll
@@ -19,8 +19,6 @@ module SsaInput implements SsaImplCommon::InputSig<Location> {
 
   BasicBlock getABasicBlockSuccessor(BasicBlock bb) { result = bb.getASuccessor() }
 
-  class ExitBasicBlock extends BasicBlock, BasicBlocks::ExitBasicBlock { }
-
   class SourceVariable = LocalScopeVariable;
 
   /**


### PR DESCRIPTION
https://github.com/github/codeql/pull/18696 broke PowerShell. This PR fixes it by matching the changes made to other languages

As is normal from these PRs, this will fail until we run it on 2.20.5.

As a bonus, this PR also fixes an compilation warning in SSA caused by https://github.com/github/codeql/pull/18729. There are a few other harder-to-fix warnings caused by that PR, but I'll delay those until later when I've got more time to look into the necessary changes

cc @dilanbhalla 