### PR TITLE
PS: Actually implement `localExprTaint`

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingPublic.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/TaintTrackingPublic.qll
@@ -15,6 +15,8 @@ predicate localTaint(DataFlow::Node source, DataFlow::Node sink) { localTaintSte
  * local (intra-procedural) steps.
  */
 pragma[inline]
-predicate localExprTaint(CfgNodes::ExprCfgNode e1, CfgNodes::ExprCfgNode e2) { none() }
+predicate localExprTaint(CfgNodes::ExprCfgNode e1, CfgNodes::ExprCfgNode e2) {
+  localTaintStep*(DataFlow::exprNode(e1), DataFlow::exprNode(e2))
+}
 
 predicate localTaintStep = localTaintStepCached/2;


### PR DESCRIPTION
Seems like this predicate was missed when I was filling in the trivial parts of taint-tracking.

This predicate is only used when a query needs local taint flow instead of global taint flow. And we don't have any such queries yet (which is why we never noticed it).