### PR TITLE
Update .NET Version for Powershell Extractor to Net 9.0

### DIFF
--- a/powershell/.gitignore
+++ b/powershell/.gitignore
@@ -1,0 +1,2 @@
+extractor/**/bin/*
+extractor/**/obj/*

--- a/powershell/extractor/Microsoft.Extractor.Tests/Microsoft.Extractor.Tests.csproj
+++ b/powershell/extractor/Microsoft.Extractor.Tests/Microsoft.Extractor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/powershell/extractor/Microsoft.Extractor.Tests/Microsoft.Extractor.Tests.csproj
+++ b/powershell/extractor/Microsoft.Extractor.Tests/Microsoft.Extractor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Semmle.Extraction.PowerShell.Standalone.csproj
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Semmle.Extraction.PowerShell.Standalone.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	<AssemblyName>Semmle.Extraction.PowerShell.Standalone</AssemblyName>
 	<RootNamespace>Semmle.Extraction.PowerShell.Standalone</RootNamespace>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Semmle.Extraction.PowerShell.Standalone.csproj
+++ b/powershell/extractor/Semmle.Extraction.PowerShell.Standalone/Semmle.Extraction.PowerShell.Standalone.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<AssemblyName>Semmle.Extraction.PowerShell.Standalone</AssemblyName>
 	<RootNamespace>Semmle.Extraction.PowerShell.Standalone</RootNamespace>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockEntity.cs
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Entities/ScriptBlockEntity.cs
@@ -15,7 +15,8 @@ namespace Semmle.Extraction.PowerShell.Entities
         public ScriptBlockAst Fragment => Symbol.Item1;
         public override void Populate(TextWriter trapFile)
         {
-            trapFile.script_block(this, Fragment.UsingStatements.Count, Fragment.ScriptRequirements?.RequiredModules.Count ?? 0, Fragment.ScriptRequirements?.RequiredAssemblies.Count ?? 0, Fragment.ScriptRequirements?.RequiredPSEditions.Count ?? 0, Fragment.ScriptRequirements?.RequiresPSSnapIns.Count ?? 0);
+            // RequiresPsSnapins Property was removed in System.Management package 7.4.x and later
+            trapFile.script_block(this, Fragment.UsingStatements.Count, Fragment.ScriptRequirements?.RequiredModules.Count ?? 0, Fragment.ScriptRequirements?.RequiredAssemblies.Count ?? 0, Fragment.ScriptRequirements?.RequiredPSEditions.Count ?? 0, 0);
             trapFile.script_block_location(this, TrapSuitableLocation);
             if (Fragment.ScriptRequirements is not null){
                 trapFile.script_block_requires_elevation(this, Fragment.ScriptRequirements.IsElevationRequired);
@@ -39,10 +40,6 @@ namespace Semmle.Extraction.PowerShell.Entities
                 for (int i = 0; i < Fragment.ScriptRequirements.RequiredPSEditions.Count; i++)
                 {
                     trapFile.script_block_required_ps_edition(this, i, Fragment.ScriptRequirements.RequiredPSEditions[i]);
-                }
-                for (int i = 0; i < Fragment.ScriptRequirements.RequiresPSSnapIns.Count; i++)
-                {
-                    trapFile.script_block_requires_ps_snapin(this, i, Fragment.ScriptRequirements.RequiresPSSnapIns[i].Name, Fragment.ScriptRequirements.RequiresPSSnapIns[i].Version.ToString());
                 }
             }
             if (Fragment.ParamBlock is not null)

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Semmle.Extraction.PowerShell.csproj
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Semmle.Extraction.PowerShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	<AssemblyName>Semmle.Extraction.PowerShell</AssemblyName>
 	<RootNamespace>Semmle.Extraction.PowerShell</RootNamespace>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Management.Automation" Version="7.3.3" />
+    <PackageReference Include="System.Management.Automation" Version="7.5.0" />
   </ItemGroup>
 
 </Project>

--- a/powershell/extractor/Semmle.Extraction.PowerShell/Semmle.Extraction.PowerShell.csproj
+++ b/powershell/extractor/Semmle.Extraction.PowerShell/Semmle.Extraction.PowerShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<AssemblyName>Semmle.Extraction.PowerShell</AssemblyName>
 	<RootNamespace>Semmle.Extraction.PowerShell</RootNamespace>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/powershell/extractor/Semmle.Extraction/Semmle.Extraction.csproj
+++ b/powershell/extractor/Semmle.Extraction/Semmle.Extraction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Semmle.Extraction</AssemblyName>
     <RootNamespace>Semmle.Extraction</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.9.0" />
-    <PackageReference Include="GitInfo" Version="2.1.2">
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
+    <PackageReference Include="GitInfo" Version="3.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/powershell/extractor/Semmle.Extraction/Semmle.Extraction.csproj
+++ b/powershell/extractor/Semmle.Extraction/Semmle.Extraction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Semmle.Extraction</AssemblyName>
     <RootNamespace>Semmle.Extraction</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/powershell/extractor/Semmle.Util/Semmle.Util.csproj
+++ b/powershell/extractor/Semmle.Util/Semmle.Util.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Semmle.Util</AssemblyName>
     <RootNamespace>Semmle.Util</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/powershell/extractor/Semmle.Util/Semmle.Util.csproj
+++ b/powershell/extractor/Semmle.Util/Semmle.Util.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Semmle.Util</AssemblyName>
     <RootNamespace>Semmle.Util</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
Also update dependencies.
Note: Due to changes in the Powershell SDK the RequiresPSSnapins property has been removed from the ScriptRequirements Property of the ScriptBlock object. I have opted to not change the dbscheme and instead just populate this value with a 0 for now, but that should be cleaned up.