### PR TITLE
PS: Fix the last remaining missing flows after AST prettification

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/ChildIndex.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/ChildIndex.qll
@@ -33,11 +33,14 @@ newtype ChildIndex =
   } or
   ThisVar() or
   PipelineParamVar() or
-  // PipelineByPropertNameVar(Raw::PipelineByPropertyNameParameter p) or
+  PipelineByPropertyNameVar(Raw::PipelineByPropertyNameParameter p) or
   PipelineIteratorVar() or
   PipelineByPropertyNameIteratorVar(Raw::PipelineByPropertyNameParameter p) or
   RealVar(string name) { name = variableNameInScope(_, _) } or
-  ProcessBlockPipelineVarReadAccess()
+  ProcessBlockPipelineVarReadAccess() or
+  ProcessBlockPipelineByPropertyNameVarReadAccess(string name) {
+    name = any(Raw::PipelineByPropertyNameParameter p).getName()
+  }
 
 int synthPipelineParameterChildIndex(Raw::ScriptBlock sb) {
   // If there is a parameter block, but no pipeline parameter
@@ -340,3 +343,7 @@ ChildIndex whileStmtCond() { result = RawChildIndex(Raw::WhileStmtCond()) }
 ChildIndex whileStmtBody() { result = RawChildIndex(Raw::WhileStmtBody()) }
 
 ChildIndex processBlockPipelineVarReadAccess() { result = ProcessBlockPipelineVarReadAccess() }
+
+ChildIndex processBlockPipelineByPropertyNameVarReadAccess(string name) {
+  result = ProcessBlockPipelineByPropertyNameVarReadAccess(name)
+}

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/NamedBlock.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/NamedBlock.qll
@@ -58,7 +58,20 @@ class ProcessBlock extends NamedBlock {
     synthChild(getRawAst(this), processBlockPipelineVarReadAccess(), result)
   }
 
+  PipelineByPropertyNameParameter getPipelineByPropertyNameParameter(string name) {
+    result = scriptBlock.getAParameter() and
+    result.getPropertyName() = name
+  }
+
   PipelineByPropertyNameParameter getAPipelineByPropertyNameParameter() {
-    result = scriptBlock.getEnclosingFunction().getAParameter()
+    result = this.getPipelineByPropertyNameParameter(_)
+  }
+
+  VarReadAccess getPipelineByPropertyNameParameterAccess(string name) {
+    synthChild(getRawAst(this), processBlockPipelineByPropertyNameVarReadAccess(name), result)
+  }
+
+  VarReadAccess getAPipelineByPropertyNameParameterAccess() {
+    result = this.getPipelineByPropertyNameParameterAccess(_)
   }
 }

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Synthesis.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Synthesis.qll
@@ -615,7 +615,7 @@ private module LiteralSynth {
 
   /**
    * Holds if `va` is an access to the automatic variable named `name`.
-   * 
+   *
    * Unlike `Raw::isAutomaticVariableAccess`, this predicate also checks for
    * shadowing.
    */
@@ -770,6 +770,13 @@ private module IteratorAccessSynth {
         or
         va.getUserPath().toLowerCase() =
           pb.getScriptBlock().getParamBlock().getPipelineParameter().getName().toLowerCase()
+        or
+        va.getUserPath().toLowerCase() =
+          pb.getScriptBlock()
+              .getParamBlock()
+              .getAPipelineByPropertyNameParameter()
+              .getName()
+              .toLowerCase()
       )
     }
 
@@ -867,12 +874,19 @@ private module PipelineAccess {
           pipelineVar = TVariableSynth(pb.getScriptBlock(), PipelineParamVar()) and
           child = SynthChild(VarAccessSynthKind(pipelineVar))
         )
+        or
+        exists(PipelineByPropertyNameVariable pipelineVar, Raw::PipelineByPropertyNameParameter p |
+          i = processBlockPipelineByPropertyNameVarReadAccess(p.getName()) and
+          getResultAst(p) = pipelineVar and
+          child = SynthChild(VarAccessSynthKind(pipelineVar))
+        )
       )
     }
 
     final override Location getLocation(Ast n) {
       exists(ProcessBlock pb |
-        pb.getPipelineParameterAccess() = n and
+        pb.getPipelineParameterAccess() = n or pb.getAPipelineByPropertyNameParameterAccess() = n
+      |
         result = pb.getLocation()
       )
     }
@@ -881,6 +895,11 @@ private module PipelineAccess {
       exists(ProcessBlock pb |
         pb.getPipelineParameterAccess() = va and
         v = pb.getPipelineParameter()
+        or
+        exists(string name |
+          pb.getPipelineByPropertyNameParameterAccess(name) = va and
+          v = pb.getPipelineByPropertyNameParameter(name)
+        )
       )
     }
   }

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Synthesis.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Synthesis.qll
@@ -904,3 +904,15 @@ private module PipelineAccess {
     }
   }
 }
+
+private module ImplicitAssignmentInForEach {
+  private class ForEachAssignment extends Synthesis {
+    override predicate implicitAssignment(Raw::Ast dest, string name) {
+      exists(Raw::ForEachStmt forEach, Raw::VarAccess va |
+        va = forEach.getVarAccess() and
+        va = dest and
+        va.getUserPath() = name
+      )
+    }
+  }
+}

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Variable.qll
@@ -45,7 +45,9 @@ module Private {
 
   class ParameterImpl extends VariableSynth {
     ParameterImpl() {
-      i instanceof FunParam or i instanceof PipelineParamVar or i instanceof ThisVar
+      i instanceof FunParam or
+      i instanceof PipelineParamVar or
+      i instanceof ThisVar
     }
   }
 
@@ -55,6 +57,14 @@ module Private {
 
   class PipelineVariableImpl extends ParameterImpl {
     override PipelineParamVar i;
+
+    ScriptBlock getScriptBlock() { this = TVariableSynth(getRawAst(result), _) }
+  }
+
+  class PipelineByPropertyNameVariableImpl extends ParameterImpl {
+    PipelineByPropertyNameVariableImpl() {
+      getRawAst(this) instanceof Raw::PipelineByPropertyNameParameter
+    }
 
     ScriptBlock getScriptBlock() { this = TVariableSynth(getRawAst(result), _) }
   }
@@ -168,6 +178,11 @@ module Public {
   }
 
   class PipelineVariable extends Variable instanceof PipelineVariableImpl {
+    ScriptBlock getScriptBlock() { result = super.getScriptBlock() }
+  }
+
+  class PipelineByPropertyNameVariable extends Variable instanceof PipelineByPropertyNameVariableImpl
+  {
     ScriptBlock getScriptBlock() { result = super.getScriptBlock() }
   }
 

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -277,6 +277,8 @@ private class ProcessBlockChildMapping extends NamedBlockChildMapping, ProcessBl
     super.relevantChild(child)
     or
     child = super.getPipelineParameterAccess()
+    or
+    child = super.getAPipelineByPropertyNameParameterAccess()
   }
 }
 
