### PR TITLE
PS: Lift string literals to the public AST

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Internal.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Internal.qll
@@ -66,6 +66,7 @@ module Public {
   import ParenExpr
   import Pipeline
   import StringConstantExpression
+  import StringLiteral
   import MemberExpr
   import InvokeMemberExpression
   import ObjectCreation

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/StringLiteral.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/StringLiteral.qll
@@ -1,0 +1,16 @@
+private import AstImport
+
+// TODO: A string literal should ideally be the string constants that are
+// surrounded by quotes (single or double), but we don't yet extract that
+// information. So for now we just use the StringConstExpr class, which is
+// a bit more general than we want.
+class StringLiteral instanceof StringConstExpr {
+  /** Get the string representation of this string literal. */
+  string toString() { result = this.getValue() }
+
+  /** Get the value of this string literal. */
+  string getValue() { result = super.getValueString() }
+
+  /** Get the location of this string literal. */
+  SourceLocation getLocation() { result = super.getLocation() }
+}

--- a/powershell/ql/test/library-tests/ast/Strings/String.ps1
+++ b/powershell/ql/test/library-tests/ast/Strings/String.ps1
@@ -1,0 +1,7 @@
+$x = "abc"
+Foo
+$y = 'def'
+$z = @"ghi
+"@
+$t = @'j"k"l
+'@

--- a/powershell/ql/test/library-tests/ast/Strings/Strings.expected
+++ b/powershell/ql/test/library-tests/ast/Strings/Strings.expected
@@ -1,0 +1,12 @@
+stringLiteral
+| String.ps1:1:6:1:10 | abc |
+| String.ps1:2:1:2:3 | Foo |
+| String.ps1:3:6:3:10 | def |
+| String.ps1:4:6:4:10 |  |
+| String.ps1:6:10:8:0 | '@\nkl |
+stringConstantExpression
+| String.ps1:1:6:1:10 | abc |
+| String.ps1:2:1:2:3 | Foo |
+| String.ps1:3:6:3:10 | def |
+| String.ps1:4:6:4:10 |  |
+| String.ps1:6:10:8:0 | '@\nkl |

--- a/powershell/ql/test/library-tests/ast/Strings/Strings.ql
+++ b/powershell/ql/test/library-tests/ast/Strings/Strings.ql
@@ -1,0 +1,5 @@
+import powershell
+
+query predicate stringLiteral(StringLiteral sl) { any() }
+
+query predicate stringConstantExpression(StringConstExpr sce) { any() }

--- a/powershell/ql/test/library-tests/ast/parent.expected
+++ b/powershell/ql/test/library-tests/ast/parent.expected
@@ -429,3 +429,25 @@
 | Statements/UseProcessBlockForPipelineCommand.ps1:6:9:6:13 | int | Statements/UseProcessBlockForPipelineCommand.ps1:5:9:7:15 | number |
 | Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:11 | Number | Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:11 | [Stmt] Number |
 | Statements/UseProcessBlockForPipelineCommand.ps1:10:5:10:11 | [Stmt] Number | Statements/UseProcessBlockForPipelineCommand.ps1:4:5:10:11 | {...} |
+| Strings/String.ps1:1:1:1:2 | x | Strings/String.ps1:1:1:1:10 | ...=... |
+| Strings/String.ps1:1:1:1:2 | x | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:1:1:1:10 | ...=... | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:1:1:8:0 | {...} | Strings/String.ps1:1:1:8:0 | toplevel function for String.ps1 |
+| Strings/String.ps1:1:1:8:0 | {...} | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:1:6:1:10 | abc | Strings/String.ps1:1:1:1:10 | ...=... |
+| Strings/String.ps1:2:1:2:3 | Call to foo | Strings/String.ps1:2:1:2:3 | [Stmt] Call to foo |
+| Strings/String.ps1:2:1:2:3 | Foo | Strings/String.ps1:2:1:2:3 | Call to foo |
+| Strings/String.ps1:2:1:2:3 | [Stmt] Call to foo | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:3:1:3:2 | y | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:3:1:3:2 | y | Strings/String.ps1:3:1:3:10 | ...=... |
+| Strings/String.ps1:3:1:3:10 | ...=... | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:3:6:3:10 | def | Strings/String.ps1:3:1:3:10 | ...=... |
+| Strings/String.ps1:4:1:4:2 | z | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:4:1:4:2 | z | Strings/String.ps1:4:1:4:10 | ...=... |
+| Strings/String.ps1:4:1:4:10 | ...=... | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:4:6:4:10 |  | Strings/String.ps1:4:1:4:10 | ...=... |
+| Strings/String.ps1:5:1:6:9 | $t = @'j\n@ | Strings/String.ps1:5:1:6:9 | [Stmt] $t = @'j\n@ |
+| Strings/String.ps1:5:1:6:9 | [Stmt] $t = @'j\n@ | Strings/String.ps1:1:1:8:0 | {...} |
+| Strings/String.ps1:6:10:8:0 | '@\nkl | Strings/String.ps1:6:10:8:0 | Call to kl\r\n'@\r\n |
+| Strings/String.ps1:6:10:8:0 | Call to kl\r\n'@\r\n | Strings/String.ps1:6:10:8:0 | [Stmt] Call to kl\r\n'@\r\n |
+| Strings/String.ps1:6:10:8:0 | [Stmt] Call to kl\r\n'@\r\n | Strings/String.ps1:1:1:8:0 | {...} |


### PR DESCRIPTION
We don't really use the string literal class for anything in this public repo. However, the private repo had a query that used the `StringLiteral` class. And unlike the `StringConstExpr` class, the `StringLiteral` class was never exposed publicly in the user-facing AST.

This PR "exposes" the `StringLiteral` class. I write "exposes" because we actually just alias it to be `StringConstExpr` since `StringLiteral` contains a bunch of things that aren't actually string literals (commands, comments, etc.), and what you actually want when you look for `StringLiteral`s are probably the strings in single or double quotes. These are contained in the `StringLiteral` class along with a bunch of other string-like things. We should add an extensional from the extractor to distinguish `foo` from `"foo"`, but I'll leave that for the future.