### PR TITLE
PS: Fix parameter/argument name mapping for named parameters

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -540,7 +540,7 @@ private module ParameterNodes {
     override predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
       parameter.getEnclosingScope() = c.asCfgScope() and
       (
-        pos.isKeyword(parameter.getName())
+        pos.isKeyword(parameter.getName().toLowerCase())
         or
         // Given a function f with parameters x, y we map
         // x to the positions:
@@ -558,7 +558,7 @@ private module ParameterNodes {
           parameter.getIndexExcludingPipelines() = i and
           f = parameter.getFunction() and
           f = ns.getAFunction() and
-          name = parameter.getName() and
+          name = parameter.getName().toLowerCase() and
           not name = ns.getAName() and
           j =
             i -

--- a/powershell/ql/test/library-tests/dataflow/params/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/params/test.expected
@@ -142,6 +142,9 @@ edges
 | test.ps1:39:14:39:19 | third | test.ps1:8:32:12:1 | z | provenance |  |
 | test.ps1:39:24:39:30 | second | test.ps1:8:32:12:1 | y | provenance |  |
 | test.ps1:39:32:39:37 | first | test.ps1:8:32:12:1 | x | provenance |  |
+| test.ps1:42:1:45:1 | UserInput | test.ps1:44:10:44:19 | UserInput | provenance |  |
+| test.ps1:47:10:47:19 | Call to Source | test.ps1:48:46:48:51 | input | provenance |  |
+| test.ps1:48:46:48:51 | input | test.ps1:42:1:45:1 | UserInput | provenance |  |
 nodes
 | global.ps1:1:1:6:32 | Source1 | semmle.label | Source1 |
 | global.ps1:1:1:6:32 | Source2 | semmle.label | Source2 |
@@ -230,6 +233,10 @@ nodes
 | test.ps1:39:14:39:19 | third | semmle.label | third |
 | test.ps1:39:24:39:30 | second | semmle.label | second |
 | test.ps1:39:32:39:37 | first | semmle.label | first |
+| test.ps1:42:1:45:1 | UserInput | semmle.label | UserInput |
+| test.ps1:44:10:44:19 | UserInput | semmle.label | UserInput |
+| test.ps1:47:10:47:19 | Call to Source | semmle.label | Call to Source |
+| test.ps1:48:46:48:51 | input | semmle.label | input |
 subpaths
 testFailures
 #select
@@ -241,3 +248,4 @@ testFailures
 | test.ps1:9:10:9:11 | x | test.ps1:14:10:14:19 | Call to Source | test.ps1:9:10:9:11 | x | $@ | test.ps1:14:10:14:19 | Call to Source | Call to Source |
 | test.ps1:10:10:10:11 | y | test.ps1:15:11:15:20 | Call to Source | test.ps1:10:10:10:11 | y | $@ | test.ps1:15:11:15:20 | Call to Source | Call to Source |
 | test.ps1:11:10:11:11 | z | test.ps1:16:10:16:19 | Call to Source | test.ps1:11:10:11:11 | z | $@ | test.ps1:16:10:16:19 | Call to Source | Call to Source |
+| test.ps1:44:10:44:19 | UserInput | test.ps1:47:10:47:19 | Call to Source | test.ps1:44:10:44:19 | UserInput | $@ | test.ps1:47:10:47:19 | Call to Source | Call to Source |

--- a/powershell/ql/test/library-tests/dataflow/params/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/params/test.ps1
@@ -37,3 +37,12 @@ ThreeArgs -z $third $second -x $first
 ThreeArgs -z $third -x $first $second
 ThreeArgs -z $third $first -y $second
 ThreeArgs -z $third -y $second $first
+
+function Invoke-InvokeExpressionInjection2
+{
+    param($UserInput)
+    Sink $UserInput # $ MISSING: hasValueFlow=1
+}
+
+$input = Source "1"
+Invoke-InvokeExpressionInjection2 -UserInput $input  

--- a/powershell/ql/test/library-tests/dataflow/params/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/params/test.ps1
@@ -41,7 +41,7 @@ ThreeArgs -z $third -y $second $first
 function Invoke-InvokeExpressionInjection2
 {
     param($UserInput)
-    Sink $UserInput # $ MISSING: hasValueFlow=1
+    Sink $UserInput # $ hasValueFlow=1
 }
 
 $input = Source "1"


### PR DESCRIPTION
Another missing flow found by Chanel!

Because PowerShell is case insensitive you can do stuff like:
```powershell
function Foo {
  param($myParAm)

  Write-Output $myParAm
}

Foo -MyPARAM "Hello"
```

In dataflow we need to "normalize" all the parameter names by lower-casing them. And apparently I had forgotten to lower-case the parameter names 🤦