### PR TITLE
PS: Fixup SSA after GitHub's 2.21.0 changes

### DIFF
--- a/powershell/ql/test/library-tests/dataflow/local/flow.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/flow.expected
@@ -6,11 +6,9 @@
 | test.ps1:2:1:2:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:4:1:4:2 | b | test.ps1:5:4:5:5 | b |
 | test.ps1:4:6:4:12 | Call to GetBool | test.ps1:4:1:4:2 | b |
-| test.ps1:5:1:7:1 | phi (a2) | test.ps1:8:6:8:8 | a2 |
 | test.ps1:5:4:5:5 | b | test.ps1:10:14:10:15 | b |
-| test.ps1:6:5:6:7 | a2 | test.ps1:6:11:6:16 | [input] phi (a2) |
+| test.ps1:6:5:6:7 | a2 | test.ps1:8:6:8:8 | a2 |
 | test.ps1:6:11:6:16 | Call to Source | test.ps1:6:5:6:7 | a2 |
-| test.ps1:6:11:6:16 | [input] phi (a2) | test.ps1:5:1:7:1 | phi (a2) |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:10:1:10:2 | c | test.ps1:11:6:11:7 | c |

--- a/powershell/ql/test/library-tests/dataflow/local/taint.expected
+++ b/powershell/ql/test/library-tests/dataflow/local/taint.expected
@@ -7,11 +7,9 @@
 | test.ps1:2:1:2:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:4:1:4:2 | b | test.ps1:5:4:5:5 | b |
 | test.ps1:4:6:4:12 | Call to GetBool | test.ps1:4:1:4:2 | b |
-| test.ps1:5:1:7:1 | phi (a2) | test.ps1:8:6:8:8 | a2 |
 | test.ps1:5:4:5:5 | b | test.ps1:10:14:10:15 | b |
-| test.ps1:6:5:6:7 | a2 | test.ps1:6:11:6:16 | [input] phi (a2) |
+| test.ps1:6:5:6:7 | a2 | test.ps1:8:6:8:8 | a2 |
 | test.ps1:6:11:6:16 | Call to Source | test.ps1:6:5:6:7 | a2 |
-| test.ps1:6:11:6:16 | [input] phi (a2) | test.ps1:5:1:7:1 | phi (a2) |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:8:1:8:8 | Call to Sink | test.ps1:1:1:24:22 | pre-return value for {...} |
 | test.ps1:10:1:10:2 | c | test.ps1:11:6:11:7 | c |


### PR DESCRIPTION
GitHub has been doing a number of changes to the shared SSA library (which PowerShell also uses). See, for example, https://github.com/github/codeql/pull/19147.

This PR makes the necessary PowerShell changes to make the PowerShell dataflow library work with 2.21.0

As always with these kinds of things, CI will be unhappy since these changes requires the shared libraries from 2.21.0.

cc @dilanbhalla 