### PR TITLE
DO NOT MERGE: Perform alias analysis in C/C++ dataflow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/AliasedFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/AliasedFlow.qll
@@ -1,0 +1,344 @@
+private import cpp as Cpp
+private import SsaInternals as Ssa
+private import codeql.ssa.Ssa as SsaImplCommon
+private import DataFlowPrivate
+private import DataFlowUtil as Public
+private import DataFlowNodes as Nodes
+private import semmle.code.cpp.ir.IR
+private import semmle.code.cpp.ir.internal.IRCppLanguage
+
+private module SsaInput implements SsaImplCommon::InputSig<Cpp::Location> {
+  import SsaInternalsCommon::InputSigCommon
+
+  class SourceVariable = Ssa::SourceVariable;
+
+  /**
+   * Holds if `instr` flows to the destination address of a `StoreInstruction`
+   * and flows from a read of some definition.
+   */
+  private predicate fwd(Node1Impl n, int indirectionIndex) {
+    nodeHasInstruction1(n, any(VariableAddressInstruction vai), indirectionIndex)
+    or
+    exists(Node1Impl n0 |
+      fwd(n0, indirectionIndex) and
+      simpleLocalFlowStep1(n0, n, _)
+    )
+  }
+
+  /**
+   * Holds if `instr` flows to the destination address of a `StoreInstruction`
+   */
+  private predicate revStore(Node1Impl n, int indirectionIndex, int k) {
+    fwd(pragma[only_bind_into](n), pragma[only_bind_into](indirectionIndex)) and
+    (
+      indirectionIndex > k and
+      nodeHasOperand1(n, any(StoreInstruction store).getDestinationAddressOperand(),
+        indirectionIndex - k)
+      or
+      exists(Node1Impl n1 |
+        revStore(n1, pragma[only_bind_into](indirectionIndex), k) and
+        simpleLocalFlowStep1(n, n1, _)
+      )
+    )
+  }
+
+  private newtype TStoreNode1Impl =
+    MkStoreNode1Impl(Node1Impl n, int indirectionIndex, int k) { revStore(n, indirectionIndex, k) }
+
+  /**
+   * This predicate holds if
+   * ```
+   * conversionFlow(instr1.getAUse(), instr2, _, false)
+   * ```
+   * and both `instr1` and `instr2` are instructions on a path from a read of
+   * some definition to the destination address of a `StoreInstruction`.
+   */
+  private predicate flowStoreStep(TStoreNode1Impl node1, TStoreNode1Impl node2) {
+    exists(Node1Impl n1, Node1Impl n2, int indirectionIndex, int k |
+      node1 =
+        MkStoreNode1Impl(n1, pragma[only_bind_into](indirectionIndex), pragma[only_bind_into](k)) and
+      node2 =
+        MkStoreNode1Impl(n2, pragma[only_bind_into](indirectionIndex), pragma[only_bind_into](k)) and
+      simpleLocalFlowStep1(n1, n2, _)
+    )
+  }
+
+  private predicate storeSink(TStoreNode1Impl sink) {
+    exists(Node1Impl n, int indirectionIndex, int k |
+      sink = MkStoreNode1Impl(n, indirectionIndex, k) and
+      // Subtract one because a store writes to the _indirection_ of the address operand
+      nodeHasOperand1(n, any(StoreInstruction store).getDestinationAddressOperand(),
+        indirectionIndex - k)
+    )
+  }
+
+  private predicate storeSource(TStoreNode1Impl source) {
+    exists(Node1Impl n, int indirectionIndex, int k |
+      source = MkStoreNode1Impl(n, indirectionIndex, k) and
+      nodeHasInstruction1(n, any(VariableAddressInstruction vai), indirectionIndex)
+    )
+  }
+
+  private predicate flowStorePlusImpl(TStoreNode1Impl node1, TStoreNode1Impl node2) =
+    doublyBoundedFastTC(flowStoreStep/2, storeSource/1, storeSink/1)(node1, node2)
+
+  private predicate flowStoreStepTCImpl(TStoreNode1Impl node1, TStoreNode1Impl node2) {
+    storeSource(node1) and
+    storeSink(node2) and
+    (
+      flowStorePlusImpl(node1, node2)
+      or
+      node1 = node2
+    )
+  }
+
+  private predicate flowStoreStepTC(Node1Impl n1, Node1Impl n2, int indirectionIndex, int k) {
+    exists(TStoreNode1Impl node1, TStoreNode1Impl node2 |
+      node1 =
+        MkStoreNode1Impl(n1, pragma[only_bind_into](indirectionIndex), pragma[only_bind_into](k)) and
+      node2 =
+        MkStoreNode1Impl(n2, pragma[only_bind_into](indirectionIndex), pragma[only_bind_into](k)) and
+      flowStoreStepTCImpl(node1, node2)
+    )
+  }
+
+  /**
+   * Holds if `instr` flows to the destination address of a `StoreInstruction`
+   */
+  private predicate revLoad(Node1Impl n, int indirectionIndex) {
+    fwd(pragma[only_bind_into](n), pragma[only_bind_into](indirectionIndex)) and
+    (
+      nodeHasOperand1(n, _, indirectionIndex)
+      or
+      exists(Node1Impl n1 |
+        revLoad(n1, pragma[only_bind_into](indirectionIndex)) and
+        simpleLocalFlowStep1(n, n1, _)
+      )
+    )
+  }
+
+  private newtype TLoadNode1Impl =
+    MkLoadNode1Impl(Node1Impl n, int indirectionIndex) { revLoad(n, indirectionIndex) }
+
+  private predicate flowLoadStep(TLoadNode1Impl node1, TLoadNode1Impl node2) {
+    exists(Node1Impl n1, Node1Impl n2, int indirectionIndex |
+      node1 = MkLoadNode1Impl(n1, pragma[only_bind_into](indirectionIndex)) and
+      node2 = MkLoadNode1Impl(n2, pragma[only_bind_into](indirectionIndex)) and
+      simpleLocalFlowStep1(n1, n2, _)
+    )
+  }
+
+  private predicate loadSink(TLoadNode1Impl sink) {
+    exists(Node1Impl n, int indirectionIndex |
+      sink = MkLoadNode1Impl(n, indirectionIndex) and
+      nodeHasOperand1(n, _, indirectionIndex)
+    )
+  }
+
+  private predicate loadSource(TLoadNode1Impl source) {
+    exists(Node1Impl n, int indirectionIndex |
+      source = MkLoadNode1Impl(n, indirectionIndex) and
+      nodeHasInstruction1(n, any(VariableAddressInstruction vai), indirectionIndex)
+    )
+  }
+
+  private predicate flowLoadPlusImpl(TLoadNode1Impl node1, TLoadNode1Impl node2) =
+    doublyBoundedFastTC(flowLoadStep/2, loadSource/1, loadSink/1)(node1, node2)
+
+  private predicate flowLoadStepTCImpl(TLoadNode1Impl node1, TLoadNode1Impl node2) {
+    loadSource(node1) and
+    loadSink(node2) and
+    (
+      flowLoadPlusImpl(node1, node2)
+      or
+      node1 = node2
+    )
+  }
+
+  private predicate flowLoadStepTC(Node1Impl n1, Node1Impl n2, int indirectionIndex) {
+    exists(TLoadNode1Impl node1, TLoadNode1Impl node2 |
+      node1 = MkLoadNode1Impl(n1, pragma[only_bind_into](indirectionIndex)) and
+      node2 = MkLoadNode1Impl(n2, pragma[only_bind_into](indirectionIndex)) and
+      flowLoadStepTCImpl(node1, node2)
+    )
+  }
+
+  /**
+   * Holds if the `i`'th instruction in `bb` writes to `v` through an alias.
+   * `certain` is `true` if write is guaranteed to overwrite the entire
+   * allocation.
+   */
+  additional predicate variableWrite(
+    BasicBlock bb, int i, SourceVariable sv, boolean certain, Node1Impl store
+  ) {
+    certain = true and
+    exists(
+      Node1Impl vai, VariableAddressInstruction vaiInstr, StoreInstruction storeInstr, int index,
+      Node1Impl dest, int k, Ssa::DefImpl def, int lower
+    |
+      flowStoreStepTC(vai, dest, index, k) and
+      nodeHasInstruction1(vai, vaiInstr, index) and
+      nodeHasOperand1(dest, storeInstr.getDestinationAddressOperand(), index - k) and
+      sv.getIRVariable() = vaiInstr.getIRVariable() and
+      lower =
+        pragma[only_bind_out](getMinIndirectionsForType(storeInstr
+              .getDestinationAddress()
+              .getResultType())) and
+      sv.getIndirection() = index + lower and
+      nodeHasInstruction1(store, storeInstr, index - k) and
+      def.getNode() = store and
+      def.hasIndexInBlock(bb, i)
+    )
+  }
+
+  predicate variableWrite(BasicBlock bb, int i, SourceVariable sv, boolean certain) {
+    variableWrite(bb, i, sv, certain, _)
+  }
+
+  additional predicate variableRead(
+    BasicBlock bb, int i, SourceVariable sv, boolean certain, Node1Impl load
+  ) {
+    certain = true and
+    exists(Node1Impl vai, int index, VariableAddressInstruction vaiInstr, Ssa::UseImpl use |
+      flowLoadStepTC(vai, load, index) and
+      nodeHasInstruction1(vai, vaiInstr, index) and
+      sv.getIRVariable() = vaiInstr.getIRVariable() and
+      sv.getIndirection() = index and
+      use.getNode() = load and
+      use.hasIndexInBlock(bb, i)
+    )
+  }
+
+  predicate variableRead(BasicBlock bb, int i, SourceVariable sv, boolean certain) {
+    variableRead(bb, i, sv, certain, _)
+  }
+}
+
+private module AliasedSsa = SsaImplCommon::Make<Cpp::Location, SsaInput>;
+
+private newtype TAliasedNode =
+  TNode1(Node1Impl n) or
+  TPhiNode(AliasedSsa::DefinitionExt phi) {
+    phi instanceof AliasedSsa::PhiNode or
+    phi instanceof AliasedSsa::PhiReadNode
+  }
+
+abstract private class AliasedNode extends TAliasedNode {
+  abstract string toString();
+
+  Instruction asInstruction() { none() }
+
+  abstract Cpp::Function getFunction();
+
+  abstract predicate isGLValue();
+
+  abstract Cpp::Type getType();
+
+  abstract Cpp::Location getLocation();
+}
+
+class AliasedNodeImpl = AliasedNode;
+
+private class Node1 extends AliasedNode, TNode1 {
+  Node1Impl n;
+
+  Node1() { this = TNode1(n) }
+
+  Node1Impl getImpl() { result = n }
+
+  final override string toString() { result = n.toString() }
+
+  final override Instruction asInstruction() { result = n.asInstruction() }
+
+  final override Cpp::Function getFunction() { result = n.getFunction() }
+
+  final override predicate isGLValue() { n.isGLValue() }
+
+  final override Cpp::Type getType() { result = n.getType() }
+
+  final override Cpp::Location getLocation() { result = n.getLocation() }
+}
+
+private class PhiNode extends AliasedNode, TPhiNode {
+  AliasedSsa::DefinitionExt phi;
+
+  PhiNode() { this = TPhiNode(phi) }
+
+  final override string toString() { result = phi.toString() }
+
+  AliasedSsa::DefinitionExt getPhi() { result = phi }
+
+  final override Cpp::Function getFunction() { result = phi.getBasicBlock().getEnclosingFunction() }
+
+  final override predicate isGLValue() { phi.getSourceVariable().isGLValue() }
+
+  final override Cpp::Type getType() { result = phi.getSourceVariable().getType() }
+
+  final override Cpp::Location getLocation() { result = phi.getLocation() }
+}
+
+class AliasedPhiNodeImpl = PhiNode;
+
+private predicate step(SsaInput::SourceVariable sv, IRBlock bb1, int i1, AliasedNode node2) {
+  exists(AliasedSsa::DefinitionExt def, Node1Impl load, IRBlock bb2, int i2 |
+    AliasedSsa::adjacentDefReadExt(def, sv, bb1, i1, bb2, i2) and
+    SsaInput::variableRead(bb2, i2, sv, _, load) and
+    TNode1(load) = node2
+  )
+}
+
+private predicate access(SsaInput::SourceVariable sv, IRBlock bb, int i, AliasedNode node1) {
+  exists(Node1Impl n | node1 = TNode1(n) |
+    SsaInput::variableWrite(bb, i, sv, _, n)
+    or
+    SsaInput::variableRead(bb, i, sv, _, n)
+  )
+  or
+  node1.(PhiNode).getPhi().definesAt(sv, bb, i, _)
+}
+
+private predicate stepToPhi(SsaInput::SourceVariable sv, IRBlock bb, int i, PhiNode node) {
+  exists(AliasedSsa::DefinitionExt phi |
+    AliasedSsa::lastRefRedefExt(_, sv, bb, i, phi) and
+    node.getPhi() = phi
+  )
+}
+
+predicate into(Public::Node node1, TPhiNode node2) {
+  exists(Node1Impl n |
+    node1 = Nodes::TNode1(n) and
+    aliasedFlow(TNode1(n), node2)
+  )
+}
+
+predicate step1(Public::Node node1, Public::Node node2) {
+  exists(Node1Impl n1, Node1Impl n2 |
+    node1 = Nodes::TNode1(n1) and
+    node2 = Nodes::TNode1(n2) and
+    aliasedFlow(TNode1(n1), TNode1(n2))
+  )
+}
+
+predicate step2(TPhiNode node1, TPhiNode node2) { aliasedFlow(node1, node2) }
+
+predicate out(TPhiNode node1, Public::Node node2) {
+  exists(Node1Impl n |
+    node2 = Nodes::TNode1(n) and
+    aliasedFlow(node1, TNode1(n))
+  )
+}
+
+private predicate aliasedFlow(AliasedNode node1, AliasedNode node2) {
+  node1 != node2 and
+  (
+    exists(IRBlock bb, int i, SsaInput::SourceVariable sv |
+      access(sv, bb, i, node1) and
+      step(sv, bb, i, node2)
+    )
+    or
+    exists(IRBlock bb, int i, SsaInput::SourceVariable sv |
+      access(sv, bb, i, node1) and
+      stepToPhi(sv, bb, i, node2)
+    )
+  )
+}

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
@@ -23,12 +23,6 @@ newtype TIRDataFlowNode =
     indirectionIndex =
       [getMinIndirectionsForType(var.getUnspecifiedType()) .. Ssa::getMaxIndirectionsForType(var.getUnspecifiedType())]
   } or
