### PR TITLE
C#: Fix FPs (and a small FN) in `cs/path-injection`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
@@ -64,10 +64,9 @@ private module TaintedPathConfig implements DataFlow::StateConfigSig {
     source instanceof Source and state = NotNormalized()
   }
 
-  predicate isSink(DataFlow::Node sink, FlowState state) {
-    sink instanceof Sink and
-    exists(state)
-  }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  predicate isSink(DataFlow::Node sink, FlowState state) { none() }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, FlowState s1, DataFlow::Node n2, FlowState s2) {
     any(PathNormalizationStep step).isAdditionalFlowStep(n1, n2) and

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
@@ -77,7 +77,7 @@ private module TaintedPathConfig implements DataFlow::StateConfigSig {
   predicate isBarrier(DataFlow::Node node, FlowState state) { node.(Sanitizer).isBarrier(state) }
 
   predicate isBarrierOut(DataFlow::Node node, FlowState state) {
-    isAdditionalFlowStep(node, state, _, _)
+    isAdditionalFlowStep(_, state, node, _)
   }
 }
 

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
@@ -64,6 +64,12 @@ public class TaintedPathHandler : IHttpHandler
         
         // This test ensures that we can flow through `Path.GetFullPath` and still get a result.
         ctx.Response.Write(File.ReadAllText(path)); // BAD
+
+        string absolutePath = ctx.Request.MapPath("~MyTempFile");
+        string fullPath2 = Path.Combine(absolutePath, path);
+        if (fullPath2.StartsWith(absolutePath + Path.DirectorySeparatorChar)) {
+            File.ReadAllText(fullPath2); // GOOD [FALSE POSITIVE]
+        }
     }
 
     public bool IsReusable

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
@@ -61,14 +61,14 @@ public class TaintedPathHandler : IHttpHandler
         {
             File.ReadAllText(fullPath); // GOOD
         }
-        
+
         // This test ensures that we can flow through `Path.GetFullPath` and still get a result.
         ctx.Response.Write(File.ReadAllText(path)); // BAD
 
         string absolutePath = ctx.Request.MapPath("~MyTempFile");
         string fullPath2 = Path.Combine(absolutePath, path);
         if (fullPath2.StartsWith(absolutePath + Path.DirectorySeparatorChar)) {
-            File.ReadAllText(fullPath2); // GOOD [FALSE POSITIVE]
+            File.ReadAllText(fullPath2); // GOOD
         }
     }
 

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
@@ -61,6 +61,9 @@ public class TaintedPathHandler : IHttpHandler
         {
             File.ReadAllText(fullPath); // GOOD
         }
+        
+        // This test ensures that we can flow through `Path.GetFullPath` and still get a result.
+        ctx.Response.Write(File.ReadAllText(path)); // BAD [MISSING]
     }
 
     public bool IsReusable

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.cs
@@ -63,7 +63,7 @@ public class TaintedPathHandler : IHttpHandler
         }
         
         // This test ensures that we can flow through `Path.GetFullPath` and still get a result.
-        ctx.Response.Write(File.ReadAllText(path)); // BAD [MISSING]
+        ctx.Response.Write(File.ReadAllText(path)); // BAD
     }
 
     public bool IsReusable

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
@@ -7,6 +7,7 @@
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:38:49:38:55 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:51:26:51:29 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:66:45:66:48 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:66:45:66:48 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
+| TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:12:50:12:53 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:17:51:17:54 | access to local variable path | provenance |  |
@@ -21,8 +22,13 @@ edges
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:36:25:36:31 | access to local variable badPath | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:38:49:38:55 | access to local variable badPath | provenance |  |
 | TaintedPath.cs:59:44:59:47 | access to local variable path : String | TaintedPath.cs:66:45:66:48 | access to local variable path | provenance |  |
