### PR TITLE
PS: Mark certain environment variables as not user controlled

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/EnvVariable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/EnvVariable.qll
@@ -6,6 +6,86 @@ class EnvVariable extends Expr, TEnvVariable {
   string getName() { any(Synthesis s).envVariableName(this, result) }
 }
 
+class Path extends EnvVariable {
+  Path() { this.getName() = "path" }
+}
+
+class Temp extends EnvVariable {
+  Temp() { this.getName() = ["temp", "tmp"] }
+}
+
+class AppData extends EnvVariable {
+  AppData() { this.getName() = "appdata" }
+}
+
+class LocalAppData extends EnvVariable {
+  LocalAppData() { this.getName() = "localappdata" }
+}
+
+class ProgramData extends EnvVariable {
+  ProgramData() { this.getName() = "programdata" }
+}
+
+class PSModulePath extends EnvVariable {
+  PSModulePath() { this.getName() = "psmodulepath" }
+}
+
+class Username extends EnvVariable {
+  Username() { this.getName() = "username" }
+}
+
+class UserDomain extends EnvVariable {
+  UserDomain() { this.getName() = "userdomain" }
+}
+
+class UserProfile extends EnvVariable {
+  UserProfile() { this.getName() = "userprofile" }
+}
+
+class HomePath extends EnvVariable {
+  HomePath() { this.getName() = "homepath" }
+}
+
+class ProgramFiles extends EnvVariable {
+  ProgramFiles() { this.getName() = "programfiles" }
+}
+
+class PSExecutionPolicyPreference extends EnvVariable {
+  PSExecutionPolicyPreference() { this.getName() = "psexecutionpolicypreference" }
+}
+
+class ComputerName extends EnvVariable {
+  ComputerName() { this.getName() = "computername" }
+}
+
+class OS extends EnvVariable {
+  OS() { this.getName() = "os" }
+}
+
+class SystemRoot extends EnvVariable {
+  SystemRoot() { this.getName() = "systemroot" }
+}
+
+class ProcessorArchitecture extends EnvVariable {
+  ProcessorArchitecture() { this.getName() = "processor_architecture" }
+}
+
+class NumberOfProcessors extends EnvVariable {
+  NumberOfProcessors() { this.getName() = "number_of_processors" }
+}
+
 class SystemDrive extends EnvVariable {
   SystemDrive() { this.getName() = "systemdrive" }
+}
+
+class Windir extends EnvVariable {
+  Windir() { this.getName() = "windir" }
+}
+
+class LogonServer extends EnvVariable {
+  LogonServer() { this.getName() = "logonserver" }
+}
+
+class SessionName extends EnvVariable {
+  SessionName() { this.getName() = "sessionname" }
 }

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/EnvVariable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/EnvVariable.qll
@@ -4,6 +4,16 @@ class EnvVariable extends Expr, TEnvVariable {
   final override string toString() { result = this.getName() }
 
   string getName() { any(Synthesis s).envVariableName(this, result) }
+
+  /**
+   * Holds if this environment variabler should be considered as a source of
+   * user-input.
+   *
+   * By default, any environment variable is considered to be a source of user-
+   * input. However, certain environment variables, for example
+   * `$Env:number_of_processors`, are known to not be user-controlled.
+   */
+  predicate isUserControlled() { any() }
 }
 
 class Path extends EnvVariable {
@@ -28,64 +38,96 @@ class ProgramData extends EnvVariable {
 
 class PSModulePath extends EnvVariable {
   PSModulePath() { this.getName() = "psmodulepath" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class Username extends EnvVariable {
   Username() { this.getName() = "username" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class UserDomain extends EnvVariable {
   UserDomain() { this.getName() = "userdomain" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class UserProfile extends EnvVariable {
   UserProfile() { this.getName() = "userprofile" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class HomePath extends EnvVariable {
   HomePath() { this.getName() = "homepath" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class ProgramFiles extends EnvVariable {
   ProgramFiles() { this.getName() = "programfiles" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class PSExecutionPolicyPreference extends EnvVariable {
   PSExecutionPolicyPreference() { this.getName() = "psexecutionpolicypreference" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class ComputerName extends EnvVariable {
   ComputerName() { this.getName() = "computername" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class OS extends EnvVariable {
   OS() { this.getName() = "os" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class SystemRoot extends EnvVariable {
   SystemRoot() { this.getName() = "systemroot" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class ProcessorArchitecture extends EnvVariable {
   ProcessorArchitecture() { this.getName() = "processor_architecture" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class NumberOfProcessors extends EnvVariable {
   NumberOfProcessors() { this.getName() = "number_of_processors" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class SystemDrive extends EnvVariable {
   SystemDrive() { this.getName() = "systemdrive" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class Windir extends EnvVariable {
   Windir() { this.getName() = "windir" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class LogonServer extends EnvVariable {
   LogonServer() { this.getName() = "logonserver" }
+
+  final override predicate isUserControlled() { none() }
 }
 
 class SessionName extends EnvVariable {
   SessionName() { this.getName() = "sessionname" }
+
+  final override predicate isUserControlled() { none() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/Local.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/Local.qll
@@ -31,7 +31,7 @@ abstract class EnvironmentVariableSource extends LocalFlowSource {
 }
 
 private class EnvironmentVariableEnv extends EnvironmentVariableSource {
-  EnvironmentVariableEnv() { this.asExpr().getExpr() instanceof EnvVariable }
+  EnvironmentVariableEnv() { this.asExpr().getExpr().(EnvVariable).isUserControlled() }
 }
 
 private class ExternalEnvironmentVariableSource extends EnvironmentVariableSource {

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -6,7 +6,6 @@ edges
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:78:13:78:22 | userinput | provenance | Src:MaD:0  |
 | test.ps1:72:15:79:1 | ${...} [element Query] | test.ps1:81:15:81:25 | QueryConn2 | provenance |  |
 | test.ps1:78:13:78:22 | userinput | test.ps1:72:15:79:1 | ${...} [element Query] | provenance |  |
-| test.ps1:84:18:84:42 | number_of_processors | test.ps1:87:76:87:81 | query | provenance |  |
 nodes
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
@@ -16,8 +15,6 @@ nodes
 | test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
 | test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
 | test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |
-| test.ps1:84:18:84:42 | number_of_processors | semmle.label | number_of_processors |
-| test.ps1:87:76:87:81 | query | semmle.label | query |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -25,4 +22,3 @@ subpaths
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
-| test.ps1:87:76:87:81 | query | test.ps1:84:18:84:42 | number_of_processors | test.ps1:87:76:87:81 | query | This SQL query depends on a $@. | test.ps1:84:18:84:42 | number_of_processors | environment variable |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -6,6 +6,7 @@ edges
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:78:13:78:22 | userinput | provenance | Src:MaD:0  |
 | test.ps1:72:15:79:1 | ${...} [element Query] | test.ps1:81:15:81:25 | QueryConn2 | provenance |  |
 | test.ps1:78:13:78:22 | userinput | test.ps1:72:15:79:1 | ${...} [element Query] | provenance |  |
+| test.ps1:84:18:84:42 | number_of_processors | test.ps1:87:76:87:81 | query | provenance |  |
 nodes
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
@@ -15,6 +16,8 @@ nodes
 | test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
 | test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
 | test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |
+| test.ps1:84:18:84:42 | number_of_processors | semmle.label | number_of_processors |
+| test.ps1:87:76:87:81 | query | semmle.label | query |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -22,3 +25,4 @@ subpaths
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
+| test.ps1:87:76:87:81 | query | test.ps1:84:18:84:42 | number_of_processors | test.ps1:87:76:87:81 | query | This SQL query depends on a $@. | test.ps1:84:18:84:42 | number_of_processors | environment variable |

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -79,3 +79,10 @@ $QueryConn2 = @{
 }
 
 Invoke-Sqlcmd @QueryConn2 # BAD
+
+function safe_env_read {
+    $userinput = $Env:number_of_processors
+
+    $query = "SELECT * FROM MyTable WHERE MyColumn = '$userinput'"
+    Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -Query $query # GOOD [FALSE POSITIVE]
+}

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -84,5 +84,5 @@ function safe_env_read {
     $userinput = $Env:number_of_processors
 
     $query = "SELECT * FROM MyTable WHERE MyColumn = '$userinput'"
-    Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -Query $query # GOOD [FALSE POSITIVE]
+    Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -Query $query # GOOD
 }


### PR DESCRIPTION
@chanel-y made an observation that I feel like I've only seen while reviewing some PowerShell query results: Certain environment variables are used very commonly, and they likely shouldn't be considered user input.

In https://github.com/microsoft/codeql/commit/3a66283e3274e85d067ee8bc114e48bd9622cd02 you can see which environment variables I decided on excluding. @chanel-y I'd love to hear your thoughts on that list. In particular:
- Should we simply exclude _any environment variable_? Or should we only exclude the "known good ones" as I'm doing here?
- Are there any environment variables in the list that you feel like we shouldn't exclude?
- Are there any environment variables in the list that we should exclude?