-  TPostUpdateNodeImpl(Operand operand, int indirectionIndex) {
-    operand = any(FieldAddress fa).getObjectAddressOperand() and
-    indirectionIndex = [0 .. Ssa::countIndirectionsForCppType(Ssa::getLanguageType(operand))]
-    or
-    Ssa::isModifiableByCall(operand, indirectionIndex)
-  } or
   TSsaIteratorNode(IteratorFlow::IteratorFlowNode n) or
   TBodyLessParameterNodeImpl(Parameter p, int indirectionIndex) {
     // Rule out parameters of catch blocks.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
@@ -29,8 +29,6 @@ newtype TIRDataFlowNode =
     or
     Ssa::isModifiableByCall(operand, indirectionIndex)
   } or
-  TSsaPhiInputNode(Ssa::PhiNode phi, IRBlock input) { phi.hasInputFromBlock(_, _, _, _, input) } or
-  TSsaPhiNode(Ssa::PhiNode phi) or
   TSsaIteratorNode(IteratorFlow::IteratorFlowNode n) or
   TBodyLessParameterNodeImpl(Parameter p, int indirectionIndex) {
     // Rule out parameters of catch blocks.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
@@ -32,7 +32,6 @@ newtype TIRDataFlowNode =
   TSsaPhiInputNode(Ssa::PhiNode phi, IRBlock input) { phi.hasInputFromBlock(_, _, _, _, input) } or
   TSsaPhiNode(Ssa::PhiNode phi) or
   TSsaIteratorNode(IteratorFlow::IteratorFlowNode n) or
-  TInitialGlobalValue(Ssa::GlobalDef globalUse) or
   TBodyLessParameterNodeImpl(Parameter p, int indirectionIndex) {
     // Rule out parameters of catch blocks.
     not exists(p.getCatchBlock()) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
@@ -32,12 +32,6 @@ newtype TIRDataFlowNode =
   TSsaPhiInputNode(Ssa::PhiNode phi, IRBlock input) { phi.hasInputFromBlock(_, _, _, _, input) } or
   TSsaPhiNode(Ssa::PhiNode phi) or
   TSsaIteratorNode(IteratorFlow::IteratorFlowNode n) or
-  TFinalParameterNode(Parameter p, int indirectionIndex) {
-    exists(Ssa::FinalParameterUse use |
-      use.getParameter() = p and
-      use.getIndirectionIndex() = indirectionIndex
-    )
-  } or
   TFinalGlobalValue(Ssa::GlobalUse globalUse) or
   TInitialGlobalValue(Ssa::GlobalDef globalUse) or
   TBodyLessParameterNodeImpl(Parameter p, int indirectionIndex) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
@@ -32,7 +32,6 @@ newtype TIRDataFlowNode =
   TSsaPhiInputNode(Ssa::PhiNode phi, IRBlock input) { phi.hasInputFromBlock(_, _, _, _, input) } or
   TSsaPhiNode(Ssa::PhiNode phi) or
   TSsaIteratorNode(IteratorFlow::IteratorFlowNode n) or
-  TFinalGlobalValue(Ssa::GlobalUse globalUse) or
   TInitialGlobalValue(Ssa::GlobalDef globalUse) or
   TBodyLessParameterNodeImpl(Parameter p, int indirectionIndex) {
     // Rule out parameters of catch blocks.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
@@ -4,6 +4,7 @@ private import semmle.code.cpp.ir.IR
 private import DataFlowImplCommon as DataFlowImplCommon
 private import SsaInternals as Ssa
 private import semmle.code.cpp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
+private import AliasedFlow
 
 /**
  * The IR dataflow graph consists of the following nodes:
@@ -33,4 +34,5 @@ newtype TIRDataFlowNode =
     indirectionIndex = [0 .. Ssa::getMaxIndirectionsForType(p.getUnspecifiedType()) - 1] and
     not any(InitializeParameterInstruction init).getParameter() = p
   } or
+  TAliasedPhiNode(AliasedPhiNodeImpl n) or
   TFlowSummaryNode(FlowSummaryImpl::Private::SummaryNode sn)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowNodes.qll
@@ -1,0 +1,52 @@
+private import cpp
+private import DataFlowPrivate
+private import semmle.code.cpp.ir.IR
+private import DataFlowImplCommon as DataFlowImplCommon
+private import SsaInternals as Ssa
+private import semmle.code.cpp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
+
+/**
+ * The IR dataflow graph consists of the following nodes:
+ * - `Node1`, which injects most instructions and operands directly into the
+ *    dataflow graph, as well as indirections of these instructions and
+ *    operands.
+ * - `VariableNode`, which is used to model flow through global variables.
+ * - `PostUpdateNodeImpl`, which is used to model the state of an object after
+ *    an update after a number of loads.
+ * - `SsaPhiNode`, which represents phi nodes as computed by the shared SSA
+ *    library.
+ */
+cached
+newtype TIRDataFlowNode =
+  TNode1(Node1Impl node) { DataFlowImplCommon::forceCachingInSameStage() } or
+  TGlobalLikeVariableNode(GlobalLikeVariable var, int indirectionIndex) {
+    indirectionIndex =
+      [getMinIndirectionsForType(var.getUnspecifiedType()) .. Ssa::getMaxIndirectionsForType(var.getUnspecifiedType())]
+  } or
+  TPostUpdateNodeImpl(Operand operand, int indirectionIndex) {
+    operand = any(FieldAddress fa).getObjectAddressOperand() and
+    indirectionIndex = [0 .. Ssa::countIndirectionsForCppType(Ssa::getLanguageType(operand))]
+    or
+    Ssa::isModifiableByCall(operand, indirectionIndex)
+  } or
+  TSsaPhiInputNode(Ssa::PhiNode phi, IRBlock input) { phi.hasInputFromBlock(_, _, _, _, input) } or
+  TSsaPhiNode(Ssa::PhiNode phi) or
+  TSsaIteratorNode(IteratorFlow::IteratorFlowNode n) or
+  TFinalParameterNode(Parameter p, int indirectionIndex) {
+    exists(Ssa::FinalParameterUse use |
+      use.getParameter() = p and
+      use.getIndirectionIndex() = indirectionIndex
+    )
+  } or
+  TFinalGlobalValue(Ssa::GlobalUse globalUse) or
+  TInitialGlobalValue(Ssa::GlobalDef globalUse) or
+  TBodyLessParameterNodeImpl(Parameter p, int indirectionIndex) {
+    // Rule out parameters of catch blocks.
+    not exists(p.getCatchBlock()) and
+    // We subtract one because `getMaxIndirectionsForType` returns the maximum
+    // indirection for a glvalue of a given type, and this doesn't apply to
+    // parameters.
+    indirectionIndex = [0 .. Ssa::getMaxIndirectionsForType(p.getUnspecifiedType()) - 1] and
+    not any(InitializeParameterInstruction init).getParameter() = p
+  } or
+  TFlowSummaryNode(FlowSummaryImpl::Private::SummaryNode sn)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -12,6 +12,7 @@ private import ModelUtil
 private import semmle.code.cpp.models.interfaces.FunctionInputsAndOutputs as IO
 private import semmle.code.cpp.models.interfaces.DataFlow as DF
 private import semmle.code.cpp.dataflow.ExternalFlow as External
+private import DataFlowNodes
 
 cached
 private module Cached {
@@ -2518,7 +2519,7 @@ module IteratorFlow {
     or
     exists(Ssa::UseImpl use |
       use.hasIndexInBlock(bb, i, sv) and
-      nodeTo = use.getNode()
+      nodeTo = TNode1(use.getNode())
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -52,7 +52,8 @@ private module Cached {
           use.getParameter() = p and
           use.getIndirectionIndex() = indirectionIndex
         )
-      }
+      } or
+      TFinalGlobalValue(Ssa::GlobalUse use)
   }
 
   /**
@@ -627,6 +628,32 @@ class FinalParameterNode0 extends Node1Impl, TFinalParameterNode {
   }
 
   override string toStringImpl() { result = stars0(this) + p.toString() }
+}
+
+/**
+ * INTERNAL: do not use.
+ *
+ * A node representing the value of a global variable just before returning
+ * from a function body.
+ */
+class FinalGlobalValue0 extends Node1Impl, TFinalGlobalValue {
+  Ssa::GlobalUse use;
+
+  FinalGlobalValue0() { this = TFinalGlobalValue(use) }
+
+  override Declaration getEnclosingCallable() { result = this.getFunction() }
+
+  override Declaration getFunction() { result = use.getIRFunction().getFunction() }
+
+  override DataFlowType getType() {
+    result = getTypeImpl(use.getUnderlyingType(), use.getIndirectionIndex() - 1)
+  }
+
+  final override Location getLocationImpl() { result = use.getLocation() }
+
+  override string toStringImpl() { result = use.toString() }
+
+  Ssa::GlobalUse getGlobalUse() { result = use }
 }
 
 /** Gets the callable in which this node occurs. */

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -375,9 +375,9 @@ class InstructionNode1 extends Node1Impl, Node0 {
   Instruction getInstruction() { result = node.getInstruction() }
 }
 
-private Node0 operandNode0(Operand op) { result.asOperand() = op }
+Node0 operandNode0(Operand op) { result.asOperand() = op }
 
-private Node0 instructionNode0(Instruction i) { result.asInstruction() = i }
+Node0 instructionNode0(Instruction i) { result.asInstruction() = i }
 
 private class RawIndirectOperand0 extends Node1Impl, TRawIndirectOperand0 {
   Node0Impl node;
@@ -2462,6 +2462,8 @@ private Instruction getAnInstruction(Node n) {
   result = n.asOperand().getUse()
   or
   result = n.(SsaPhiNode).getPhiNode().getBasicBlock().getFirstInstruction()
+  or
+  result = n.(AliasedPhiNode).getPhi().getPhi().getBasicBlock().getFirstInstruction()
   or
   result = n.(SsaPhiInputNode).getBasicBlock().getFirstInstruction()
   or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1062,39 +1062,17 @@ Type getTypeImpl(Type t, int indirectionIndex) {
  * A node representing the value of an update parameter
  * just before reaching the end of a function.
  */
-class FinalParameterNode extends Node, TFinalParameterNode {
-  Parameter p;
-  int indirectionIndex;
-
-  FinalParameterNode() { this = TFinalParameterNode(p, indirectionIndex) }
+class FinalParameterNode extends Node, Node1 {
+  override FinalParameterNode0 node;
 
   /** Gets the parameter associated with this final use. */
-  Parameter getParameter() { result = p }
+  Parameter getParameter() { result = node.getParameter() }
 
   /** Gets the underlying indirection index. */
-  int getIndirectionIndex() { result = indirectionIndex }
+  int getIndirectionIndex() { result = node.getIndirectionIndex() }
 
   /** Gets the argument index associated with this final use. */
-  final int getArgumentIndex() { result = p.getIndex() }
-
-  override Declaration getFunction() { result = p.getFunction() }
-
-  override DataFlowCallable getEnclosingCallable() {
-    result.asSourceCallable() = this.getFunction()
-  }
-
-  override DataFlowType getType() { result = getTypeImpl(p.getUnderlyingType(), indirectionIndex) }
-
-  final override Location getLocationImpl() {
-    // Parameters can have multiple locations. When there's a unique location we use
-    // that one, but if multiple locations exist we default to an unknown location.
-    result = unique( | | p.getLocation())
-    or
-    not exists(unique( | | p.getLocation())) and
-    result instanceof UnknownDefaultLocation
-  }
-
-  override string toStringImpl() { result = stars(this) + p.toString() }
+  final int getArgumentIndex() { result = node.getArgumentIndex() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -510,36 +510,20 @@ Type stripPointer(Type t) {
   result = t.(FunctionPointerIshType).getBaseType()
 }
 
-/**
- * INTERNAL: Do not use.
- */
-class PostUpdateNodeImpl extends PartialDefinitionNode, TPostUpdateNodeImpl {
-  int indirectionIndex;
+class PostUpdateNodeImpl extends Node1, PartialDefinitionNode {
+  override PostUpdateNodeImpl0 node;
   Operand operand;
 
-  PostUpdateNodeImpl() { this = TPostUpdateNodeImpl(operand, indirectionIndex) }
+  PostUpdateNodeImpl() { operand = node.getOperand() }
 
-  override Declaration getFunction() { result = operand.getUse().getEnclosingFunction() }
+  final override Node getPreUpdateNode() { result = TNode1(node.getPreUpdateNode()) }
 
-  override DataFlowCallable getEnclosingCallable() {
-    result = this.getPreUpdateNode().getEnclosingCallable()
-  }
+  override DataFlowType getType() { result = node.getType() }
 
   /** Gets the operand associated with this node. */
   Operand getOperand() { result = operand }
 
-  /** Gets the indirection index associated with this node. */
-  override int getIndirectionIndex() { result = indirectionIndex }
-
-  override Location getLocationImpl() { result = operand.getLocation() }
-
-  final override Node getPreUpdateNode() {
-    indirectionIndex > 0 and
-    hasOperandAndIndex(result, operand, indirectionIndex)
-    or
-    indirectionIndex = 0 and
-    result.asOperand() = operand
-  }
+  override int getIndirectionIndex() { result = node.getIndirectionIndex() }
 
   final override Expr getDefinedExpr() {
     result = operand.getDef().getUnconvertedResultExpression()
@@ -803,7 +787,9 @@ class IndirectArgumentOutNode extends PostUpdateNodeImpl {
   Function getStaticCallTarget() { result = this.getCallInstruction().getStaticCallTarget() }
 
   override string toStringImpl() {
-    exists(string prefix | if indirectionIndex > 0 then prefix = "" else prefix = "pointer to " |
+    exists(string prefix |
+      if this.getIndirectionIndex() > 0 then prefix = "" else prefix = "pointer to "
+    |
       // This string should be unique enough to be helpful but common enough to
       // avoid storing too many different strings.
       result = prefix + this.getStaticCallTarget().getName() + " output argument"
@@ -1214,7 +1200,7 @@ abstract class PostUpdateNode extends Node {
    */
   abstract Node getPreUpdateNode();
 
-  final override DataFlowType getType() { result = this.getPreUpdateNode().getType() }
+  override DataFlowType getType() { result = this.getPreUpdateNode().getType() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -665,9 +665,7 @@ class SideEffectOperandNode extends Node instanceof IndirectOperand {
 class FinalGlobalValue extends Node, Node1 {
   override FinalGlobalValue0 node;
 
-  Ssa::GlobalUse getGlobalUse() {
-    result = node.getGlobalUse()
-  }
+  Ssa::GlobalUse getGlobalUse() { result = node.getGlobalUse() }
 }
 
 class InitialGlobalValue extends Node, Node1 {
@@ -950,6 +948,8 @@ class FinalParameterNode extends Node, Node1 {
 
   /** Gets the argument index associated with this final use. */
   final int getArgumentIndex() { result = node.getArgumentIndex() }
+
+  Ssa::FinalParameterUse getUse() { result = node.getUse() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -738,36 +738,12 @@ class SideEffectOperandNode extends Node instanceof IndirectOperand {
   Expr getArgument() { result = call.getArgument(argumentIndex).getUnconvertedResultExpression() }
 }
 
-/**
- * INTERNAL: do not use.
- *
- * A node representing the value of a global variable just before returning
- * from a function body.
- */
-class FinalGlobalValue extends Node, TFinalGlobalValue {
-  Ssa::GlobalUse globalUse;
+class FinalGlobalValue extends Node, Node1 {
+  override FinalGlobalValue0 node;
 
-  FinalGlobalValue() { this = TFinalGlobalValue(globalUse) }
-
-  /** Gets the underlying SSA use. */
-  Ssa::GlobalUse getGlobalUse() { result = globalUse }
-
-  override DataFlowCallable getEnclosingCallable() {
-    result.asSourceCallable() = this.getFunction()
+  Ssa::GlobalUse getGlobalUse() {
+    result = node.getGlobalUse()
   }
-
-  override Declaration getFunction() { result = globalUse.getIRFunction().getFunction() }
-
-  override DataFlowType getType() {
-    exists(int indirectionIndex |
-      indirectionIndex = globalUse.getIndirectionIndex() and
-      result = getTypeImpl(globalUse.getUnderlyingType(), indirectionIndex - 1)
-    )
-  }
-
-  final override Location getLocationImpl() { result = globalUse.getLocation() }
-
-  override string toStringImpl() { result = globalUse.toString() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -801,54 +801,23 @@ class IndirectArgumentOutNode extends PostUpdateNodeImpl {
 }
 
 /**
- * Holds if `node` is an indirect operand with columns `(operand, indirectionIndex)`, and
- * `operand` represents a use of the fully converted value of `call`.
- */
-private predicate hasOperand(Node node, CallInstruction call, int indirectionIndex, Operand operand) {
-  operandForFullyConvertedCall(operand, call) and
-  hasOperandAndIndex(node, operand, indirectionIndex)
-}
-
-/**
- * Holds if `node` is an indirect instruction with columns `(instr, indirectionIndex)`, and
- * `instr` represents a use of the fully converted value of `call`.
- *
- * Note that `hasOperand(node, _, _, _)` implies `not hasInstruction(node, _, _, _)`.
- */
-private predicate hasInstruction(
-  Node node, CallInstruction call, int indirectionIndex, Instruction instr
-) {
-  instructionForFullyConvertedCall(instr, call) and
-  hasInstructionAndIndex(node, instr, indirectionIndex)
-}
-
-/**
  * INTERNAL: do not use.
  *
  * A node representing the indirect value of a function call (i.e., a value hidden
  * behind a number of indirections).
  */
-class IndirectReturnOutNode extends Node {
-  CallInstruction call;
-  int indirectionIndex;
+class IndirectReturnOutNode extends Node1 {
+  override IndirectReturnOutNode0 node;
 
-  IndirectReturnOutNode() {
-    // Annoyingly, we need to pick the fully converted value as the output of the function to
-    // make flow through in the shared dataflow library work correctly.
-    hasOperand(this, call, indirectionIndex, _)
-    or
-    hasInstruction(this, call, indirectionIndex, _)
-  }
+  CallInstruction getCallInstruction() { result = node.getCallInstruction() }
 
-  CallInstruction getCallInstruction() { result = call }
-
-  int getIndirectionIndex() { result = indirectionIndex }
+  int getIndirectionIndex() { result = node.getIndirectionIndex() }
 
   /** Gets the operand associated with this node, if any. */
-  Operand getOperand() { hasOperand(this, call, indirectionIndex, result) }
+  Operand getOperand() { result = node.getOperand() }
 
   /** Gets the instruction associated with this node, if any. */
-  Instruction getInstruction() { hasInstruction(this, call, indirectionIndex, result) }
+  Instruction getInstruction() { result = node.getInstruction() }
 }
 
 /**
@@ -872,6 +841,8 @@ private class PostIndirectReturnOutNode extends IndirectReturnOutNode, PostUpdat
   }
 
   override Node getPreUpdateNode() { result = this }
+
+  override DataFlowType getType() { result = node.getType() }
 }
 
 /**
@@ -942,20 +913,11 @@ class FinalParameterNode extends Node, Node1 {
  * The value of an uninitialized local variable, viewed as a node in a data
  * flow graph.
  */
-class UninitializedNode extends Node {
-  LocalVariable v;
-
-  UninitializedNode() {
-    exists(Ssa::DefinitionExt def, Ssa::SourceVariable sv |
-      def.getIndirectionIndex() = 0 and
-      def.getValue().asInstruction() instanceof UninitializedInstruction and
-      Ssa::defToNode(this, def, sv, _, _, _) and
-      v = sv.getBaseVariable().(Ssa::BaseIRVariable).getIRVariable().getAst()
-    )
-  }
+class UninitializedNode extends Node1 {
+  override UninitializedNode0 node;
 
   /** Gets the uninitialized local variable corresponding to this node. */
-  LocalVariable getLocalVariable() { result = v }
+  LocalVariable getLocalVariable() { result = node.getLocalVariable() }
 }
 
 abstract private class AbstractParameterNode extends Node {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -746,33 +746,10 @@ class FinalGlobalValue extends Node, Node1 {
   }
 }
 
-/**
- * INTERNAL: do not use.
- *
- * A node representing the value of a global variable just after entering
- * a function body.
- */
-class InitialGlobalValue extends Node, TInitialGlobalValue {
-  Ssa::GlobalDef globalDef;
+class InitialGlobalValue extends Node, Node1 {
+  override InitialGlobalValue0 node;
 
-  InitialGlobalValue() { this = TInitialGlobalValue(globalDef) }
-
-  /** Gets the underlying SSA definition. */
-  Ssa::GlobalDef getGlobalDef() { result = globalDef }
-
-  override DataFlowCallable getEnclosingCallable() {
-    result.asSourceCallable() = this.getFunction()
-  }
-
-  override Declaration getFunction() { result = globalDef.getFunction() }
-
-  final override predicate isGLValue() { globalDef.getIndirectionIndex() = 0 }
-
-  override DataFlowType getType() { result = globalDef.getUnderlyingType() }
-
-  final override Location getLocationImpl() { result = globalDef.getLocation() }
-
-  override string toStringImpl() { result = globalDef.toString() }
+  Ssa::GlobalDef getDef() { result = node.getDef() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1358,48 +1358,9 @@ private module Cached {
       simpleLocalFlowStep1(nFrom, nTo, model)
     )
     or
-    // Reverse flow: data that flows from the definition node back into the indirection returned
-    // by a function. This allows data to flow 'in' through references returned by a modeled
-    // function such as `operator[]`.
-    reverseFlow(nodeFrom, nodeTo) and
-    model = ""
-    or
     // models-as-data summarized flow
     FlowSummaryImpl::Private::Steps::summaryLocalStep(nodeFrom.(FlowSummaryNode).getSummaryNode(),
       nodeTo.(FlowSummaryNode).getSummaryNode(), true, model)
-  }
-
-  private predicate reverseFlow(Node nodeFrom, Node nodeTo) {
-    reverseFlowOperand(nodeFrom, nodeTo)
-    or
-    reverseFlowInstruction(nodeFrom, nodeTo)
-  }
-
-  private predicate reverseFlowOperand(Node nodeFrom, IndirectReturnOutNode nodeTo) {
-    exists(Operand address, int indirectionIndex |
-      nodeHasOperand(nodeTo, address, indirectionIndex)
-    |
-      exists(StoreInstruction store |
-        nodeHasInstruction(nodeFrom, store, indirectionIndex - 1) and
-        store.getDestinationAddressOperand() = address
-      )
-      or
-      // We also want a write coming out of an `OutNode` to flow `nodeTo`.
-      // This is different from `reverseFlowInstruction` since `nodeFrom` can never
-      // be an `OutNode` when it's defined by an instruction.
-      Ssa::outNodeHasAddressAndIndex(nodeFrom, address, indirectionIndex)
-    )
-  }
-
-  private predicate reverseFlowInstruction(Node nodeFrom, IndirectReturnOutNode nodeTo) {
-    exists(Instruction address, int indirectionIndex |
-      nodeHasInstruction(nodeTo, address, indirectionIndex)
-    |
-      exists(StoreInstruction store |
-        nodeHasInstruction(nodeFrom, store, indirectionIndex - 1) and
-        store.getDestinationAddress() = address
-      )
-    )
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ModelUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ModelUtil.qll
@@ -45,48 +45,73 @@ DataFlow::Node callInput(CallInstruction call, FunctionInput input) {
  * Gets the node that represents the output of `call` with kind `output` at
  * indirection index `indirectionIndex`.
  */
-private Node callOutputWithIndirectionIndex(
+private Node1Impl callOutputWithIndirectionIndex0(
   CallInstruction call, FunctionOutput output, int indirectionIndex
 ) {
   // The return value
-  simpleOutNode(result, call) and
+  simpleOutNode1(result, call) and
   output.isReturnValue() and
   indirectionIndex = 0
   or
   // The side effect of a call on the value pointed to by an argument or qualifier
   exists(int index |
-    result.(IndirectArgumentOutNode).getArgumentIndex() = index and
-    result.(IndirectArgumentOutNode).getIndirectionIndex() = indirectionIndex - 1 and
-    result.(IndirectArgumentOutNode).getCallInstruction() = call and
+    result.(IndirectArgumentOutNode0).getArgumentIndex() = index and
+    result.(IndirectArgumentOutNode0).getIndirectionIndex() = indirectionIndex - 1 and
+    result.(IndirectArgumentOutNode0).getCallInstruction() = call and
     output.isParameterDerefOrQualifierObject(index, indirectionIndex - 1)
   )
   or
-  result = getIndirectReturnOutNode(call, indirectionIndex) and
+  result = getIndirectReturnOutNode0(call, indirectionIndex) and
   output.isReturnValueDeref(indirectionIndex)
 }
 
 /**
  * Gets the instruction that holds the `output` for `call`.
  */
-Node callOutput(CallInstruction call, FunctionOutput output) {
-  result = callOutputWithIndirectionIndex(call, output, _)
+Node1Impl callOutput0(CallInstruction call, FunctionOutput output) {
+  result = callOutputWithIndirectionIndex0(call, output, _)
 }
 
-DataFlow::Node callInput(CallInstruction call, FunctionInput input, int d) {
-  exists(DataFlow::Node n | n = callInput(call, input) and d > 0 |
+/**
+ * Gets the instruction that holds the `output` for `call`.
+ */
+Node callOutput(CallInstruction call, FunctionOutput output) {
+  result = TNode1(callOutput0(call, output))
+}
+
+Node1Impl callInput0(CallInstruction call, FunctionInput input, int d) {
+  exists(Node1Impl n | n = callInput0(call, input) and d > 0 |
     // An argument or qualifier
-    hasOperandAndIndex(result, n.asOperand(), d)
+    hasOperandAndIndex1(result, n.asOperand(), d)
     or
     exists(Operand operand, int indirectionIndex |
       // A value pointed to by an argument or qualifier
-      hasOperandAndIndex(n, operand, indirectionIndex) and
-      hasOperandAndIndex(result, operand, indirectionIndex + d)
+      hasOperandAndIndex1(n, operand, indirectionIndex) and
+      hasOperandAndIndex1(result, operand, indirectionIndex + d)
     )
   )
 }
 
-private IndirectReturnOutNode getIndirectReturnOutNode(CallInstruction call, int d) {
-  result = TNode1(getIndirectReturnOutNode0(call, d))
+DataFlow::Node callInput(CallInstruction call, FunctionInput input, int d) {
+  result = TNode1(callInput0(call, input, d))
+}
+
+/**
+ * Gets the instruction that holds the `output` for `call`.
+ */
+bindingset[d]
+Node1Impl callOutput0(CallInstruction call, FunctionOutput output, int d) {
+  exists(Node1Impl n, int indirectionIndex |
+    n = callOutputWithIndirectionIndex0(call, output, indirectionIndex) and d > 0
+  |
+    // The return value
+    result = callOutputWithIndirectionIndex0(call, output, indirectionIndex + d)
+    or
+    // If there isn't an indirect out node for the call with indirection `d` then
+    // we conflate this with the underlying `CallInstruction`.
+    not exists(getIndirectReturnOutNode0(call, indirectionIndex + d)) and
+    n = result
+  )
 }
 
 /**
@@ -94,15 +119,5 @@ private IndirectReturnOutNode getIndirectReturnOutNode(CallInstruction call, int
  */
 bindingset[d]
 Node callOutput(CallInstruction call, FunctionOutput output, int d) {
-  exists(DataFlow::Node n, int indirectionIndex |
-    n = callOutputWithIndirectionIndex(call, output, indirectionIndex) and d > 0
-  |
-    // The return value
-    result = callOutputWithIndirectionIndex(call, output, indirectionIndex + d)
-    or
-    // If there isn't an indirect out node for the call with indirection `d` then
-    // we conflate this with the underlying `CallInstruction`.
-    not exists(getIndirectReturnOutNode(call, indirectionIndex + d)) and
-    n = result
-  )
+  result = TNode1(callOutput0(call, output, d))
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ModelUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ModelUtil.qll
@@ -7,12 +7,18 @@ private import semmle.code.cpp.ir.IR
 private import semmle.code.cpp.ir.dataflow.DataFlow
 private import DataFlowUtil
 private import DataFlowPrivate
+private import DataFlowNodes
 private import SsaInternals as Ssa
+
+private IndirectReturnOutNode0 getIndirectReturnOutNode0(CallInstruction call, int d) {
+  result.getCallInstruction() = call and
+  result.getIndirectionIndex() = d
+}
 
 /**
  * Gets the instruction that goes into `input` for `call`.
  */
-DataFlow::Node callInput(CallInstruction call, FunctionInput input) {
+Node1Impl callInput0(CallInstruction call, FunctionInput input) {
   // An argument or qualifier
   exists(int index |
     result.asOperand() = call.getArgumentOperand(index) and
@@ -21,14 +27,18 @@ DataFlow::Node callInput(CallInstruction call, FunctionInput input) {
   or
   // A value pointed to by an argument or qualifier
   exists(int index, int indirectionIndex |
-    hasOperandAndIndex(result, call.getArgumentOperand(index), indirectionIndex) and
+    hasOperandAndIndex1(result, call.getArgumentOperand(index), indirectionIndex) and
     input.isParameterDerefOrQualifierObject(index, indirectionIndex)
   )
   or
   exists(int ind |
-    result = getIndirectReturnOutNode(call, ind) and
+    result = getIndirectReturnOutNode0(call, ind) and
     input.isReturnValueDeref(ind)
   )
+}
+
+DataFlow::Node callInput(CallInstruction call, FunctionInput input) {
+  result = TNode1(callInput0(call, input))
 }
 
 /**
@@ -76,8 +86,7 @@ DataFlow::Node callInput(CallInstruction call, FunctionInput input, int d) {
 }
 
 private IndirectReturnOutNode getIndirectReturnOutNode(CallInstruction call, int d) {
-  result.getCallInstruction() = call and
-  result.getIndirectionIndex() = d
+  result = TNode1(getIndirectReturnOutNode0(call, d))
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/Node0ToString.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/Node0ToString.qll
@@ -11,7 +11,30 @@
 private import semmle.code.cpp.ir.IR
 private import codeql.util.Unit
 private import DataFlowUtil
+private import DataFlowPrivate
+private import DataFlowNodes
 import NormalNode0ToString // Change this import to control which version should be used.
+
+private int getNumberOfIndirections(Node n) {
+  exists(Node1Impl n1 |
+    n = TNode1(n1) and
+    result = getNumberOfIndirections0(n1)
+  )
+  or
+  result = n.(VariableNode).getIndirectionIndex()
+  or
+  result = n.(PostUpdateNodeImpl).getIndirectionIndex()
+  or
+  result = n.(FinalParameterNode).getIndirectionIndex()
+  or
+  result = n.(BodyLessParameterNodeImpl).getIndirectionIndex()
+}
+
+/**
+ * Gets the number of stars (i.e., `*`s) needed to produce the `toString`
+ * output for `n`.
+ */
+string stars(Node n) { result = repeatStars(getNumberOfIndirections(n)) }
 
 /** An abstract class to control the behavior of `Node.toString`. */
 abstract class Node0ToString extends Unit {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -697,14 +697,6 @@ predicate useToNode0(IRBlock bb, int i, SourceVariable sv, Node1Impl nodeTo) {
   )
 }
 
-pragma[noinline]
-predicate outNodeHasAddressAndIndex(
-  IndirectArgumentOutNode out, Operand address, int indirectionIndex
-) {
-  out.getAddressOperand() = address and
-  out.getIndirectionIndex() = indirectionIndex
-}
-
 /**
  * INTERNAL: Do not use.
  *

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -475,7 +475,7 @@ class FinalParameterUse extends UseImpl, TFinalParameterUse {
 
   int getArgumentIndex() { result = p.getIndex() }
 
-  override Node getNode() { finalParameterNodeHasParameterAndIndex(result, p, indirectionIndex) }
+  override FinalParameterNode getNode() { result.getUse() = this }
 
   override int getIndirection() { result = indirectionIndex + 1 }
 
@@ -509,6 +509,8 @@ class FinalParameterUse extends UseImpl, TFinalParameterUse {
     not exists(unique( | | p.getLocation())) and
     result instanceof UnknownDefaultLocation
   }
+
+  Type getType() { result = getTypeImpl(p.getUnderlyingType(), indirectionIndex) }
 
   override BaseIRVariable getBaseSourceVariable() { result.getIRVariable().getAst() = p }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -706,7 +706,7 @@ predicate defToNode(
     or
     nodeHasInstruction(node, def.getValue().asInstruction(), def.getIndirectionIndex())
     or
-    node.(InitialGlobalValue).getGlobalDef() = def
+    node = def.(GlobalDef).getNode()
   ) and
   if def.isCertain() then uncertain = false else uncertain = true
 }
@@ -1097,6 +1097,8 @@ class GlobalDef extends DefinitionExt {
    * definition.
    */
   GlobalLikeVariable getVariable() { result = impl.getVariable() }
+
+  InitialGlobalValue getNode() { result.getDef() = this }
 }
 
 private module SsaImpl = SsaImplCommon::Make<Location, SsaInput>;

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -61,6 +61,18 @@ private module SourceVariables {
 
     /** Gets the location of this variable. */
     Location getLocation() { result = this.getBaseVariable().getLocation() }
+
+    /**
+     * Gets the SSA variable that represents `k` indirections of this variable.
+     * Note that this is the identity for `k = 0`.
+     */
+    SourceVariable getIndirectVariable(int k) {
+      k >= 0 and
+      exists(BaseSourceVariable bv, int indirection |
+        sourceVariableHasBaseAndIndex(this, bv, indirection) and
+        sourceVariableHasBaseAndIndex(result, bv, indirection + k)
+      )
+    }
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/AllocationToInvalidPointer.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/AllocationToInvalidPointer.qll
@@ -319,7 +319,7 @@ private module Config implements ProductFlow::StateConfigSig {
     // In the above case, this barrier blocks flow from the indirect node
     // for `p` to `p[1]`.
     exists(Operand operand, PointerAddInstruction add |
-      node.(IndirectOperand).hasOperandAndIndirectionIndex(operand, _) and
+      node.(DataFlow::IndirectOperand).hasOperandAndIndirectionIndex(operand, _) and
       add.getLeftOperand() = operand and
       add.getRight().(ConstantInstruction).getValue() != "0"
     )

--- a/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
@@ -15,6 +15,7 @@
 import cpp
 import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 import semmle.code.cpp.ir.dataflow.DataFlow
+import semmle.code.cpp.ir.IR
 
 /** Gets a loop that contains `e`. */
 Loop getAnEnclosingLoopOfExpr(Expr e) { result = getAnEnclosingLoopOfStmt(e.getEnclosingStmt()) }
@@ -45,9 +46,15 @@ private Expr getExpr(DataFlow::Node node) {
   or
   result = node.asOperand().getUse().getAst()
   or
-  result = node.(DataFlow::RawIndirectInstruction).getInstruction().getAst()
+  exists(Instruction i |
+    node.(DataFlow::IndirectInstruction).hasInstructionAndIndirectionIndex(i, _) and
+    result = i.getAst()
+  )
   or
-  result = node.(DataFlow::RawIndirectOperand).getOperand().getUse().getAst()
+  exists(Operand op |
+    node.(DataFlow::IndirectOperand).hasOperandAndIndirectionIndex(op, _) and
+    result = op.getUse().getAst()
+  )
 }
 
 /**


### PR DESCRIPTION
This is my ongoing work related to adding dataflow through aliased definitions in C/C++ dataflow. For example for something like:
```cpp
int x;
int* p = &x;
x = source();
int y = *p;
sink(y);
```
on `main` there won't be any dataflow from `source()` to the `sink` argument, but on this branch we'll have that dataflow.

This is still a WIP since:
1. It has a 15-20% performance regression on DCA that I'm still battling, and
2. It still has a few cases of pointer/pointee conflation (i.e., we mistake an `int*` for an `int` and vice versa).

I'm leaving the PR open here for others to experiment with it.