### PR TITLE
C++: Make `asExpr` return `AggregateLiteral`s

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1357,6 +1357,8 @@ predicate nodeIsHidden(Node n) {
   n instanceof InitialGlobalValue
   or
   n instanceof SsaSynthNode
+  or
+  n instanceof AggregateNode
 }
 
 predicate neverSkipInPathGraph(Node n) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -73,6 +73,7 @@ private newtype TIRDataFlowNode =
     indirectionIndex = [0 .. Ssa::getMaxIndirectionsForType(p.getUnspecifiedType()) - 1] and
     not any(InitializeParameterInstruction init).getParameter() = p
   } or
+  TAggregateNode(Ssa::AggregateUse use) or
   TFlowSummaryNode(FlowSummaryImpl::Private::SummaryNode sn)
 
 /**
@@ -866,6 +867,40 @@ class BodyLessParameterNodeImpl extends Node, TBodyLessParameterNodeImpl {
   final override string toStringImpl() {
     exists(string prefix | prefix = stars(this) | result = prefix + p.toString())
   }
+}
+
+/**
+ * INTERNAL: do not use.
+ *
+ * A node representing a use of an `AggregateLiteral` after it has been
+ * initialized. This node exists to ensure that
+ * ```
+ * node.asExpr() instanceof AggregateLiteral
+ * ```
+ * has a result.
+ */
+class AggregateNode extends Node, TAggregateNode {
+  Ssa::AggregateUse use;
+
+  AggregateNode() { this = TAggregateNode(use) }
+
+  override DataFlowCallable getEnclosingCallable() {
+    result.asSourceCallable() = this.getFunction()
+  }
+
+  override Declaration getFunction() { result = use.getBlock().getEnclosingFunction() }
+
+  override DataFlowType getType() { result = use.getSourceVariable().getType() }
+
+  final override Location getLocationImpl() { result = use.getLocation() }
+
+  final override string toStringImpl() { result = use.toString() }
+
+  /** Gets the `AggregateUse` corresponding to this node. */
+  Ssa::AggregateUse getUse() { result = use }
+
+  /** Gets the `AggregateLiteral` that has just been initialized. */
+  AggregateLiteral getAggregateLiteral() { result = use.getAggregateLiteral() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ExprNodes.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ExprNodes.qll
@@ -264,6 +264,11 @@ private module Cached {
     e = getConvertedResultExpression(node.asInstruction(), n)
   }
 
+  private predicate exprNodeShouldBeAggregateNode(AggregateNode node, Expr e, int n) {
+    node.getAggregateLiteral() = e and
+    n = 0
+  }
+
   /** Holds if `node` should be an `IndirectInstruction` that maps `node.asIndirectExpr()` to `e`. */
   private predicate indirectExprNodeShouldBeIndirectInstruction(
     IndirectInstruction node, Expr e, int n, int indirectionIndex
@@ -294,7 +299,8 @@ private module Cached {
     exprNodeShouldBeInstruction(_, e, n) or
     exprNodeShouldBeOperand(_, e, n) or
     exprNodeShouldBeIndirectOutNode(_, e, n) or
-    exprNodeShouldBeIndirectOperand(_, e, n)
+    exprNodeShouldBeIndirectOperand(_, e, n) or
+    exprNodeShouldBeAggregateNode(_, e, n)
   }
 
   private class InstructionExprNode extends ExprNodeBase, InstructionNode {
@@ -440,6 +446,12 @@ private module Cached {
     IndirectOperandExprNode() { exprNodeShouldBeIndirectOperand(this, _, _) }
 
     final override Expr getConvertedExpr(int n) { exprNodeShouldBeIndirectOperand(this, result, n) }
+  }
+
+  private class AggregateExprNode extends ExprNodeBase instanceof AggregateNode {
+    AggregateExprNode() { exprNodeShouldBeAggregateNode(this, _, _) }
+
+    final override Expr getConvertedExpr(int n) { exprNodeShouldBeAggregateNode(this, result, n) }
   }
 
   /**

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
@@ -21,3 +21,20 @@ A& get_ref();
 void test2() {
   take_ref(get_ref()); // $ asExpr="call to get_ref" asIndirectExpr="call to get_ref"
 }
+
+struct S {
+  int a;
+  int b;
+};
+
+void test_aggregate_literal() {
+  S s1 = {1, 2}; // $ asExpr=1 asExpr=2
+  const S s2 = {3, 4}; // $ asExpr=3 asExpr=4
+  S s3 = (S){5, 6}; // $ asExpr=5 asExpr=6
+  const S s4 = (S){7, 8}; // $ asExpr=7 asExpr=8
+
+  S s5 = {.a = 1, .b = 2}; // $ asExpr=1 asExpr=2
+
+  int xs[] = {1, 2, 3}; // $ asExpr=1 asExpr=2 asExpr=3
+  const int ys[] = {[0] = 4, [1] = 5, [0] = 6}; // $ asExpr=4 asExpr=5 asExpr=6
+}

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test.cpp
@@ -28,13 +28,13 @@ struct S {
 };
 
 void test_aggregate_literal() {
-  S s1 = {1, 2}; // $ asExpr=1 asExpr=2
-  const S s2 = {3, 4}; // $ asExpr=3 asExpr=4
-  S s3 = (S){5, 6}; // $ asExpr=5 asExpr=6
-  const S s4 = (S){7, 8}; // $ asExpr=7 asExpr=8
+  S s1 = {1, 2}; // $ asExpr=1 asExpr=2 asExpr={...}
+  const S s2 = {3, 4}; // $ asExpr=3 asExpr=4 asExpr={...}
+  S s3 = (S){5, 6}; // $ asExpr=5 asExpr=6 asExpr={...}
+  const S s4 = (S){7, 8}; // $ asExpr=7 asExpr=8 asExpr={...}
 
-  S s5 = {.a = 1, .b = 2}; // $ asExpr=1 asExpr=2
+  S s5 = {.a = 1, .b = 2}; // $ asExpr=1 asExpr=2 asExpr={...}
 
-  int xs[] = {1, 2, 3}; // $ asExpr=1 asExpr=2 asExpr=3
-  const int ys[] = {[0] = 4, [1] = 5, [0] = 6}; // $ asExpr=4 asExpr=5 asExpr=6
+  int xs[] = {1, 2, 3}; // $ asExpr=1 asExpr=2 asExpr=3 asExpr={...}
+  const int ys[] = {[0] = 4, [1] = 5, [0] = 6}; // $ asExpr=4 asExpr=5 asExpr=6 asExpr={...}
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow-ir.expected
@@ -15,9 +15,9 @@
 | example.c:17:11:17:16 | *definition of coords | example.c:17:11:17:16 | *definition of coords |
 | example.c:17:11:17:16 | *definition of coords | example.c:17:11:17:16 | *definition of coords |
 | example.c:17:11:17:16 | *definition of coords | example.c:17:11:17:16 | *definition of coords |
-| example.c:17:11:17:16 | *definition of coords | example.c:17:11:17:16 | *definition of coords |
+| example.c:17:11:17:16 | *definition of coords | example.c:17:19:17:22 | {...} |
 | example.c:17:11:17:16 | *definition of coords | example.c:24:13:24:18 | *coords |
-| example.c:17:11:17:16 | *definition of coords [post update] | example.c:17:11:17:16 | *definition of coords |
+| example.c:17:11:17:16 | *definition of coords [post update] | example.c:17:19:17:22 | {...} |
 | example.c:17:11:17:16 | *definition of coords [post update] | example.c:24:13:24:18 | *coords |
 | example.c:17:11:17:16 | definition of coords | example.c:17:11:17:16 | *definition of coords |
 | example.c:17:11:17:16 | definition of coords | example.c:17:11:17:16 | definition of coords |
@@ -27,6 +27,7 @@
 | example.c:17:11:17:16 | definition of coords | example.c:24:13:24:18 | coords |
 | example.c:17:11:17:16 | definition of coords [post update] | example.c:17:11:17:16 | definition of coords |
 | example.c:17:11:17:16 | definition of coords [post update] | example.c:24:13:24:18 | coords |
+| example.c:17:19:17:22 | {...} | example.c:17:11:17:16 | *definition of coords |
 | example.c:17:19:17:22 | {...} | example.c:17:19:17:22 | {...} |
 | example.c:17:21:17:21 | 0 | example.c:17:21:17:21 | 0 |
 | example.c:19:6:19:6 | *b | example.c:15:37:15:37 | *b |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
@@ -36,6 +36,7 @@ irTypeBugs
 | ../../../include/iterator.h:31:16:31:25 | ../../../include/iterator.h:31:16:31:25 | ../../../include/iterator.h:31:16:31:25 | [summary] read: Argument[this].Element[*] in operator-> |
 | ../../../include/iterator.h:31:16:31:25 | ../../../include/iterator.h:31:16:31:25 | ../../../include/iterator.h:31:16:31:25 | [summary] to write: ReturnValue[**] in operator-> |
 | ../../../include/iterator.h:31:16:31:25 | ../../../include/iterator.h:31:16:31:25 | ../../../include/iterator.h:31:16:31:25 | [summary] to write: ReturnValue[*] in operator-> |
+| clang.cpp:40:30:40:51 | clang.cpp:40:30:40:51 | clang.cpp:40:30:40:51 | {...} |
 incorrectBaseType
 | clang.cpp:22:8:22:20 | *& ... | Expected 'Node.getType()' to be int, but it was int * |
 | clang.cpp:23:17:23:29 | *& ... | Expected 'Node.getType()' to be int, but it was int * |


### PR DESCRIPTION
Notice the new inconsistency on `irTypeBugs`. This actually reveals that this solution isn't as general as I would like it to be (basically it doesn't work for recursive aggregate literals). I'd like to have that fixed before I pull this out of draft.

Other than that the PR should be fine (pending performance testing). On this branch you can do `node.asExpr() instanceof AggregateLiteral` and get the right node for flow out of an aggregate literal.

cc @bdrodes 