### PR TITLE
Sync Upstream Tags

### DIFF
--- a/.github/workflows/sync-main-tags.yml
+++ b/.github/workflows/sync-main-tags.yml
@@ -1,0 +1,27 @@
+name: Sync Main Tags
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  sync-main-tags:
+    name: Sync Main Tags
+    runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/codeql' && github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'auto/sync-main-pr'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Push Tags
+        run: |
+          git fetch upstream --tags --force
+          git push --force origin --tags
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
Upon completion of auto/sync-main-pr pull request (syncs upstream commits), this workflow runs and also syncs upstream tags.