### PR TITLE
Fix in cpp/global-use-before-init

### DIFF
--- a/cpp/ql/src/Critical/GlobalUseBeforeInit.ql
+++ b/cpp/ql/src/Critical/GlobalUseBeforeInit.ql
@@ -38,7 +38,7 @@ predicate uninitialisedBefore(GlobalVariable v, Function f) {
   exists(Call call, Function g |
     uninitialisedBefore(v, g) and
     call.getEnclosingFunction() = g and
-    (not functionInitialises(f, v) or locallyUninitialisedAt(v, call)) and
+    (not functionInitialises(g, v) or locallyUninitialisedAt(v, call)) and
     resolvedCall(call, f)
   )
 }


### PR DESCRIPTION
The query in its current form seems to be unsound due to a small typo. For example, consider a `GlobalVariable v` that is uninitialized at its declaration, but is set in `main` just before `main` calls `Function f`. `f` reads `v` but never writes it.