+| TaintedPath.cs:59:44:59:47 | access to local variable path : String | TaintedPath.cs:69:55:69:58 | access to local variable path : String | provenance |  |
+| TaintedPath.cs:69:16:69:24 | access to local variable fullPath2 : String | TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | provenance |  |
+| TaintedPath.cs:69:28:69:59 | call to method Combine : String | TaintedPath.cs:69:16:69:24 | access to local variable fullPath2 : String | provenance |  |
+| TaintedPath.cs:69:55:69:58 | access to local variable path : String | TaintedPath.cs:69:28:69:59 | call to method Combine : String | provenance | MaD:2 |
 models
 | 1 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
+| 2 | Summary: System.IO; Path; false; Combine; (System.String,System.String); ; Argument[1]; ReturnValue; taint; manual |
 nodes
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | semmle.label | access to local variable path : String |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
@@ -37,4 +43,8 @@ nodes
 | TaintedPath.cs:51:26:51:29 | access to local variable path | semmle.label | access to local variable path |
 | TaintedPath.cs:59:44:59:47 | access to local variable path : String | semmle.label | access to local variable path : String |
 | TaintedPath.cs:66:45:66:48 | access to local variable path | semmle.label | access to local variable path |
+| TaintedPath.cs:69:16:69:24 | access to local variable fullPath2 : String | semmle.label | access to local variable fullPath2 : String |
+| TaintedPath.cs:69:28:69:59 | call to method Combine : String | semmle.label | call to method Combine : String |
+| TaintedPath.cs:69:55:69:58 | access to local variable path : String | semmle.label | access to local variable path : String |
+| TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | semmle.label | access to local variable fullPath2 |
 subpaths

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
@@ -6,6 +6,7 @@
 | TaintedPath.cs:36:25:36:31 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:36:25:36:31 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:38:49:38:55 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:51:26:51:29 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
+| TaintedPath.cs:66:45:66:48 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:66:45:66:48 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:12:50:12:53 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:17:51:17:54 | access to local variable path | provenance |  |
@@ -13,11 +14,13 @@ edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:31:30:31:33 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:51:26:51:29 | access to local variable path | provenance |  |
+| TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:59:44:59:47 | access to local variable path : String | provenance |  |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:16:10:19 | access to local variable path : String | provenance |  |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:10:23:10:53 | access to indexer : String | provenance | MaD:1 |
 | TaintedPath.cs:10:23:10:53 | access to indexer : String | TaintedPath.cs:10:16:10:19 | access to local variable path : String | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:36:25:36:31 | access to local variable badPath | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:38:49:38:55 | access to local variable badPath | provenance |  |
+| TaintedPath.cs:59:44:59:47 | access to local variable path : String | TaintedPath.cs:66:45:66:48 | access to local variable path | provenance |  |
 models
 | 1 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
 nodes
@@ -32,4 +35,6 @@ nodes
 | TaintedPath.cs:36:25:36:31 | access to local variable badPath | semmle.label | access to local variable badPath |
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | semmle.label | access to local variable badPath |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | semmle.label | access to local variable path |
+| TaintedPath.cs:59:44:59:47 | access to local variable path : String | semmle.label | access to local variable path : String |
+| TaintedPath.cs:66:45:66:48 | access to local variable path | semmle.label | access to local variable path |
 subpaths

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
@@ -7,7 +7,6 @@
 | TaintedPath.cs:38:49:38:55 | access to local variable badPath | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:38:49:38:55 | access to local variable badPath | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:51:26:51:29 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:51:26:51:29 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 | TaintedPath.cs:66:45:66:48 | access to local variable path | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:66:45:66:48 | access to local variable path | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
-| TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | This path depends on a $@. | TaintedPath.cs:10:23:10:45 | access to property QueryString | user-provided value |
 edges
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:12:50:12:53 | access to local variable path | provenance |  |
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | TaintedPath.cs:17:51:17:54 | access to local variable path | provenance |  |
@@ -22,13 +21,8 @@ edges
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:36:25:36:31 | access to local variable badPath | provenance |  |
 | TaintedPath.cs:35:16:35:22 | access to local variable badPath : String | TaintedPath.cs:38:49:38:55 | access to local variable badPath | provenance |  |
 | TaintedPath.cs:59:44:59:47 | access to local variable path : String | TaintedPath.cs:66:45:66:48 | access to local variable path | provenance |  |
