### PR TITLE
PS: Proper AST support for switch arguments

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Constant.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Constant.qll
@@ -1,4 +1,5 @@
 private import AstImport
+private import codeql.util.Boolean
 
 private newtype TConstantValue =
   TConstInteger(int value) {
@@ -12,15 +13,7 @@ private newtype TConstantValue =
     )
   } or
   TConstString(string value) { exists(Raw::StringLiteral sl | sl.getValue() = value) } or
-  TConstBoolean(boolean value) {
-    exists(Raw::VarAccess va |
-      value = true and
-      va.getUserPath() = "true"
-      or
-      value = false and
-      va.getUserPath() = "false"
-    )
-  } or
+  TConstBoolean(Boolean b) or
   TNull()
 
 /** A constant value. */
@@ -61,9 +54,7 @@ class ConstInteger extends ConstantValue, TConstInteger {
 
   final override string serialize() { result = this.getValue() }
 
-  final override ConstExpr getAnExpr() {
-    result.getValueString() = this.getValue()
-  }
+  final override ConstExpr getAnExpr() { result.getValueString() = this.getValue() }
 }
 
 /** A constant floating point value. */

--- a/powershell/ql/test/library-tests/ast/Arguments/arguments.expected
+++ b/powershell/ql/test/library-tests/ast/Arguments/arguments.expected
@@ -1,0 +1,9 @@
+positionalArguments
+| arguments.ps1:1:5:1:5 | 1 | 0 |
+namedArguments
+| arguments.ps1:2:8:2:8 | 1 | x |
+| arguments.ps1:3:8:3:8 | 1 | x |
+| arguments.ps1:7:8:7:8 | 1 | x |
+| arguments.ps1:7:13:7:13 | 2 | y |
+| arguments.ps1:8:8:8:8 | 1 | x |
+| arguments.ps1:8:13:8:13 | 2 | y |

--- a/powershell/ql/test/library-tests/ast/Arguments/arguments.expected
+++ b/powershell/ql/test/library-tests/ast/Arguments/arguments.expected
@@ -3,6 +3,9 @@ positionalArguments
 namedArguments
 | arguments.ps1:2:8:2:8 | 1 | x |
 | arguments.ps1:3:8:3:8 | 1 | x |
+| arguments.ps1:4:5:4:6 | true | x |
+| arguments.ps1:6:5:6:6 | true | x |
+| arguments.ps1:6:8:6:9 | true | y |
 | arguments.ps1:7:8:7:8 | 1 | x |
 | arguments.ps1:7:13:7:13 | 2 | y |
 | arguments.ps1:8:8:8:8 | 1 | x |

--- a/powershell/ql/test/library-tests/ast/Arguments/arguments.ps1
+++ b/powershell/ql/test/library-tests/ast/Arguments/arguments.ps1
@@ -1,0 +1,8 @@
+Foo 1
+Foo -x 1
+Foo -x:1
+Foo -x
+
+Bar -x -y
+Bar -x 1 -y 2
+Bar -x:1 -y:2

--- a/powershell/ql/test/library-tests/ast/Arguments/arguments.ql
+++ b/powershell/ql/test/library-tests/ast/Arguments/arguments.ql
@@ -1,0 +1,5 @@
+import powershell
+
+query predicate positionalArguments(Argument a, int p) { p = a.getPosition() }
+
+query predicate namedArguments(Argument a, string name) { name = a.getName() }