@@ -299,6 +301,23 @@ class ProcessBlockCfgNode extends NamedBlockCfgNode {
 
   PipelineIteratorVariable getPipelineIteratorVariable() {
     result.getProcessBlock().getScriptBlock() = this.getScriptBlock().getAstNode()
+  }
+
+  PipelineByPropertyNameIteratorVariable getPipelineBypropertyNameIteratorVariable(string name) {
+    result.getPropertyName() = name and
+    result.getProcessBlock().getScriptBlock() = this.getScriptBlock().getAstNode()
+  }
+
+  PipelineByPropertyNameIteratorVariable getAPipelineBypropertyNameIteratorVariable() {
+    result = this.getPipelineBypropertyNameIteratorVariable(_)
+  }
+
+  ExprNodes::VarReadAccessCfgNode getPipelineByPropertyNameParameterAccess(string name) {
+    block.hasCfgChild(block.getPipelineByPropertyNameParameterAccess(name), this, result)
+  }
+
+  ExprNodes::VarReadAccessCfgNode getAPipelineByPropertyNameParameterAccess() {
+    result = this.getPipelineByPropertyNameParameterAccess(_)
   }
 }
 

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/Completion.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/Completion.qll
@@ -188,7 +188,11 @@ private predicate inMatchingContext(Ast n) {
  * Holds if a normal completion of `cfe` must be an emptiness completion. Thats is,
  * whether `cfe` determines whether to execute the body of a `foreach` statement.
  */
-private predicate mustHaveEmptinessCompletion(Ast n) { n instanceof ForEachStmt }
+private predicate mustHaveEmptinessCompletion(Ast n) {
+  n instanceof ForEachStmt
+  or
+  any(CfgImpl::Trees::ProcessBlockTree pbtree).lastEmptinessCheck(n)
+}
 
 /**
  * A completion that represents normal evaluation of a statement or an

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
@@ -158,7 +158,7 @@ module Ssa {
         not exists(this.getSplitString()) and
         prefix = ""
       |
-        result = prefix + "phi"
+        result = prefix + "phi (" + this.getSourceVariable() + ")"
       )
     }
 

--- a/powershell/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/powershell/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -271,8 +271,14 @@
 | functions.ps1:28:5:28:8 | sum | functions.ps1:28:12:28:12 | 0 |  |
 | functions.ps1:28:5:28:12 | ...=... | functions.ps1:28:5:28:8 | sum |  |
 | functions.ps1:28:12:28:12 | 0 | functions.ps1:29:25:29:32 | numbers |  |
+| functions.ps1:29:5:32:5 | forach(... in ...) | functions.ps1:29:14:29:20 | number | non-empty |
 | functions.ps1:29:5:32:5 | forach(... in ...) | functions.ps1:33:5:33:8 | [Stmt] sum | empty |
+| functions.ps1:29:14:29:20 | number | functions.ps1:29:35:32:5 | {...} |  |
 | functions.ps1:29:25:29:32 | numbers | functions.ps1:29:5:32:5 | forach(... in ...) |  |
+| functions.ps1:29:35:32:5 | {...} | functions.ps1:31:9:31:23 | ...=... |  |
+| functions.ps1:31:9:31:12 | sum | functions.ps1:31:17:31:23 | number |  |
+| functions.ps1:31:9:31:23 | ...=... | functions.ps1:31:9:31:12 | sum |  |
+| functions.ps1:31:17:31:23 | number | functions.ps1:29:5:32:5 | forach(... in ...) |  |
 | functions.ps1:33:5:33:8 | [Stmt] sum | functions.ps1:33:5:33:8 | sum |  |
 | functions.ps1:33:5:33:8 | sum | functions.ps1:22:33:34:1 | exit {...} (normal) |  |
 | functions.ps1:36:1:52:1 | def of Add-Numbers-From-Pipeline | functions.ps1:1:1:54:0 | exit {...} (normal) |  |
@@ -284,9 +290,10 @@
 | functions.ps1:41:5:43:5 | {...} | functions.ps1:42:9:42:16 | ...=... |  |
 | functions.ps1:42:9:42:12 | sum | functions.ps1:42:16:42:16 | 0 |  |
 | functions.ps1:42:9:42:16 | ...=... | functions.ps1:42:9:42:12 | sum |  |
-| functions.ps1:42:16:42:16 | 0 | functions.ps1:44:5:47:5 | [synth] pipeline |  |
-| functions.ps1:44:5:47:5 | [synth] pipeline | functions.ps1:44:5:47:5 | {...} |  |
-| functions.ps1:44:5:47:5 | {...} | functions.ps1:46:9:46:18 | ...=... |  |
+| functions.ps1:42:16:42:16 | 0 | functions.ps1:44:5:47:5 | {...} |  |
+| functions.ps1:44:5:47:5 | [synth] pipeline | functions.ps1:46:9:46:18 | ...=... | non-empty |
+| functions.ps1:44:5:47:5 | [synth] pipeline | functions.ps1:48:5:51:5 | {...} | empty |
+| functions.ps1:44:5:47:5 | {...} | functions.ps1:44:5:47:5 | [synth] pipeline |  |
 | functions.ps1:46:9:46:12 | sum | functions.ps1:46:17:46:18 | __pipeline_iterator |  |
 | functions.ps1:46:9:46:18 | ...=... | functions.ps1:46:9:46:12 | sum |  |
 | functions.ps1:46:17:46:18 | __pipeline_iterator | functions.ps1:44:5:47:5 | [synth] pipeline |  |
@@ -452,7 +459,15 @@
 | loops.ps1:51:5:51:10 | ...=... | loops.ps1:51:5:51:6 | a |  |
 | loops.ps1:51:10:51:10 | 0 | loops.ps1:52:25:52:36 | letterArray |  |
 | loops.ps1:52:5:55:5 | forach(... in ...) | loops.ps1:49:23:56:1 | exit {...} (normal) | empty |
+| loops.ps1:52:5:55:5 | forach(... in ...) | loops.ps1:52:14:52:20 | letter | non-empty |
+| loops.ps1:52:14:52:20 | letter | loops.ps1:53:5:55:5 | {...} |  |
 | loops.ps1:52:25:52:36 | letterArray | loops.ps1:52:5:55:5 | forach(... in ...) |  |
+| loops.ps1:53:5:55:5 | {...} | loops.ps1:54:9:54:19 | ...=... |  |
+| loops.ps1:54:9:54:10 | a | loops.ps1:54:14:54:15 | a |  |
+| loops.ps1:54:9:54:19 | ...=... | loops.ps1:54:9:54:10 | a |  |
+| loops.ps1:54:14:54:15 | a | loops.ps1:54:19:54:19 | 1 |  |
+| loops.ps1:54:14:54:19 | ...+... | loops.ps1:52:5:55:5 | forach(... in ...) |  |
+| loops.ps1:54:19:54:19 | 1 | loops.ps1:54:14:54:19 | ...+... |  |
 | loops.ps1:58:1:68:1 | def of Test-For-Ever | loops.ps1:1:1:70:0 | exit {...} (normal) |  |
 | loops.ps1:58:24:68:1 | [synth] pipeline | loops.ps1:59:5:67:5 | {...} |  |
 | loops.ps1:58:24:68:1 | enter {...} | loops.ps1:58:24:68:1 | {...} |  |

--- a/powershell/ql/test/library-tests/dataflow/fields/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.expected
@@ -6,33 +6,33 @@ edges
 | test.ps1:10:1:10:5 | [post] arr1 [element 3] | test.ps1:11:6:11:10 | arr1 [element 3] | provenance |  |
 | test.ps1:10:12:10:21 | Call to Source | test.ps1:10:1:10:5 | [post] arr1 [element 3] | provenance |  |
 | test.ps1:11:6:11:10 | arr1 [element 3] | test.ps1:11:6:11:13 | ...[...] | provenance |  |
-| test.ps1:14:1:14:5 | [post] arr2 [element] | test.ps1:15:6:15:10 | arr2 [element] | provenance |  |
-| test.ps1:14:19:14:28 | Call to Source | test.ps1:14:1:14:5 | [post] arr2 [element] | provenance |  |
-| test.ps1:15:6:15:10 | arr2 [element] | test.ps1:15:6:15:13 | ...[...] | provenance |  |
+| test.ps1:14:1:14:5 | [post] arr2 [unknown] | test.ps1:15:6:15:10 | arr2 [unknown] | provenance |  |
+| test.ps1:14:19:14:28 | Call to Source | test.ps1:14:1:14:5 | [post] arr2 [unknown] | provenance |  |
+| test.ps1:15:6:15:10 | arr2 [unknown] | test.ps1:15:6:15:13 | ...[...] | provenance |  |
 | test.ps1:17:1:17:5 | [post] arr3 [element 3] | test.ps1:18:6:18:10 | arr3 [element 3] | provenance |  |
 | test.ps1:17:12:17:21 | Call to Source | test.ps1:17:1:17:5 | [post] arr3 [element 3] | provenance |  |
 | test.ps1:18:6:18:10 | arr3 [element 3] | test.ps1:18:6:18:20 | ...[...] | provenance |  |
-| test.ps1:20:1:20:5 | [post] arr4 [element] | test.ps1:21:6:21:10 | arr4 [element] | provenance |  |
-| test.ps1:20:20:20:29 | Call to Source | test.ps1:20:1:20:5 | [post] arr4 [element] | provenance |  |
-| test.ps1:21:6:21:10 | arr4 [element] | test.ps1:21:6:21:21 | ...[...] | provenance |  |
-| test.ps1:23:1:23:5 | [post] arr5 [element, element 1] | test.ps1:24:6:24:10 | arr5 [element, element 1] | provenance |  |
-| test.ps1:23:1:23:16 | [post] ...[...] [element 1] | test.ps1:23:1:23:5 | [post] arr5 [element, element 1] | provenance |  |
+| test.ps1:20:1:20:5 | [post] arr4 [unknown] | test.ps1:21:6:21:10 | arr4 [unknown] | provenance |  |
+| test.ps1:20:20:20:29 | Call to Source | test.ps1:20:1:20:5 | [post] arr4 [unknown] | provenance |  |
+| test.ps1:21:6:21:10 | arr4 [unknown] | test.ps1:21:6:21:21 | ...[...] | provenance |  |
+| test.ps1:23:1:23:5 | [post] arr5 [unknown, element 1] | test.ps1:24:6:24:10 | arr5 [unknown, element 1] | provenance |  |
+| test.ps1:23:1:23:16 | [post] ...[...] [element 1] | test.ps1:23:1:23:5 | [post] arr5 [unknown, element 1] | provenance |  |
 | test.ps1:23:23:23:32 | Call to Source | test.ps1:23:1:23:16 | [post] ...[...] [element 1] | provenance |  |
-| test.ps1:24:6:24:10 | arr5 [element, element 1] | test.ps1:24:6:24:21 | ...[...] [element 1] | provenance |  |
+| test.ps1:24:6:24:10 | arr5 [unknown, element 1] | test.ps1:24:6:24:21 | ...[...] [element 1] | provenance |  |
 | test.ps1:24:6:24:21 | ...[...] [element 1] | test.ps1:24:6:24:24 | ...[...] | provenance |  |
-| test.ps1:27:1:27:5 | [post] arr6 [element 1, element] | test.ps1:28:6:28:10 | arr6 [element 1, element] | provenance |  |
-| test.ps1:27:1:27:8 | [post] ...[...] [element] | test.ps1:27:1:27:5 | [post] arr6 [element 1, element] | provenance |  |
-| test.ps1:27:23:27:32 | Call to Source | test.ps1:27:1:27:8 | [post] ...[...] [element] | provenance |  |
-| test.ps1:28:6:28:10 | arr6 [element 1, element] | test.ps1:28:6:28:13 | ...[...] [element] | provenance |  |
-| test.ps1:28:6:28:13 | ...[...] [element] | test.ps1:28:6:28:24 | ...[...] | provenance |  |
-| test.ps1:31:1:31:5 | [post] arr7 [element, element] | test.ps1:32:6:32:10 | arr7 [element, element] | provenance |  |
-| test.ps1:31:1:31:5 | [post] arr7 [element, element] | test.ps1:33:6:33:10 | arr7 [element, element] | provenance |  |
-| test.ps1:31:1:31:16 | [post] ...[...] [element] | test.ps1:31:1:31:5 | [post] arr7 [element, element] | provenance |  |
-| test.ps1:31:31:31:40 | Call to Source | test.ps1:31:1:31:16 | [post] ...[...] [element] | provenance |  |
-| test.ps1:32:6:32:10 | arr7 [element, element] | test.ps1:32:6:32:13 | ...[...] [element] | provenance |  |
-| test.ps1:32:6:32:13 | ...[...] [element] | test.ps1:32:6:32:16 | ...[...] | provenance |  |
-| test.ps1:33:6:33:10 | arr7 [element, element] | test.ps1:33:6:33:21 | ...[...] [element] | provenance |  |
-| test.ps1:33:6:33:21 | ...[...] [element] | test.ps1:33:6:33:32 | ...[...] | provenance |  |
+| test.ps1:27:1:27:5 | [post] arr6 [element 1, unknown] | test.ps1:28:6:28:10 | arr6 [element 1, unknown] | provenance |  |
+| test.ps1:27:1:27:8 | [post] ...[...] [unknown] | test.ps1:27:1:27:5 | [post] arr6 [element 1, unknown] | provenance |  |
+| test.ps1:27:23:27:32 | Call to Source | test.ps1:27:1:27:8 | [post] ...[...] [unknown] | provenance |  |
+| test.ps1:28:6:28:10 | arr6 [element 1, unknown] | test.ps1:28:6:28:13 | ...[...] [unknown] | provenance |  |
+| test.ps1:28:6:28:13 | ...[...] [unknown] | test.ps1:28:6:28:24 | ...[...] | provenance |  |
+| test.ps1:31:1:31:5 | [post] arr7 [unknown, unknown] | test.ps1:32:6:32:10 | arr7 [unknown, unknown] | provenance |  |
+| test.ps1:31:1:31:5 | [post] arr7 [unknown, unknown] | test.ps1:33:6:33:10 | arr7 [unknown, unknown] | provenance |  |
+| test.ps1:31:1:31:16 | [post] ...[...] [unknown] | test.ps1:31:1:31:5 | [post] arr7 [unknown, unknown] | provenance |  |
+| test.ps1:31:31:31:40 | Call to Source | test.ps1:31:1:31:16 | [post] ...[...] [unknown] | provenance |  |
+| test.ps1:32:6:32:10 | arr7 [unknown, unknown] | test.ps1:32:6:32:13 | ...[...] [unknown] | provenance |  |
+| test.ps1:32:6:32:13 | ...[...] [unknown] | test.ps1:32:6:32:16 | ...[...] | provenance |  |
+| test.ps1:33:6:33:10 | arr7 [unknown, unknown] | test.ps1:33:6:33:21 | ...[...] [unknown] | provenance |  |
+| test.ps1:33:6:33:21 | ...[...] [unknown] | test.ps1:33:6:33:32 | ...[...] | provenance |  |
 | test.ps1:35:6:35:16 | Call to Source | test.ps1:37:15:37:16 | x | provenance |  |
 | test.ps1:37:9:37:16 | ...,... [element 2] | test.ps1:40:6:40:10 | arr8 [element 2] | provenance |  |
 | test.ps1:37:9:37:16 | ...,... [element 2] | test.ps1:41:6:41:10 | arr8 [element 2] | provenance |  |
@@ -53,15 +53,15 @@ edges
 | test.ps1:66:10:66:20 | Call to Source | test.ps1:69:5:69:6 | x | provenance |  |
 | test.ps1:67:10:67:20 | Call to Source | test.ps1:70:5:70:6 | y | provenance |  |
 | test.ps1:68:10:68:20 | Call to Source | test.ps1:70:9:70:10 | z | provenance |  |
-| test.ps1:69:5:69:6 | x | test.ps1:73:6:73:12 | Call to produce [element] | provenance |  |
-| test.ps1:70:5:70:6 | y | test.ps1:73:6:73:12 | Call to produce [element] | provenance |  |
-| test.ps1:70:9:70:10 | z | test.ps1:73:6:73:12 | Call to produce [element] | provenance |  |
-| test.ps1:73:6:73:12 | Call to produce [element] | test.ps1:74:6:74:7 | x [element] | provenance |  |
-| test.ps1:73:6:73:12 | Call to produce [element] | test.ps1:75:6:75:7 | x [element] | provenance |  |
-| test.ps1:73:6:73:12 | Call to produce [element] | test.ps1:76:6:76:7 | x [element] | provenance |  |
-| test.ps1:74:6:74:7 | x [element] | test.ps1:74:6:74:10 | ...[...] | provenance |  |
-| test.ps1:75:6:75:7 | x [element] | test.ps1:75:6:75:10 | ...[...] | provenance |  |
-| test.ps1:76:6:76:7 | x [element] | test.ps1:76:6:76:10 | ...[...] | provenance |  |
+| test.ps1:69:5:69:6 | x | test.ps1:73:6:73:12 | Call to produce [unknown index] | provenance |  |
+| test.ps1:70:5:70:6 | y | test.ps1:73:6:73:12 | Call to produce [unknown index] | provenance |  |
+| test.ps1:70:9:70:10 | z | test.ps1:73:6:73:12 | Call to produce [unknown index] | provenance |  |
+| test.ps1:73:6:73:12 | Call to produce [unknown index] | test.ps1:74:6:74:7 | x [unknown index] | provenance |  |
+| test.ps1:73:6:73:12 | Call to produce [unknown index] | test.ps1:75:6:75:7 | x [unknown index] | provenance |  |
+| test.ps1:73:6:73:12 | Call to produce [unknown index] | test.ps1:76:6:76:7 | x [unknown index] | provenance |  |
+| test.ps1:74:6:74:7 | x [unknown index] | test.ps1:74:6:74:10 | ...[...] | provenance |  |
+| test.ps1:75:6:75:7 | x [unknown index] | test.ps1:75:6:75:10 | ...[...] | provenance |  |
+| test.ps1:76:6:76:7 | x [unknown index] | test.ps1:76:6:76:10 | ...[...] | provenance |  |
 | test.ps1:78:9:81:1 | ${...} [element a] | test.ps1:83:6:83:10 | hash [element a] | provenance |  |
 | test.ps1:78:9:81:1 | ${...} [element a] | test.ps1:87:6:87:10 | hash [element a] | provenance |  |
 | test.ps1:79:7:79:17 | Call to Source | test.ps1:78:9:81:1 | ${...} [element a] | provenance |  |
@@ -79,38 +79,38 @@ nodes
 | test.ps1:10:12:10:21 | Call to Source | semmle.label | Call to Source |
 | test.ps1:11:6:11:10 | arr1 [element 3] | semmle.label | arr1 [element 3] |
 | test.ps1:11:6:11:13 | ...[...] | semmle.label | ...[...] |
-| test.ps1:14:1:14:5 | [post] arr2 [element] | semmle.label | [post] arr2 [element] |
+| test.ps1:14:1:14:5 | [post] arr2 [unknown] | semmle.label | [post] arr2 [unknown] |
 | test.ps1:14:19:14:28 | Call to Source | semmle.label | Call to Source |
-| test.ps1:15:6:15:10 | arr2 [element] | semmle.label | arr2 [element] |
+| test.ps1:15:6:15:10 | arr2 [unknown] | semmle.label | arr2 [unknown] |
 | test.ps1:15:6:15:13 | ...[...] | semmle.label | ...[...] |
 | test.ps1:17:1:17:5 | [post] arr3 [element 3] | semmle.label | [post] arr3 [element 3] |
 | test.ps1:17:12:17:21 | Call to Source | semmle.label | Call to Source |
 | test.ps1:18:6:18:10 | arr3 [element 3] | semmle.label | arr3 [element 3] |
 | test.ps1:18:6:18:20 | ...[...] | semmle.label | ...[...] |
-| test.ps1:20:1:20:5 | [post] arr4 [element] | semmle.label | [post] arr4 [element] |
+| test.ps1:20:1:20:5 | [post] arr4 [unknown] | semmle.label | [post] arr4 [unknown] |
 | test.ps1:20:20:20:29 | Call to Source | semmle.label | Call to Source |
-| test.ps1:21:6:21:10 | arr4 [element] | semmle.label | arr4 [element] |
+| test.ps1:21:6:21:10 | arr4 [unknown] | semmle.label | arr4 [unknown] |
 | test.ps1:21:6:21:21 | ...[...] | semmle.label | ...[...] |
-| test.ps1:23:1:23:5 | [post] arr5 [element, element 1] | semmle.label | [post] arr5 [element, element 1] |
+| test.ps1:23:1:23:5 | [post] arr5 [unknown, element 1] | semmle.label | [post] arr5 [unknown, element 1] |
 | test.ps1:23:1:23:16 | [post] ...[...] [element 1] | semmle.label | [post] ...[...] [element 1] |
 | test.ps1:23:23:23:32 | Call to Source | semmle.label | Call to Source |
-| test.ps1:24:6:24:10 | arr5 [element, element 1] | semmle.label | arr5 [element, element 1] |
+| test.ps1:24:6:24:10 | arr5 [unknown, element 1] | semmle.label | arr5 [unknown, element 1] |
 | test.ps1:24:6:24:21 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | test.ps1:24:6:24:24 | ...[...] | semmle.label | ...[...] |
-| test.ps1:27:1:27:5 | [post] arr6 [element 1, element] | semmle.label | [post] arr6 [element 1, element] |
-| test.ps1:27:1:27:8 | [post] ...[...] [element] | semmle.label | [post] ...[...] [element] |
+| test.ps1:27:1:27:5 | [post] arr6 [element 1, unknown] | semmle.label | [post] arr6 [element 1, unknown] |
+| test.ps1:27:1:27:8 | [post] ...[...] [unknown] | semmle.label | [post] ...[...] [unknown] |
 | test.ps1:27:23:27:32 | Call to Source | semmle.label | Call to Source |
-| test.ps1:28:6:28:10 | arr6 [element 1, element] | semmle.label | arr6 [element 1, element] |
-| test.ps1:28:6:28:13 | ...[...] [element] | semmle.label | ...[...] [element] |
+| test.ps1:28:6:28:10 | arr6 [element 1, unknown] | semmle.label | arr6 [element 1, unknown] |
+| test.ps1:28:6:28:13 | ...[...] [unknown] | semmle.label | ...[...] [unknown] |
 | test.ps1:28:6:28:24 | ...[...] | semmle.label | ...[...] |
-| test.ps1:31:1:31:5 | [post] arr7 [element, element] | semmle.label | [post] arr7 [element, element] |
-| test.ps1:31:1:31:16 | [post] ...[...] [element] | semmle.label | [post] ...[...] [element] |
+| test.ps1:31:1:31:5 | [post] arr7 [unknown, unknown] | semmle.label | [post] arr7 [unknown, unknown] |
+| test.ps1:31:1:31:16 | [post] ...[...] [unknown] | semmle.label | [post] ...[...] [unknown] |
 | test.ps1:31:31:31:40 | Call to Source | semmle.label | Call to Source |
-| test.ps1:32:6:32:10 | arr7 [element, element] | semmle.label | arr7 [element, element] |
-| test.ps1:32:6:32:13 | ...[...] [element] | semmle.label | ...[...] [element] |
+| test.ps1:32:6:32:10 | arr7 [unknown, unknown] | semmle.label | arr7 [unknown, unknown] |
+| test.ps1:32:6:32:13 | ...[...] [unknown] | semmle.label | ...[...] [unknown] |
 | test.ps1:32:6:32:16 | ...[...] | semmle.label | ...[...] |
-| test.ps1:33:6:33:10 | arr7 [element, element] | semmle.label | arr7 [element, element] |
-| test.ps1:33:6:33:21 | ...[...] [element] | semmle.label | ...[...] [element] |
+| test.ps1:33:6:33:10 | arr7 [unknown, unknown] | semmle.label | arr7 [unknown, unknown] |
+| test.ps1:33:6:33:21 | ...[...] [unknown] | semmle.label | ...[...] [unknown] |
 | test.ps1:33:6:33:32 | ...[...] | semmle.label | ...[...] |
 | test.ps1:35:6:35:16 | Call to Source | semmle.label | Call to Source |
 | test.ps1:37:9:37:16 | ...,... [element 2] | semmle.label | ...,... [element 2] |
@@ -138,12 +138,12 @@ nodes
 | test.ps1:69:5:69:6 | x | semmle.label | x |
 | test.ps1:70:5:70:6 | y | semmle.label | y |
 | test.ps1:70:9:70:10 | z | semmle.label | z |
-| test.ps1:73:6:73:12 | Call to produce [element] | semmle.label | Call to produce [element] |
-| test.ps1:74:6:74:7 | x [element] | semmle.label | x [element] |
+| test.ps1:73:6:73:12 | Call to produce [unknown index] | semmle.label | Call to produce [unknown index] |
+| test.ps1:74:6:74:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:74:6:74:10 | ...[...] | semmle.label | ...[...] |
-| test.ps1:75:6:75:7 | x [element] | semmle.label | x [element] |
+| test.ps1:75:6:75:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:75:6:75:10 | ...[...] | semmle.label | ...[...] |
-| test.ps1:76:6:76:7 | x [element] | semmle.label | x [element] |
+| test.ps1:76:6:76:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:76:6:76:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:78:9:81:1 | ${...} [element a] | semmle.label | ${...} [element a] |
 | test.ps1:79:7:79:17 | Call to Source | semmle.label | Call to Source |

--- a/powershell/ql/test/library-tests/dataflow/local/flow.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/flow.expected
@@ -6,11 +6,11 @@
 | test.ps1:2:1:2:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:4:1:4:2 | b | test.ps1:5:4:5:5 | b |
 | test.ps1:4:6:4:12 | Call to GetBool | test.ps1:4:1:4:2 | b |
-| test.ps1:5:1:7:1 | phi | test.ps1:8:6:8:8 | a2 |
+| test.ps1:5:1:7:1 | phi (a2) | test.ps1:8:6:8:8 | a2 |
 | test.ps1:5:4:5:5 | b | test.ps1:10:14:10:15 | b |
-| test.ps1:6:5:6:7 | a2 | test.ps1:6:11:6:16 | [input] phi |
+| test.ps1:6:5:6:7 | a2 | test.ps1:6:11:6:16 | [input] phi (a2) |
 | test.ps1:6:11:6:16 | Call to Source | test.ps1:6:5:6:7 | a2 |
-| test.ps1:6:11:6:16 | [input] phi | test.ps1:5:1:7:1 | phi |
+| test.ps1:6:11:6:16 | [input] phi (a2) | test.ps1:5:1:7:1 | phi (a2) |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:10:1:10:2 | c | test.ps1:11:6:11:7 | c |

--- a/powershell/ql/test/library-tests/dataflow/local/taint.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/taint.expected
@@ -7,11 +7,11 @@
 | test.ps1:2:1:2:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:4:1:4:2 | b | test.ps1:5:4:5:5 | b |
 | test.ps1:4:6:4:12 | Call to GetBool | test.ps1:4:1:4:2 | b |
-| test.ps1:5:1:7:1 | phi | test.ps1:8:6:8:8 | a2 |
+| test.ps1:5:1:7:1 | phi (a2) | test.ps1:8:6:8:8 | a2 |
 | test.ps1:5:4:5:5 | b | test.ps1:10:14:10:15 | b |
-| test.ps1:6:5:6:7 | a2 | test.ps1:6:11:6:16 | [input] phi |
+| test.ps1:6:5:6:7 | a2 | test.ps1:6:11:6:16 | [input] phi (a2) |
 | test.ps1:6:11:6:16 | Call to Source | test.ps1:6:5:6:7 | a2 |
-| test.ps1:6:11:6:16 | [input] phi | test.ps1:5:1:7:1 | phi |
+| test.ps1:6:11:6:16 | [input] phi (a2) | test.ps1:5:1:7:1 | phi (a2) |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:10:1:10:2 | c | test.ps1:11:6:11:7 | c |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
@@ -13,14 +13,11 @@ edges
 | test.ps1:12:5:14:5 | [synth] pipeline [element 1] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
 | test.ps1:12:5:14:5 | [synth] pipeline [unknown index] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
 | test.ps1:17:1:17:7 | Call to produce [unknown index] | test.ps1:9:29:15:1 | [synth] pipeline [unknown index] | provenance |  |
-| test.ps1:17:1:17:7 | Call to produce [unknown index] | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
 | test.ps1:19:6:19:15 | Call to Source | test.ps1:21:1:21:2 | x | provenance |  |
 | test.ps1:20:6:20:15 | Call to Source | test.ps1:21:5:21:6 | y | provenance |  |
 | test.ps1:21:1:21:2 | x | test.ps1:21:1:21:6 | ...,... [element 0] | provenance |  |
 | test.ps1:21:1:21:6 | ...,... [element 0] | test.ps1:9:29:15:1 | [synth] pipeline [element 0] | provenance |  |
-| test.ps1:21:1:21:6 | ...,... [element 0] | test.ps1:21:1:21:6 | ...,... [element 0] | provenance |  |
 | test.ps1:21:1:21:6 | ...,... [element 1] | test.ps1:9:29:15:1 | [synth] pipeline [element 1] | provenance |  |
-| test.ps1:21:1:21:6 | ...,... [element 1] | test.ps1:21:1:21:6 | ...,... [element 1] | provenance |  |
 | test.ps1:21:5:21:6 | y | test.ps1:21:1:21:6 | ...,... [element 1] | provenance |  |
 | test.ps1:23:38:27:1 | [synth] pipeline [element 0] | test.ps1:24:5:26:5 | [synth] pipeline [element 0] | provenance |  |
 | test.ps1:23:38:27:1 | [synth] pipeline [element 1] | test.ps1:24:5:26:5 | [synth] pipeline [element 1] | provenance |  |
@@ -30,10 +27,26 @@ edges
 | test.ps1:30:6:30:15 | Call to Source | test.ps1:31:5:31:6 | y | provenance |  |
 | test.ps1:31:1:31:2 | x | test.ps1:31:1:31:6 | ...,... [element 0] | provenance |  |
 | test.ps1:31:1:31:6 | ...,... [element 0] | test.ps1:23:38:27:1 | [synth] pipeline [element 0] | provenance |  |
-| test.ps1:31:1:31:6 | ...,... [element 0] | test.ps1:31:1:31:6 | ...,... [element 0] | provenance |  |
 | test.ps1:31:1:31:6 | ...,... [element 1] | test.ps1:23:38:27:1 | [synth] pipeline [element 1] | provenance |  |
-| test.ps1:31:1:31:6 | ...,... [element 1] | test.ps1:31:1:31:6 | ...,... [element 1] | provenance |  |
 | test.ps1:31:5:31:6 | y | test.ps1:31:1:31:6 | ...,... [element 1] | provenance |  |
+| test.ps1:42:60:48:1 | x [element 0, element x] | test.ps1:45:5:47:5 | x [element 0, element x] | provenance |  |
+| test.ps1:42:60:48:1 | x [element 1, element x] | test.ps1:45:5:47:5 | x [element 1, element x] | provenance |  |
+| test.ps1:42:60:48:1 | x [element 2, element x] | test.ps1:45:5:47:5 | x [element 2, element x] | provenance |  |
+| test.ps1:45:5:47:5 | x [element 0, element x] | test.ps1:46:9:46:15 | __pipeline_iterator for x | provenance |  |
+| test.ps1:45:5:47:5 | x [element 1, element x] | test.ps1:46:9:46:15 | __pipeline_iterator for x | provenance |  |
+| test.ps1:45:5:47:5 | x [element 2, element x] | test.ps1:46:9:46:15 | __pipeline_iterator for x | provenance |  |
+| test.ps1:50:1:50:33 | [...]... [element x] | test.ps1:50:1:50:105 | ...,... [element 0, element x] | provenance |  |
+| test.ps1:50:1:50:105 | ...,... [element 0, element x] | test.ps1:42:60:48:1 | x [element 0, element x] | provenance |  |
+| test.ps1:50:1:50:105 | ...,... [element 1, element x] | test.ps1:42:60:48:1 | x [element 1, element x] | provenance |  |
+| test.ps1:50:1:50:105 | ...,... [element 2, element x] | test.ps1:42:60:48:1 | x [element 2, element x] | provenance |  |
+| test.ps1:50:17:50:33 | ${...} [element x] | test.ps1:50:1:50:33 | [...]... [element x] | provenance |  |
+| test.ps1:50:23:50:32 | Call to Source | test.ps1:50:17:50:33 | ${...} [element x] | provenance |  |
+| test.ps1:50:36:50:69 | [...]... [element x] | test.ps1:50:1:50:105 | ...,... [element 1, element x] | provenance |  |
+| test.ps1:50:52:50:69 | ${...} [element x] | test.ps1:50:36:50:69 | [...]... [element x] | provenance |  |
+| test.ps1:50:58:50:68 | Call to Source | test.ps1:50:52:50:69 | ${...} [element x] | provenance |  |
+| test.ps1:50:72:50:105 | [...]... [element x] | test.ps1:50:1:50:105 | ...,... [element 2, element x] | provenance |  |
+| test.ps1:50:88:50:105 | ${...} [element x] | test.ps1:50:72:50:105 | [...]... [element x] | provenance |  |
+| test.ps1:50:94:50:104 | Call to Source | test.ps1:50:88:50:105 | ${...} [element x] | provenance |  |
 nodes
 | test.ps1:2:10:2:19 | Call to Source | semmle.label | Call to Source |
 | test.ps1:3:10:3:19 | Call to Source | semmle.label | Call to Source |
@@ -49,13 +62,10 @@ nodes
 | test.ps1:12:5:14:5 | [synth] pipeline [unknown index] | semmle.label | [synth] pipeline [unknown index] |
 | test.ps1:13:9:13:15 | __pipeline_iterator | semmle.label | __pipeline_iterator |
 | test.ps1:17:1:17:7 | Call to produce [unknown index] | semmle.label | Call to produce [unknown index] |
-| test.ps1:17:1:17:7 | Call to produce [unknown index] | semmle.label | Call to produce [unknown index] |
 | test.ps1:19:6:19:15 | Call to Source | semmle.label | Call to Source |
 | test.ps1:20:6:20:15 | Call to Source | semmle.label | Call to Source |
 | test.ps1:21:1:21:2 | x | semmle.label | x |
 | test.ps1:21:1:21:6 | ...,... [element 0] | semmle.label | ...,... [element 0] |
-| test.ps1:21:1:21:6 | ...,... [element 0] | semmle.label | ...,... [element 0] |
-| test.ps1:21:1:21:6 | ...,... [element 1] | semmle.label | ...,... [element 1] |
 | test.ps1:21:1:21:6 | ...,... [element 1] | semmle.label | ...,... [element 1] |
 | test.ps1:21:5:21:6 | y | semmle.label | y |
 | test.ps1:23:38:27:1 | [synth] pipeline [element 0] | semmle.label | [synth] pipeline [element 0] |
@@ -67,16 +77,29 @@ nodes
 | test.ps1:30:6:30:15 | Call to Source | semmle.label | Call to Source |
 | test.ps1:31:1:31:2 | x | semmle.label | x |
 | test.ps1:31:1:31:6 | ...,... [element 0] | semmle.label | ...,... [element 0] |
-| test.ps1:31:1:31:6 | ...,... [element 0] | semmle.label | ...,... [element 0] |
-| test.ps1:31:1:31:6 | ...,... [element 1] | semmle.label | ...,... [element 1] |
 | test.ps1:31:1:31:6 | ...,... [element 1] | semmle.label | ...,... [element 1] |
 | test.ps1:31:5:31:6 | y | semmle.label | y |
+| test.ps1:42:60:48:1 | x [element 0, element x] | semmle.label | x [element 0, element x] |
+| test.ps1:42:60:48:1 | x [element 1, element x] | semmle.label | x [element 1, element x] |
+| test.ps1:42:60:48:1 | x [element 2, element x] | semmle.label | x [element 2, element x] |
+| test.ps1:45:5:47:5 | x [element 0, element x] | semmle.label | x [element 0, element x] |
+| test.ps1:45:5:47:5 | x [element 1, element x] | semmle.label | x [element 1, element x] |
+| test.ps1:45:5:47:5 | x [element 2, element x] | semmle.label | x [element 2, element x] |
+| test.ps1:46:9:46:15 | __pipeline_iterator for x | semmle.label | __pipeline_iterator for x |
+| test.ps1:50:1:50:33 | [...]... [element x] | semmle.label | [...]... [element x] |
+| test.ps1:50:1:50:105 | ...,... [element 0, element x] | semmle.label | ...,... [element 0, element x] |
+| test.ps1:50:1:50:105 | ...,... [element 1, element x] | semmle.label | ...,... [element 1, element x] |
+| test.ps1:50:1:50:105 | ...,... [element 2, element x] | semmle.label | ...,... [element 2, element x] |
+| test.ps1:50:17:50:33 | ${...} [element x] | semmle.label | ${...} [element x] |
+| test.ps1:50:23:50:32 | Call to Source | semmle.label | Call to Source |
+| test.ps1:50:36:50:69 | [...]... [element x] | semmle.label | [...]... [element x] |
+| test.ps1:50:52:50:69 | ${...} [element x] | semmle.label | ${...} [element x] |
+| test.ps1:50:58:50:68 | Call to Source | semmle.label | Call to Source |
+| test.ps1:50:72:50:105 | [...]... [element x] | semmle.label | [...]... [element x] |
+| test.ps1:50:88:50:105 | ${...} [element x] | semmle.label | ${...} [element x] |
+| test.ps1:50:94:50:104 | Call to Source | semmle.label | Call to Source |
 subpaths
 testFailures
-| test.ps1:36:13:36:30 | # $ hasValueFlow=8 | Missing result: hasValueFlow=8 |
-| test.ps1:46:17:46:66 | # $ hasValueFlow=9 hasValueFlow=10 hasValueFlow=11 | Missing result: hasValueFlow=9 |
-| test.ps1:46:17:46:66 | # $ hasValueFlow=9 hasValueFlow=10 hasValueFlow=11 | Missing result: hasValueFlow=10 |
-| test.ps1:46:17:46:66 | # $ hasValueFlow=9 hasValueFlow=10 hasValueFlow=11 | Missing result: hasValueFlow=11 |
 #select
 | test.ps1:13:9:13:15 | __pipeline_iterator | test.ps1:2:10:2:19 | Call to Source | test.ps1:13:9:13:15 | __pipeline_iterator | $@ | test.ps1:2:10:2:19 | Call to Source | Call to Source |
 | test.ps1:13:9:13:15 | __pipeline_iterator | test.ps1:3:10:3:19 | Call to Source | test.ps1:13:9:13:15 | __pipeline_iterator | $@ | test.ps1:3:10:3:19 | Call to Source | Call to Source |
@@ -85,3 +108,6 @@ testFailures
 | test.ps1:13:9:13:15 | __pipeline_iterator | test.ps1:20:6:20:15 | Call to Source | test.ps1:13:9:13:15 | __pipeline_iterator | $@ | test.ps1:20:6:20:15 | Call to Source | Call to Source |
 | test.ps1:25:9:25:15 | __pipeline_iterator | test.ps1:29:6:29:15 | Call to Source | test.ps1:25:9:25:15 | __pipeline_iterator | $@ | test.ps1:29:6:29:15 | Call to Source | Call to Source |
 | test.ps1:25:9:25:15 | __pipeline_iterator | test.ps1:30:6:30:15 | Call to Source | test.ps1:25:9:25:15 | __pipeline_iterator | $@ | test.ps1:30:6:30:15 | Call to Source | Call to Source |
+| test.ps1:46:9:46:15 | __pipeline_iterator for x | test.ps1:50:23:50:32 | Call to Source | test.ps1:46:9:46:15 | __pipeline_iterator for x | $@ | test.ps1:50:23:50:32 | Call to Source | Call to Source |
+| test.ps1:46:9:46:15 | __pipeline_iterator for x | test.ps1:50:58:50:68 | Call to Source | test.ps1:46:9:46:15 | __pipeline_iterator for x | $@ | test.ps1:50:58:50:68 | Call to Source | Call to Source |
+| test.ps1:46:9:46:15 | __pipeline_iterator for x | test.ps1:50:94:50:104 | Call to Source | test.ps1:46:9:46:15 | __pipeline_iterator for x | $@ | test.ps1:50:94:50:104 | Call to Source | Call to Source |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
@@ -3,17 +3,17 @@ edges
 | test.ps1:2:10:2:19 | Call to Source | test.ps1:5:5:5:6 | x | provenance |  |
 | test.ps1:3:10:3:19 | Call to Source | test.ps1:6:5:6:6 | y | provenance |  |
 | test.ps1:4:10:4:19 | Call to Source | test.ps1:6:9:6:10 | z | provenance |  |
-| test.ps1:5:5:5:6 | x | test.ps1:17:1:17:7 | Call to produce [element] | provenance |  |
-| test.ps1:6:5:6:6 | y | test.ps1:17:1:17:7 | Call to produce [element] | provenance |  |
-| test.ps1:6:9:6:10 | z | test.ps1:17:1:17:7 | Call to produce [element] | provenance |  |
+| test.ps1:5:5:5:6 | x | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
+| test.ps1:6:5:6:6 | y | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
+| test.ps1:6:9:6:10 | z | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
 | test.ps1:9:29:15:1 | [synth] pipeline [element 0] | test.ps1:12:5:14:5 | [synth] pipeline [element 0] | provenance |  |
 | test.ps1:9:29:15:1 | [synth] pipeline [element 1] | test.ps1:12:5:14:5 | [synth] pipeline [element 1] | provenance |  |
-| test.ps1:9:29:15:1 | [synth] pipeline [element] | test.ps1:12:5:14:5 | [synth] pipeline [element] | provenance |  |
+| test.ps1:9:29:15:1 | [synth] pipeline [unknown index] | test.ps1:12:5:14:5 | [synth] pipeline [unknown index] | provenance |  |
 | test.ps1:12:5:14:5 | [synth] pipeline [element 0] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
 | test.ps1:12:5:14:5 | [synth] pipeline [element 1] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
-| test.ps1:12:5:14:5 | [synth] pipeline [element] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
-| test.ps1:17:1:17:7 | Call to produce [element] | test.ps1:9:29:15:1 | [synth] pipeline [element] | provenance |  |
-| test.ps1:17:1:17:7 | Call to produce [element] | test.ps1:17:1:17:7 | Call to produce [element] | provenance |  |
+| test.ps1:12:5:14:5 | [synth] pipeline [unknown index] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
+| test.ps1:17:1:17:7 | Call to produce [unknown index] | test.ps1:9:29:15:1 | [synth] pipeline [unknown index] | provenance |  |
+| test.ps1:17:1:17:7 | Call to produce [unknown index] | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
 | test.ps1:19:6:19:15 | Call to Source | test.ps1:21:1:21:2 | x | provenance |  |
 | test.ps1:20:6:20:15 | Call to Source | test.ps1:21:5:21:6 | y | provenance |  |
 | test.ps1:21:1:21:2 | x | test.ps1:21:1:21:6 | ...,... [element 0] | provenance |  |
@@ -43,13 +43,13 @@ nodes
 | test.ps1:6:9:6:10 | z | semmle.label | z |
 | test.ps1:9:29:15:1 | [synth] pipeline [element 0] | semmle.label | [synth] pipeline [element 0] |
 | test.ps1:9:29:15:1 | [synth] pipeline [element 1] | semmle.label | [synth] pipeline [element 1] |
-| test.ps1:9:29:15:1 | [synth] pipeline [element] | semmle.label | [synth] pipeline [element] |
+| test.ps1:9:29:15:1 | [synth] pipeline [unknown index] | semmle.label | [synth] pipeline [unknown index] |
 | test.ps1:12:5:14:5 | [synth] pipeline [element 0] | semmle.label | [synth] pipeline [element 0] |
 | test.ps1:12:5:14:5 | [synth] pipeline [element 1] | semmle.label | [synth] pipeline [element 1] |
-| test.ps1:12:5:14:5 | [synth] pipeline [element] | semmle.label | [synth] pipeline [element] |
+| test.ps1:12:5:14:5 | [synth] pipeline [unknown index] | semmle.label | [synth] pipeline [unknown index] |
 | test.ps1:13:9:13:15 | __pipeline_iterator | semmle.label | __pipeline_iterator |
-| test.ps1:17:1:17:7 | Call to produce [element] | semmle.label | Call to produce [element] |
-| test.ps1:17:1:17:7 | Call to produce [element] | semmle.label | Call to produce [element] |
+| test.ps1:17:1:17:7 | Call to produce [unknown index] | semmle.label | Call to produce [unknown index] |
+| test.ps1:17:1:17:7 | Call to produce [unknown index] | semmle.label | Call to produce [unknown index] |
 | test.ps1:19:6:19:15 | Call to Source | semmle.label | Call to Source |
 | test.ps1:20:6:20:15 | Call to Source | semmle.label | Call to Source |
 | test.ps1:21:1:21:2 | x | semmle.label | x |

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.ps1
@@ -33,7 +33,7 @@ $x, $y | consumeWithProcessAnonymous
 function consumeValueFromPipelineByPropertyNameWithoutProcess {
     Param([Parameter(ValueFromPipelineByPropertyName)] $x)
 
-    Sink $x # $ hasValueFlow=8
+    Sink $x # $ MISSING: hasValueFlow=8
 }
 
 $x = Source "8"

--- a/powershell/ql/test/library-tests/dataflow/returns/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.expected
@@ -2,37 +2,37 @@ models
 edges
 | test.ps1:2:5:2:14 | Call to Source | test.ps1:5:6:5:19 | Call to callSourceOnce | provenance |  |
 | test.ps1:5:6:5:19 | Call to callSourceOnce | test.ps1:6:6:6:7 | x | provenance |  |
-| test.ps1:9:5:9:14 | Call to Source | test.ps1:13:6:13:20 | Call to callSourceTwice [element] | provenance |  |
-| test.ps1:10:5:10:14 | Call to Source | test.ps1:13:6:13:20 | Call to callSourceTwice [element] | provenance |  |
-| test.ps1:13:6:13:20 | Call to callSourceTwice [element] | test.ps1:15:6:15:7 | x [element] | provenance |  |
-| test.ps1:13:6:13:20 | Call to callSourceTwice [element] | test.ps1:16:6:16:7 | x [element] | provenance |  |
-| test.ps1:15:6:15:7 | x [element] | test.ps1:15:6:15:10 | ...[...] | provenance |  |
-| test.ps1:16:6:16:7 | x [element] | test.ps1:16:6:16:10 | ...[...] | provenance |  |
+| test.ps1:9:5:9:14 | Call to Source | test.ps1:13:6:13:20 | Call to callSourceTwice [unknown index] | provenance |  |
+| test.ps1:10:5:10:14 | Call to Source | test.ps1:13:6:13:20 | Call to callSourceTwice [unknown index] | provenance |  |
+| test.ps1:13:6:13:20 | Call to callSourceTwice [unknown index] | test.ps1:15:6:15:7 | x [unknown index] | provenance |  |
+| test.ps1:13:6:13:20 | Call to callSourceTwice [unknown index] | test.ps1:16:6:16:7 | x [unknown index] | provenance |  |
+| test.ps1:15:6:15:7 | x [unknown index] | test.ps1:15:6:15:10 | ...[...] | provenance |  |
+| test.ps1:16:6:16:7 | x [unknown index] | test.ps1:16:6:16:10 | ...[...] | provenance |  |
 | test.ps1:19:12:19:21 | Call to Source | test.ps1:22:6:22:18 | Call to returnSource1 | provenance |  |
 | test.ps1:22:6:22:18 | Call to returnSource1 | test.ps1:23:6:23:7 | x | provenance |  |
 | test.ps1:26:10:26:19 | Call to Source | test.ps1:27:5:27:6 | x | provenance |  |
-| test.ps1:27:5:27:6 | x | test.ps1:32:6:32:18 | Call to returnSource2 [element] | provenance |  |
+| test.ps1:27:5:27:6 | x | test.ps1:32:6:32:18 | Call to returnSource2 [unknown index] | provenance |  |
 | test.ps1:28:10:28:19 | Call to Source | test.ps1:29:12:29:13 | y | provenance |  |
-| test.ps1:29:12:29:13 | y | test.ps1:32:6:32:18 | Call to returnSource2 [element] | provenance |  |
-| test.ps1:32:6:32:18 | Call to returnSource2 [element] | test.ps1:33:6:33:7 | x [element] | provenance |  |
-| test.ps1:32:6:32:18 | Call to returnSource2 [element] | test.ps1:34:6:34:7 | x [element] | provenance |  |
-| test.ps1:33:6:33:7 | x [element] | test.ps1:33:6:33:10 | ...[...] | provenance |  |
-| test.ps1:34:6:34:7 | x [element] | test.ps1:34:6:34:10 | ...[...] | provenance |  |
-| test.ps1:38:9:38:18 | Call to Source | test.ps1:42:6:42:21 | Call to callSourceInLoop [element] | provenance |  |
-| test.ps1:42:6:42:21 | Call to callSourceInLoop [element] | test.ps1:43:6:43:7 | x [element] | provenance |  |
-| test.ps1:42:6:42:21 | Call to callSourceInLoop [element] | test.ps1:44:6:44:7 | x [element] | provenance |  |
-| test.ps1:43:6:43:7 | x [element] | test.ps1:43:6:43:10 | ...[...] | provenance |  |
-| test.ps1:44:6:44:7 | x [element] | test.ps1:44:6:44:10 | ...[...] | provenance |  |
+| test.ps1:29:12:29:13 | y | test.ps1:32:6:32:18 | Call to returnSource2 [unknown index] | provenance |  |
+| test.ps1:32:6:32:18 | Call to returnSource2 [unknown index] | test.ps1:33:6:33:7 | x [unknown index] | provenance |  |
+| test.ps1:32:6:32:18 | Call to returnSource2 [unknown index] | test.ps1:34:6:34:7 | x [unknown index] | provenance |  |
+| test.ps1:33:6:33:7 | x [unknown index] | test.ps1:33:6:33:10 | ...[...] | provenance |  |
+| test.ps1:34:6:34:7 | x [unknown index] | test.ps1:34:6:34:10 | ...[...] | provenance |  |
+| test.ps1:38:9:38:18 | Call to Source | test.ps1:42:6:42:21 | Call to callSourceInLoop [unknown index] | provenance |  |
+| test.ps1:42:6:42:21 | Call to callSourceInLoop [unknown index] | test.ps1:43:6:43:7 | x [unknown index] | provenance |  |
+| test.ps1:42:6:42:21 | Call to callSourceInLoop [unknown index] | test.ps1:44:6:44:7 | x [unknown index] | provenance |  |
+| test.ps1:43:6:43:7 | x [unknown index] | test.ps1:43:6:43:10 | ...[...] | provenance |  |
+| test.ps1:44:6:44:7 | x [unknown index] | test.ps1:44:6:44:10 | ...[...] | provenance |  |
 nodes
 | test.ps1:2:5:2:14 | Call to Source | semmle.label | Call to Source |
 | test.ps1:5:6:5:19 | Call to callSourceOnce | semmle.label | Call to callSourceOnce |
 | test.ps1:6:6:6:7 | x | semmle.label | x |
 | test.ps1:9:5:9:14 | Call to Source | semmle.label | Call to Source |
 | test.ps1:10:5:10:14 | Call to Source | semmle.label | Call to Source |
-| test.ps1:13:6:13:20 | Call to callSourceTwice [element] | semmle.label | Call to callSourceTwice [element] |
-| test.ps1:15:6:15:7 | x [element] | semmle.label | x [element] |
+| test.ps1:13:6:13:20 | Call to callSourceTwice [unknown index] | semmle.label | Call to callSourceTwice [unknown index] |
+| test.ps1:15:6:15:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:15:6:15:10 | ...[...] | semmle.label | ...[...] |
-| test.ps1:16:6:16:7 | x [element] | semmle.label | x [element] |
+| test.ps1:16:6:16:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:16:6:16:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:19:12:19:21 | Call to Source | semmle.label | Call to Source |
 | test.ps1:22:6:22:18 | Call to returnSource1 | semmle.label | Call to returnSource1 |
@@ -41,16 +41,16 @@ nodes
 | test.ps1:27:5:27:6 | x | semmle.label | x |
 | test.ps1:28:10:28:19 | Call to Source | semmle.label | Call to Source |
 | test.ps1:29:12:29:13 | y | semmle.label | y |
-| test.ps1:32:6:32:18 | Call to returnSource2 [element] | semmle.label | Call to returnSource2 [element] |
-| test.ps1:33:6:33:7 | x [element] | semmle.label | x [element] |
+| test.ps1:32:6:32:18 | Call to returnSource2 [unknown index] | semmle.label | Call to returnSource2 [unknown index] |
+| test.ps1:33:6:33:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:33:6:33:10 | ...[...] | semmle.label | ...[...] |
-| test.ps1:34:6:34:7 | x [element] | semmle.label | x [element] |
+| test.ps1:34:6:34:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:34:6:34:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:38:9:38:18 | Call to Source | semmle.label | Call to Source |
-| test.ps1:42:6:42:21 | Call to callSourceInLoop [element] | semmle.label | Call to callSourceInLoop [element] |
-| test.ps1:43:6:43:7 | x [element] | semmle.label | x [element] |
+| test.ps1:42:6:42:21 | Call to callSourceInLoop [unknown index] | semmle.label | Call to callSourceInLoop [unknown index] |
+| test.ps1:43:6:43:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:43:6:43:10 | ...[...] | semmle.label | ...[...] |
-| test.ps1:44:6:44:7 | x [element] | semmle.label | x [element] |
+| test.ps1:44:6:44:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:44:6:44:10 | ...[...] | semmle.label | ...[...] |
 subpaths
 testFailures


### PR DESCRIPTION
This fixes the last remaining missing flows that were caused by https://github.com/microsoft/codeql/pull/178. The last ones are mostly concerned with pipeline-by-property-name parameters.