-| TaintedPath.cs:59:44:59:47 | access to local variable path : String | TaintedPath.cs:69:55:69:58 | access to local variable path : String | provenance |  |
-| TaintedPath.cs:69:16:69:24 | access to local variable fullPath2 : String | TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | provenance |  |
-| TaintedPath.cs:69:28:69:59 | call to method Combine : String | TaintedPath.cs:69:16:69:24 | access to local variable fullPath2 : String | provenance |  |
-| TaintedPath.cs:69:55:69:58 | access to local variable path : String | TaintedPath.cs:69:28:69:59 | call to method Combine : String | provenance | MaD:2 |
 models
 | 1 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
-| 2 | Summary: System.IO; Path; false; Combine; (System.String,System.String); ; Argument[1]; ReturnValue; taint; manual |
 nodes
 | TaintedPath.cs:10:16:10:19 | access to local variable path : String | semmle.label | access to local variable path : String |
 | TaintedPath.cs:10:23:10:45 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
@@ -43,8 +37,4 @@ nodes
 | TaintedPath.cs:51:26:51:29 | access to local variable path | semmle.label | access to local variable path |
 | TaintedPath.cs:59:44:59:47 | access to local variable path : String | semmle.label | access to local variable path : String |
 | TaintedPath.cs:66:45:66:48 | access to local variable path | semmle.label | access to local variable path |
-| TaintedPath.cs:69:16:69:24 | access to local variable fullPath2 : String | semmle.label | access to local variable fullPath2 : String |
-| TaintedPath.cs:69:28:69:59 | call to method Combine : String | semmle.label | call to method Combine : String |
-| TaintedPath.cs:69:55:69:58 | access to local variable path : String | semmle.label | access to local variable path : String |
-| TaintedPath.cs:71:30:71:38 | access to local variable fullPath2 | semmle.label | access to local variable fullPath2 |
 subpaths


### PR DESCRIPTION
This PR does three small improvements to the `cs/path-injection` query (each in their own commit):

- b40a43701cc99d3f9c48bd5c30f620d9129a079b does a very very small optimization. When you write:
  ```ql
  predicate isSink(DataFlow::Node sink, FlowState state) {
    sink instanceof Sink and
    exists(state)
  }
  ```
  you're technically creating a cartesian product (CP) between all sinks and all states. This isn't a problem in this particular case since there are only 2 states (normalized and non-normalized) so the CP is very small. However, this can be a real problem if there are many states. Because of this we added a way to avoid this in https://github.com/github/codeql/pull/13851. The technical details aren't super important. However, it may be worth remembering that it's always safe to make the transformation in https://github.com/microsoft/codeql/commit/b40a43701cc99d3f9c48bd5c30f620d9129a079b for a very small performance boost 🥳
- 03e671aff1fc849457f665a2a0d8afee9b8e6f72 adds a false negative test that is fixed by a2d4c2006899a2b535a0f21f39040202d8baee26.
  When I added the normalization logic in https://github.com/microsoft/codeql/pull/106 to fix FPs due to missed good uses of `StartsWith` I accidentally introduced a false negative. Luckily, it was easy to fix.
- db7119c29ff0485f54b53837474351583a739ecb adds a false positive that is fixed by 4dfa88626ab3a75d2f4216020809f3ad44c6b4d9.
  This is the meat of this PR (and the whole reason I started looking at the query). We already had logic for concluding when it's safe to use `StartsWith` as a sanitizer (as I explained above). However, we were missing some cases of "path normalization" which meant that the `StartsWith` call wasn't marked as a sanitizer.

Commit-by-commit review recommended 🙂