### PR TITLE
PS: Remove unnecessary data extension pattern to fix warning

### DIFF
--- a/powershell/ql/lib/qlpack.yml
+++ b/powershell/ql/lib/qlpack.yml
@@ -14,8 +14,6 @@ dependencies:
   codeql/util: ${workspace}
   codeql/mad: ${workspace}
 dataExtensions:
-  - semmle/code/powershell/frameworks/**/model.yml
   - semmle/code/powershell/frameworks/**/*.model.yml
-  - semmle/code/powershell/frameworks/**/typemodel.yml
   - semmle/code/powershell/frameworks/**/*.typemodel.yml
 warnOnImplicitThis: true


### PR DESCRIPTION
@dilanbhalla reported this warning when running `codeql database analyze`:
```
WARNING: Pattern 'semmle/code/powershell/frameworks/**/model.yml' did not match any extension files. (microsoft/powershell-all/0.0.1/qlpack.yml:1,1-1)
WARNING: Pattern 'semmle/code/powershell/frameworks/**/typemodel.yml' did not match any extension files. (microsoft/powershell-all/0.0.1/qlpack.yml:1,1-1)
WARNING: Pattern 'semmle/code/powershell/frameworks/**/model.yml' did not match any extension files. (microsoft/powershell-all/0.0.1/qlpack.yml:1,1-1)
WARNING: Pattern 'semmle/code/powershell/frameworks/**/typemodel.yml' did not match any extension files. (microsoft/powershell-all/0.0.1/qlpack.yml:1,1-1)
```

These happen because the qlpack has specified that there are data extensions (i.e., `.yml` files) that match the pattern `powershell/frameworks/**/model.yml`, but no data extensions match this file name. This is because we recently changed the names of all the data extensions to be `blablabla.model.yml` (instead of `blablabla/model.yml`) to be more consistent with GitHub's directory structure.

By removing the two patterns that do not match any data extensions we will remove the warning.