--- a/powershell/ql/test/library-tests/ast/parent.expected
+++ b/powershell/ql/test/library-tests/ast/parent.expected
@@ -1,3 +1,36 @@
+| Arguments/arguments.ps1:1:1:1:3 | Foo | Arguments/arguments.ps1:1:1:1:5 | Call to Foo |
+| Arguments/arguments.ps1:1:1:1:5 | Call to Foo | Arguments/arguments.ps1:1:1:1:5 | [Stmt] Call to Foo |
+| Arguments/arguments.ps1:1:1:1:5 | [Stmt] Call to Foo | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:1:1:8:13 | {...} | Arguments/arguments.ps1:1:1:8:13 | toplevel function for arguments.ps1 |
+| Arguments/arguments.ps1:1:1:8:13 | {...} | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:1:5:1:5 | 1 | Arguments/arguments.ps1:1:1:1:5 | Call to Foo |
+| Arguments/arguments.ps1:2:1:2:3 | Foo | Arguments/arguments.ps1:2:1:2:8 | Call to Foo |
+| Arguments/arguments.ps1:2:1:2:8 | Call to Foo | Arguments/arguments.ps1:2:1:2:8 | [Stmt] Call to Foo |
+| Arguments/arguments.ps1:2:1:2:8 | [Stmt] Call to Foo | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:2:8:2:8 | 1 | Arguments/arguments.ps1:2:1:2:8 | Call to Foo |
+| Arguments/arguments.ps1:3:1:3:3 | Foo | Arguments/arguments.ps1:3:1:3:8 | Call to Foo |
+| Arguments/arguments.ps1:3:1:3:8 | Call to Foo | Arguments/arguments.ps1:3:1:3:8 | [Stmt] Call to Foo |
+| Arguments/arguments.ps1:3:1:3:8 | [Stmt] Call to Foo | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:3:8:3:8 | 1 | Arguments/arguments.ps1:3:1:3:8 | Call to Foo |
+| Arguments/arguments.ps1:4:1:4:3 | Foo | Arguments/arguments.ps1:4:1:4:6 | Call to Foo |
+| Arguments/arguments.ps1:4:1:4:6 | Call to Foo | Arguments/arguments.ps1:4:1:4:6 | [Stmt] Call to Foo |
+| Arguments/arguments.ps1:4:1:4:6 | [Stmt] Call to Foo | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:4:5:4:6 | true | Arguments/arguments.ps1:4:1:4:6 | Call to Foo |
+| Arguments/arguments.ps1:6:1:6:3 | Bar | Arguments/arguments.ps1:6:1:6:9 | Call to Bar |
+| Arguments/arguments.ps1:6:1:6:9 | Call to Bar | Arguments/arguments.ps1:6:1:6:9 | [Stmt] Call to Bar |
+| Arguments/arguments.ps1:6:1:6:9 | [Stmt] Call to Bar | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:6:5:6:6 | true | Arguments/arguments.ps1:6:1:6:9 | Call to Bar |
+| Arguments/arguments.ps1:6:8:6:9 | true | Arguments/arguments.ps1:6:1:6:9 | Call to Bar |
+| Arguments/arguments.ps1:7:1:7:3 | Bar | Arguments/arguments.ps1:7:1:7:13 | Call to Bar |
+| Arguments/arguments.ps1:7:1:7:13 | Call to Bar | Arguments/arguments.ps1:7:1:7:13 | [Stmt] Call to Bar |
+| Arguments/arguments.ps1:7:1:7:13 | [Stmt] Call to Bar | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:7:8:7:8 | 1 | Arguments/arguments.ps1:7:1:7:13 | Call to Bar |
+| Arguments/arguments.ps1:7:13:7:13 | 2 | Arguments/arguments.ps1:7:1:7:13 | Call to Bar |
+| Arguments/arguments.ps1:8:1:8:3 | Bar | Arguments/arguments.ps1:8:1:8:13 | Call to Bar |
+| Arguments/arguments.ps1:8:1:8:13 | Call to Bar | Arguments/arguments.ps1:8:1:8:13 | [Stmt] Call to Bar |
+| Arguments/arguments.ps1:8:1:8:13 | [Stmt] Call to Bar | Arguments/arguments.ps1:1:1:8:13 | {...} |
+| Arguments/arguments.ps1:8:8:8:8 | 1 | Arguments/arguments.ps1:8:1:8:13 | Call to Bar |
+| Arguments/arguments.ps1:8:13:8:13 | 2 | Arguments/arguments.ps1:8:1:8:13 | Call to Bar |
 | Arrays/Arrays.ps1:0:0:0:-1 | {...} | Arrays/Arrays.ps1:14:41:14:43 | @(...) |
 | Arrays/Arrays.ps1:1:1:1:7 | array1 | Arrays/Arrays.ps1:1:1:1:36 | ...=... |
 | Arrays/Arrays.ps1:1:1:1:7 | array1 | Arrays/Arrays.ps1:1:1:15:14 | {...} |
