### PR TITLE
PS: Add `Node.getCallee` predicate on `DataFlow::CallNode`

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPublic.qll
@@ -536,6 +536,8 @@ class CallNode extends ExprNode {
    * Note that this predicate doesn't get the pipeline argument, if any.
    */
   Node getAnArgument() { result.asExpr() = call.getAnArgument() }
+
+  Node getCallee() { result.asExpr() = call.getCallee() }
 }
 
 /** A call to operator `&`, viwed as a node in a data flow graph. */


### PR DESCRIPTION
We may as well make this predicate available on dataflow nodes like it is on the AST nodes and on the control-flow nodes.