### PR TITLE
PS: Fix FPs on `powershell/microsoft/public/sql-injection`

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingPrivate.qll
@@ -18,7 +18,7 @@ predicate defaultTaintSanitizer(DataFlow::Node node) { none() }
 bindingset[node]
 predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet c) {
   node instanceof ArgumentNode and
-  c.isAnyElement()
+  c.isAnyPositional()
 }
 
 cached

--- a/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
+++ b/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
@@ -40,7 +40,10 @@ module SqlInjection {
       exists(DataFlow::CallNode call | call.matchesName("Invoke-Sqlcmd") |
         this = call.getNamedArgument("query")
         or
+        this = call.getNamedArgument("inputfile")
+        or
         not call.hasNamedArgument("query") and
+        not call.hasNamedArgument("inputfile") and
         this = call.getArgument(0)
       )
     }

--- a/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionQuery.qll
+++ b/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionQuery.qll
@@ -18,6 +18,10 @@ private module Config implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet cs) {
+    node.(Sink).allowImplicitRead(cs)
+  }
 }
 
 /**

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -3,23 +3,15 @@ edges
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
-| test.ps1:58:11:58:30 | server_instance | test.ps1:63:22:63:28 | server | provenance |  |
-| test.ps1:61:14:68:1 | ${...} [element ServerInstance] | test.ps1:70:15:70:24 | QueryConn | provenance |  |
-| test.ps1:63:22:63:28 | server | test.ps1:61:14:68:1 | ${...} [element ServerInstance] | provenance |  |
 nodes
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
 | test.ps1:9:72:9:77 | query | semmle.label | query |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
-| test.ps1:58:11:58:30 | server_instance | semmle.label | server_instance |
-| test.ps1:61:14:68:1 | ${...} [element ServerInstance] | semmle.label | ${...} [element ServerInstance] |
-| test.ps1:63:22:63:28 | server | semmle.label | server |
-| test.ps1:70:15:70:24 | QueryConn | semmle.label | QueryConn |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:9:72:9:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
-| test.ps1:70:15:70:24 | QueryConn | test.ps1:58:11:58:30 | server_instance | test.ps1:70:15:70:24 | QueryConn | This SQL query depends on a $@. | test.ps1:58:11:58:30 | server_instance | user-provided value |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -3,15 +3,23 @@ edges
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
+| test.ps1:58:11:58:30 | server_instance | test.ps1:63:22:63:28 | server | provenance |  |
+| test.ps1:61:14:68:1 | ${...} [element ServerInstance] | test.ps1:70:15:70:24 | QueryConn | provenance |  |
+| test.ps1:63:22:63:28 | server | test.ps1:61:14:68:1 | ${...} [element ServerInstance] | provenance |  |
 nodes
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
 | test.ps1:9:72:9:77 | query | semmle.label | query |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
+| test.ps1:58:11:58:30 | server_instance | semmle.label | server_instance |
+| test.ps1:61:14:68:1 | ${...} [element ServerInstance] | semmle.label | ${...} [element ServerInstance] |
+| test.ps1:63:22:63:28 | server | semmle.label | server |
+| test.ps1:70:15:70:24 | QueryConn | semmle.label | QueryConn |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:9:72:9:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
+| test.ps1:70:15:70:24 | QueryConn | test.ps1:58:11:58:30 | server_instance | test.ps1:70:15:70:24 | QueryConn | This SQL query depends on a $@. | test.ps1:58:11:58:30 | server_instance | user-provided value |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -3,15 +3,22 @@ edges
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
+| test.ps1:1:14:1:45 | Call to read-host | test.ps1:78:13:78:22 | userinput | provenance | Src:MaD:0  |
+| test.ps1:72:15:79:1 | ${...} [element Query] | test.ps1:81:15:81:25 | QueryConn2 | provenance |  |
+| test.ps1:78:13:78:22 | userinput | test.ps1:72:15:79:1 | ${...} [element Query] | provenance |  |
 nodes
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
 | test.ps1:9:72:9:77 | query | semmle.label | query |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
+| test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
+| test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
+| test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:9:72:9:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
+| test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -3,19 +3,15 @@ edges
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
-| test.ps1:58:11:58:30 | server_instance | test.ps1:59:31:59:37 | server | provenance |  |
 nodes
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
 | test.ps1:9:72:9:77 | query | semmle.label | query |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
-| test.ps1:58:11:58:30 | server_instance | semmle.label | server_instance |
-| test.ps1:59:31:59:37 | server | semmle.label | server |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:9:72:9:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
-| test.ps1:59:31:59:37 | server | test.ps1:58:11:58:30 | server_instance | test.ps1:59:31:59:37 | server | This SQL query depends on a $@. | test.ps1:58:11:58:30 | server_instance | user-provided value |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -3,15 +3,19 @@ edges
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
+| test.ps1:58:11:58:30 | server_instance | test.ps1:59:31:59:37 | server | provenance |  |
 nodes
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
 | test.ps1:9:72:9:77 | query | semmle.label | query |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
+| test.ps1:58:11:58:30 | server_instance | semmle.label | server_instance |
+| test.ps1:59:31:59:37 | server | semmle.label | server |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:9:72:9:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | user-provided value |
+| test.ps1:59:31:59:37 | server | test.ps1:58:11:58:30 | server_instance | test.ps1:59:31:59:37 | server | This SQL query depends on a $@. | test.ps1:58:11:58:30 | server_instance | user-provided value |

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -67,4 +67,4 @@ $QueryConn = @{
     Query = ""
 }
 
-Invoke-Sqlcmd @QueryConn # GOOD [FALSE POSITIVE]
+Invoke-Sqlcmd @QueryConn # GOOD

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -56,4 +56,4 @@ $reader.Close()
 $connection.Close()
 
 $server = $Env:SERVER_INSTANCE
-Invoke-Sqlcmd -ServerInstance $server -Database "MyDatabase" -InputFile "Foo/Bar/query.sql" # GOOD [FALSE POSITIVE]
+Invoke-Sqlcmd -ServerInstance $server -Database "MyDatabase" -InputFile "Foo/Bar/query.sql" # GOOD

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -57,3 +57,14 @@ $connection.Close()
 
 $server = $Env:SERVER_INSTANCE
 Invoke-Sqlcmd -ServerInstance $server -Database "MyDatabase" -InputFile "Foo/Bar/query.sql" # GOOD
+
+$QueryConn = @{
+    Database = "MyDB"
+    ServerInstance = $server
+    Username = "MyUserName"
+    Password = "MyPassword"
+    ConnectionTimeout = 0
+    Query = ""
+}
+
+Invoke-Sqlcmd @QueryConn # GOOD [FALSE POSITIVE]

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -68,3 +68,14 @@ $QueryConn = @{
 }
 
 Invoke-Sqlcmd @QueryConn # GOOD
+
+$QueryConn2 = @{
+    Database = "MyDB"
+    ServerInstance = "MyServer"
+    Username = "MyUserName"
+    Password = "MyPassword"
+    ConnectionTimeout = 0
+    Query = $userinput
+}
+
+Invoke-Sqlcmd @QueryConn2 # BAD [NOT DETECTED]

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -54,3 +54,6 @@ $parameter.Value = $userinput # GOOD
 $reader = $command.ExecuteReader()
 $reader.Close()
 $connection.Close()
+
+$server = $Env:SERVER_INSTANCE
+Invoke-Sqlcmd -ServerInstance $server -Database "MyDatabase" -InputFile "Foo/Bar/query.sql" # GOOD [FALSE POSITIVE]

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -78,4 +78,4 @@ $QueryConn2 = @{
     Query = $userinput
 }
 
-Invoke-Sqlcmd @QueryConn2 # BAD [NOT DETECTED]
+Invoke-Sqlcmd @QueryConn2 # BAD


### PR DESCRIPTION
This PR fixes two FPs on the `powershell/microsoft/public/sql-injection` query:

1. We were missing calls to `Invoke-Sqlcmd` with an `InputFile` named argument, and because the logic of the sink is "if we cannot find the right argument to the call to `Invoke-Sqlcmd` then just use the first argument" then we incorrectly marked the first argument of `Invoke-Sqlcmd` as the sink when it should have been the `InputFile` named argument. See the FP in the first commit for an example of this.
This has been fixed in c18db919c9f84da219da27d2998819e49b6b5e42.

2. The next FP fix requires some explanation. Consider this example (in some simplified language):
```
x.f = source();
sink(x);
```
normally there wouldn't be any path from `source()` to `sink(x)` in the above since we never read `f` off the `x` object before passing it to `sink`. However, sometimes we want to have a result in those scenarios. So in taint-tracking we specify certain kinds of "implicit reads" that happen at sinks.
For PowerShell I decided [at some point](https://github.com/microsoft/codeql/commit/a0e17ee37b14481e6382f30823bb2b73d4571f14) that any kind of field could be read off implicitly at sinks. However, this gives a FP when a specific field of an object is tainted, and we only want an alert when _that_ specific field is tainted. See 25d94fabcc36e0e3cc33c784f496aa12f46be2c3 for an example FP from this.

In 148620014628d8de97e0fb89c471277a8861cf61 I've fixed this FP by only allowing implicit reads by default on "array index"-like values. This matches what other CodeQL languages.

Now, this means that we have to add such implicit reads at sinks specifically where we need them. So in 1ff04d9f94d94eb7cb3919c32983df725571b732 I added a false negative which requires these implicit reads, and in 148620014628d8de97e0fb89c471277a8861cf61 I've added support for such implicit reads.