### PR TITLE
PS: Add query for insecure uses of `Set-ExecutionPolicy`

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Raw/ChildIndex.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Raw/ChildIndex.qll
@@ -14,6 +14,7 @@ newtype ChildIndex =
   CatchClauseBody() or
   CatchClauseType(int i) { exists(any(CatchClause c).getCatchType(i)) } or
   CmdElement_(int i) { exists(any(Cmd cmd).getElement(i)) } or // TODO: Get rid of this?
+  CmdParameterExpr() or
   CmdCallee() or
   CmdRedirection(int i) { exists(any(Cmd cmd).getRedirection(i)) } or
   CmdExprExpr() or
@@ -126,6 +127,8 @@ string stringOfChildIndex(ChildIndex i) {
   i = CatchClauseType(_) and result = "CatchClauseType"
   or
   i = CmdElement_(_) and result = "CmdElement"
+  or
+  i = CmdParameterExpr() and result = "CmdParameterExpr"
   or
   i = CmdCallee() and result = "CmdCallee"
   or

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Raw/CommandParameter.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Raw/CommandParameter.qll
@@ -5,8 +5,11 @@ class CmdParameter extends @command_parameter, CmdElement {
 
   string getName() { command_parameter(this, result) }
 
-  Ast getExpr() {
-    command_parameter_argument(this, result)
+  Ast getExpr() { command_parameter_argument(this, result) }
+
+  final override Ast getChild(ChildIndex i) {
+    i instanceof CmdParameterExpr and
+    result = this.getExpr()
   }
 
   Cmd getCmd() { result.getElement(_) = this }

--- a/powershell/ql/src/queries/security/cwe-250/InsecureExecutionPolicy.qhelp
+++ b/powershell/ql/src/queries/security/cwe-250/InsecureExecutionPolicy.qhelp
@@ -1,0 +1,32 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>The command <code>Set-ExecutionPolicy</code> is used to set the execution policies for Windows computers.
+The execution policy is used to determine which configuration files can be loaded and which scripts can be run.
+Setting the execution policy to <code>Bypass</code> disables all warnings and signature checks for script execution,
+allowing any script—including malicious or unsigned code—to run without restriction.</p>
+</overview>
+
+<recommendation>
+<p>Always prefer <code>AllSigned</code> to enforce full signature verification.</p>
+<p>If this is not possible, set the execution policy to <code>RemoteSigned</code> to allow local scripts while requiring downloaded scripts to be signed.</p>
+<p>Always limit the scope of the execution policy by supplying the most restrictive <code>Scope</code> as possible. Use <code>Process</code> to limit the execution policy to the current PowerShell session. When no <code>Scope</code> is supplied the execution policy change is applied system-wide.
+</recommendation>
+
+<example>
+<p>In the following example, <code>Set-ExecutionPolicy</code> is called twice</p>
+
+<p>The first call sets the execution policy to <code>Bypass</code> which allows any script to be run.</p>
+
+<p>The second call sets the execution policy to <code>RemoteSigned</code> which allows local scripts to be run,
+but requires scripts and configurations downloaded from the Internet to be signed.</p>
+
+<sample src="examples/InsecureExecutionPolicy.ps1" />
+</example>
+
+<references>
+<li>MSDN: <a href="https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy">Set-ExecutionPolicy</a>.</li>
+</references>
+</qhelp>

--- a/powershell/ql/src/queries/security/cwe-250/InsecureExecutionPolicy.ql
+++ b/powershell/ql/src/queries/security/cwe-250/InsecureExecutionPolicy.ql
@@ -41,6 +41,9 @@ class SetExecutionPolicy extends CmdCall {
       else result = this.getPositionalArgument(1)
     )
   }
+
+  /** Holds if the argument `flag` is supplied with a `$true` value. */
+  predicate isForced() { this.getNamedArgument("force").getValue().asBoolean() = true }
 }
 
 class Process extends Expr {
@@ -56,5 +59,7 @@ class BypassSetExecutionPolicy extends SetExecutionPolicy {
 }
 
 from BypassSetExecutionPolicy setExecutionPolicy
-where not setExecutionPolicy.getScope() instanceof Process
+where
+  not setExecutionPolicy.getScope() instanceof Process and
+  setExecutionPolicy.isForced()
 select setExecutionPolicy, "Insecure use of 'Set-ExecutionPolicy'."

--- a/powershell/ql/src/queries/security/cwe-250/InsecureExecutionPolicy.ql
+++ b/powershell/ql/src/queries/security/cwe-250/InsecureExecutionPolicy.ql
@@ -1,0 +1,60 @@
+/**
+ * @name Insecure execution policy
+ * @description Calling `Set-ExecutionPolicy` with an insecure execution policy argument may allow
+ *              attackers to execute malicious scripts or load malicious configurations.
+ * @kind problem
+ * @problem.severity error
+ * @security-severity 8.8
+ * @precision high
+ * @id powershell/microsoft/public/insecure-execution-policy
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-250
+ */
+
+import powershell
+
+/** A call to `Set-ExecutionPolicy`. */
+class SetExecutionPolicy extends CmdCall {
+  SetExecutionPolicy() { this.getAName() = "Set-ExecutionPolicy" }
+
+  /** Gets the execution policy of this call to `Set-ExecutionPolicy`. */
+  Expr getExecutionPolicy() {
+    result = this.getNamedArgument("executionpolicy")
+    or
+    not this.hasNamedArgument("executionpolicy") and
+    result = this.getPositionalArgument(0)
+  }
+
+  /** Gets the scope of this call to `Set-ExecutionPolicy`, if any. */
+  Expr getScope() {
+    result = this.getNamedArgument("scope")
+    or
+    not this.hasNamedArgument("scope") and
+    (
+      // The ExecutionPolicy argument has position 0 so if is present as a
+      // named argument then the position of the Scope argument is 0. However,
+      // if the ExecutionPolicy is present as a positional argument then the
+      // Scope argument is at position 1.
+      if this.hasNamedArgument("executionpolicy")
+      then result = this.getPositionalArgument(0)
+      else result = this.getPositionalArgument(1)
+    )
+  }
+}
+
+class Process extends Expr {
+  Process() { this.getValue().stringMatches("process") }
+}
+
+class Bypass extends Expr {
+  Bypass() { this.getValue().stringMatches("Bypass") }
+}
+
+class BypassSetExecutionPolicy extends SetExecutionPolicy {
+  BypassSetExecutionPolicy() { this.getExecutionPolicy() instanceof Bypass }
+}
+
+from BypassSetExecutionPolicy setExecutionPolicy
+where not setExecutionPolicy.getScope() instanceof Process
+select setExecutionPolicy, "Insecure use of 'Set-ExecutionPolicy'."

--- a/powershell/ql/src/queries/security/cwe-250/examples/InsecureExecutionPolicy.ps1
+++ b/powershell/ql/src/queries/security/cwe-250/examples/InsecureExecutionPolicy.ps1
@@ -1,0 +1,9 @@
+Invoke-WebRequest -Uri "https://example.com/script.ps1" -OutFile "C:\Path\To\script.ps1"
+
+# BAD: No warnings or prompts when running potentially unsafe scripts
+Set-ExecutionPolicy Bypass
+& "C:\Path\To\script.ps1" # Will never be blocked
+
+# GOOD: Requires that scripts and configuration files downloaded from the Internet are signed
+Set-ExecutionPolicy RemoteSigned
+& "C:\Path\To\script.ps1" # Will not run unless script.ps1 is signed

--- a/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.expected
+++ b/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.expected
@@ -1,2 +1,2 @@
-| test.ps1:1:1:1:26 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |
-| test.ps1:5:1:5:47 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |
+| test.ps1:1:1:1:33 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |
+| test.ps1:5:1:5:54 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |

--- a/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.expected
+++ b/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.expected
@@ -1,2 +1,3 @@
 | test.ps1:1:1:1:33 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |
 | test.ps1:5:1:5:54 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |
+| test.ps1:7:1:7:39 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |

--- a/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.expected
+++ b/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.expected
@@ -1,0 +1,2 @@
+| test.ps1:1:1:1:26 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |
+| test.ps1:5:1:5:47 | Call to set-executionpolicy | Insecure use of 'Set-ExecutionPolicy'. |

--- a/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.qlref
+++ b/powershell/ql/test/query-tests/security/cwe-250/InsecureExecutionPolicy.qlref
@@ -1,0 +1,1 @@
+queries/security/cwe-250/InsecureExecutionPolicy.ql

--- a/powershell/ql/test/query-tests/security/cwe-250/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-250/test.ps1
@@ -1,0 +1,5 @@
+Set-ExecutionPolicy Bypass # BAD
+Set-ExecutionPolicy RemoteSigned # GOOD
+Set-ExecutionPolicy Bypass -Scope Process # GOOD
+Set-ExecutionPolicy RemoteSigned -Scope Process # GOOD
+Set-ExecutionPolicy Bypass -Scope MachinePolicy # BAD

--- a/powershell/ql/test/query-tests/security/cwe-250/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-250/test.ps1
@@ -1,5 +1,14 @@
-Set-ExecutionPolicy Bypass # BAD
+Set-ExecutionPolicy Bypass -Force # BAD
+Set-ExecutionPolicy RemoteSigned -Force # GOOD
+Set-ExecutionPolicy Bypass -Scope Process -Force # GOOD
+Set-ExecutionPolicy RemoteSigned -Scope Process -Force # GOOD
+Set-ExecutionPolicy Bypass -Scope MachinePolicy -Force # BAD
+
+Set-ExecutionPolicy Bypass -Force:$true # BAD [NOT DETECTED]
+Set-ExecutionPolicy Bypass -Force:$false # GOOD
+
+Set-ExecutionPolicy Bypass # GOOD
 Set-ExecutionPolicy RemoteSigned # GOOD
 Set-ExecutionPolicy Bypass -Scope Process # GOOD
 Set-ExecutionPolicy RemoteSigned -Scope Process # GOOD
-Set-ExecutionPolicy Bypass -Scope MachinePolicy # BAD
+Set-ExecutionPolicy Bypass -Scope MachinePolicy # GOOD

--- a/powershell/ql/test/query-tests/security/cwe-250/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-250/test.ps1
@@ -4,7 +4,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force # GOOD
 Set-ExecutionPolicy RemoteSigned -Scope Process -Force # GOOD
 Set-ExecutionPolicy Bypass -Scope MachinePolicy -Force # BAD
 
-Set-ExecutionPolicy Bypass -Force:$true # BAD [NOT DETECTED]
+Set-ExecutionPolicy Bypass -Force:$true # BAD
 Set-ExecutionPolicy Bypass -Force:$false # GOOD
 
 Set-ExecutionPolicy Bypass # GOOD


### PR DESCRIPTION
This PR adds a new PowerShell query `powershell/microsoft/public/insecure-execution-policy` which finds calls to `Set-ExecutionPolicy` that:
- Sets the execution policy to `Bypass` (["Nothing is blocked and there are no warnings or prompts."](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.5#-executionpolicy) 😱)
- Sets the scope to more than `Process`.
- Sets the `-Force` flag.

I ran an initial draft query that omitted the restriction on the `Scope`, and I got **lots** of results that modified the execution policy only for the current process. So as a way to get _some_ version of this query merged I think it makes sense to initially make the query only alert on calls to `Set-ExecutionPolicy` that doesn't limit the scope to the current process. The default value for this parameter is apparently `LocalMachine` which is already super scary considering that this is a persistent change.