@@ -189,6 +222,8 @@
 | Expressions/ConvertWithSecureString.ps1:2:19:2:40 | ConvertTo-SecureString | Expressions/ConvertWithSecureString.ps1:2:19:2:79 | Call to ConvertTo-SecureString |
 | Expressions/ConvertWithSecureString.ps1:2:19:2:79 | Call to ConvertTo-SecureString | Expressions/ConvertWithSecureString.ps1:2:1:2:79 | ...=... |
 | Expressions/ConvertWithSecureString.ps1:2:50:2:59 | UserInput | Expressions/ConvertWithSecureString.ps1:2:19:2:79 | Call to ConvertTo-SecureString |
+| Expressions/ConvertWithSecureString.ps1:2:61:2:72 | true | Expressions/ConvertWithSecureString.ps1:2:19:2:79 | Call to ConvertTo-SecureString |
+| Expressions/ConvertWithSecureString.ps1:2:74:2:79 | true | Expressions/ConvertWithSecureString.ps1:2:19:2:79 | Call to ConvertTo-SecureString |
 | Expressions/ExpandableString.ps1:1:1:1:39 | Date: $([DateTime]::Now)\nName: $name | Expressions/ExpandableString.ps1:1:1:1:39 | [Stmt] Date: $([DateTime]::Now)\nName: $name |
 | Expressions/ExpandableString.ps1:1:1:1:39 | [Stmt] Date: $([DateTime]::Now)\nName: $name | Expressions/ExpandableString.ps1:1:1:1:39 | {...} |
 | Expressions/ExpandableString.ps1:1:1:1:39 | {...} | Expressions/ExpandableString.ps1:1:1:1:39 | toplevel function for ExpandableString.ps1 |

--- a/powershell/ql/test/library-tests/ast/parent.expected
+++ b/powershell/ql/test/library-tests/ast/parent.expected
@@ -199,6 +199,14 @@
 | Expressions/ExpandableString.ps1:1:23:1:37 | [Stmt] Now | Expressions/ExpandableString.ps1:1:23:1:37 | {...} |
 | Expressions/ExpandableString.ps1:1:23:1:37 | {...} | Expressions/ExpandableString.ps1:1:21:1:38 | $(...) |
 | Expressions/ExpandableString.ps1:1:35:1:37 | Now | Expressions/ExpandableString.ps1:1:23:1:37 | Now |
+| Expressions/MemberExpression.ps1:1:1:2:14 | [synth] pipeline | Expressions/MemberExpression.ps1:1:1:2:14 | {...} |
+| Expressions/MemberExpression.ps1:1:1:2:14 | {...} | Expressions/MemberExpression.ps1:1:1:2:14 | toplevel function for MemberExpression.ps1 |
+| Expressions/MemberExpression.ps1:1:1:2:14 | {...} | Expressions/MemberExpression.ps1:1:1:2:14 | {...} |
+| Expressions/MemberExpression.ps1:1:7:1:8 | x | Expressions/MemberExpression.ps1:1:1:2:14 | {...} |
+| Expressions/MemberExpression.ps1:2:1:2:10 | DateTime | Expressions/MemberExpression.ps1:2:1:2:14 | ... |
+| Expressions/MemberExpression.ps1:2:1:2:14 | ... | Expressions/MemberExpression.ps1:2:1:2:14 | [Stmt] ... |
+| Expressions/MemberExpression.ps1:2:1:2:14 | [Stmt] ... | Expressions/MemberExpression.ps1:1:1:2:14 | {...} |
+| Expressions/MemberExpression.ps1:2:13:2:14 | x | Expressions/MemberExpression.ps1:2:1:2:14 | ... |
 | Expressions/SubExpression.ps1:1:1:1:11 | $(...) | Expressions/SubExpression.ps1:1:1:1:23 | Call to AddDays |
 | Expressions/SubExpression.ps1:1:1:1:23 | Call to AddDays | Expressions/SubExpression.ps1:1:1:1:23 | [Stmt] Call to AddDays |
 | Expressions/SubExpression.ps1:1:1:1:23 | [Stmt] Call to AddDays | Expressions/SubExpression.ps1:1:1:2:21 | {...} |


### PR DESCRIPTION
Previously, we did not handle switch arguments when constructing the AST.

This PR fixes this by synthesizing a Boolean `$true` argument so that a switch argument such as `Foo -MyFlag` looks the same (from the AST point-of-view) as `Foo -MyFlag:$true`.

Thanks for reporting this @chanel-y! 🙇 

Commit-by-commit review recommended.