### PR TITLE
Files reads as flow sources

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ApiGraphs.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ApiGraphs.qll
@@ -153,6 +153,16 @@ module API {
     Node getReturn() { Impl::returnEdge(this.getAnEpsilonSuccessor(), result) }
 
     /**
+     * Gets the result of this call when there is a named argument with the
+     * name `name`, or the return value of this callable.
+     */
+    bindingset[this]
+    pragma[inline_late]
+    Node getReturnWithArg(string name) {
+      Impl::returnEdgeWithArg(this.getAnEpsilonSuccessor(), name, result)
+    }
+
+    /**
      * Gets the result of a call to `method` with this value as the receiver, or the return value of `method` defined on
      * an object that can reach this sink.
      *
@@ -689,6 +699,21 @@ module API {
         succ = getForwardStartNode(call)
       )
       or
+      exists(DataFlow::CallableNode callable |
+        pred = getBackwardEndNode(callable) and
+        succ = MkSinkNode(callable.getAReturnNode())
+      )
+    }
+
+    cached
+    predicate returnEdgeWithArg(Node pred, string arg, Node succ) {
+      exists(DataFlow::CallNode call |
+        pred = MkMethodAccessNode(call) and
+        exists(call.getNamedArgument(arg)) and
+        succ = getForwardStartNode(call)
+      )
+      or
+      arg = "" and // TODO
       exists(DataFlow::CallableNode callable |
         pred = getBackwardEndNode(callable) and
         succ = MkSinkNode(callable.getAReturnNode())

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/FlowSources.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/FlowSources.qll
@@ -2,6 +2,7 @@
 private import semmle.code.powershell.dataflow.internal.DataFlowPublic as DataFlow
 import semmle.code.powershell.dataflow.flowsources.Remote
 import semmle.code.powershell.dataflow.flowsources.Local
+import semmle.code.powershell.dataflow.flowsources.Stored
 import semmle.code.powershell.frameworks.data.internal.ApiGraphModels
 
 /**

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/Stored.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/Stored.qll
@@ -1,0 +1,35 @@
+/**
+ * Provides classes representing sources of stored data.
+ */
+
+import powershell
+private import FlowSources
+
+/** A data flow source of stored user input. */
+abstract class StoredFlowSource extends SourceNode {
+  override string getThreatModel() { result = "local" }
+}
+
+/**
+ * A node with input from a database.
+ */
+abstract class DatabaseInputSource extends StoredFlowSource {
+  override string getThreatModel() { result = "database" }
+
+  override string getSourceType() { result = "database input" }
+}
+
+private class ExternalDatabaseInputSource extends DatabaseInputSource {
+  ExternalDatabaseInputSource() { this = ModelOutput::getASourceNode("database", _).asSource() }
+}
+
+/** A file stream source is considered a stored flow source. */
+abstract class FileStreamStoredFlowSource extends StoredFlowSource {
+  override string getThreatModel() { result = "file" }
+
+  override string getSourceType() { result = "file stream" }
+}
+
+private class ExternalFileStreamStoredFlowSource extends FileStreamStoredFlowSource {
+  ExternalFileStreamStoredFlowSource() { this = ModelOutput::getASourceNode("file", _).asSource() }
+}

--- a/powershell/ql/lib/semmle/code/powershell/frameworks/MicrosoftPowershellUtility/model.yml
+++ b/powershell/ql/lib/semmle/code/powershell/frameworks/MicrosoftPowershellUtility/model.yml
@@ -4,6 +4,8 @@ extensions:
       extensible: sourceModel
     data:
       - ["microsoft.powershell.utility!", "Method[Read-Host].ReturnValue", "stdin"]
+      - ["microsoft.powershell.utility!", "Method[select-xml].ReturnValue[path]", "file"]
+      - ["microsoft.powershell.utility!", "Method[format-hex].ReturnValue[path]", "file"]
 
   - addsTo:
       pack: microsoft-sdl/powershell-all
@@ -62,12 +64,12 @@ extensions:
       - ["microsoft.powershell.utility!", "Method[out-string]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[select-object]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[select-string]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
-      - ["microsoft.powershell.utility!", "Method[select-xml]", "Argument[-content,-path,-xml]", "ReturnValue", "taint"] # TODO: Source of user input?
+      - ["microsoft.powershell.utility!", "Method[select-xml]", "Argument[-content,-path,-xml]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[sort-object]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[tee-object]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[write-output]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[format-custom]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
-      - ["microsoft.powershell.utility!", "Method[format-hex]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"] # Source of user input?
+      - ["microsoft.powershell.utility!", "Method[format-hex]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[format-list]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[format-table]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]
       - ["microsoft.powershell.utility!", "Method[format-wide]", "Argument[-inputobject,pipeline]", "ReturnValue", "taint"]

--- a/powershell/ql/lib/semmle/code/powershell/frameworks/data/internal/ApiGraphModels.qll
+++ b/powershell/ql/lib/semmle/code/powershell/frameworks/data/internal/ApiGraphModels.qll
@@ -254,7 +254,12 @@ API::Node getSuccessorFromNode(API::Node node, AccessPathTokenBase token) {
   result = node.getParameter(parseIntUnbounded(token.getAnArgument()))
   or
   token.getName() = "ReturnValue" and
-  result = node.getReturn()
+  (
+    not exists(token.getAnArgument()) and
+    result = node.getReturn()
+    or
+    result = node.getReturnWithArg(token.getAnArgument())
+  )
   or
   // Language-specific tokens
   result = Specific::getExtraSuccessorFromNode(node, token)
@@ -269,7 +274,12 @@ API::Node getSuccessorFromInvoke(Specific::InvokeNode invoke, AccessPathTokenBas
   result = invoke.getParameter(parseIntWithArity(token.getAnArgument(), invoke.getNumArgument()))
   or
   token.getName() = "ReturnValue" and
-  result = invoke.getReturn()
+  (
+    not exists(token.getAnArgument()) and
+    result = invoke.getReturn()
+    or
+    result = invoke.getReturnWithArg(token.getAnArgument())
+  )
   or
   // Language-specific tokens
   result = Specific::getExtraSuccessorFromInvoke(invoke, token)

--- a/powershell/ql/lib/semmle/code/powershell/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/powershell/ql/lib/semmle/code/powershell/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -95,7 +95,7 @@ API::Node getExtraNodeFromType(string rawType) {
     result = qualifiedTypeName.(DataFlow::LocalSourceNode).track().getInstance()
   )
   or
-  (rawType = ["", getAnImplicitImport()]) and
+  rawType = ["", getAnImplicitImport()] and
   result = API::root()
 }
 


### PR DESCRIPTION
This PR does two things to add more flow sources to PowerShell:

- It adds a `Stored.qll` file containing a subclass of local flow sources that represents file reads. It turns out we already have some flow sources belonging to this kind since we stole them from C#: https://github.com/microsoft/codeql/blob/1637df0a3f635f4d31253b637767afab701a5608/powershell/ql/lib/semmle/code/powershell/frameworks/SystemIOFile/model.yml#L10. We just didn't have a QL class to make them part of `SourceNode` 😅

- Then, I also discovered two sources of user flow recently. For example, [Select-XML](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-xml?view=powershell-7.5), which can read user input when given an `-Path` argument. So this PR also adds MaD syntax for specifying "the return value of a call when there is a specific named argument". After adding this functionality, this PR also models calls to `Select-XML` and `Format-Hex` as remote flow sources of this kind.