### PR TITLE
PS: Global flow through environment variables

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/ChildIndex.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/ChildIndex.qll
@@ -34,7 +34,8 @@ newtype ChildIndex =
   ProcessBlockPipelineVarReadAccess() or
   ProcessBlockPipelineByPropertyNameVarReadAccess(string name) {
     name = any(Raw::PipelineByPropertyNameParameter p).getLowerCaseName()
-  }
+  } or
+  EnvVar(string var) { Raw::isEnvVariableAccess(_, var) }
 
 int synthPipelineParameterChildIndex(Raw::ScriptBlock sb) {
   // If there is a parameter block, but no pipeline parameter

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/ChildIndex.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/ChildIndex.qll
@@ -26,11 +26,7 @@ newtype ChildIndex =
   ExprRedirection(int i) { exists(any(Raw::Cmd cmdExpr).getRedirection(i)) } or
   FunDefFun() or
   TypeDefType() or
-  TypeMember(int i) {
-    exists(any(Raw::TypeStmt typedef).getMember(i))
-    // or
-    // hasMemberInType(_, _, i, _)
-  } or
+  TypeMember(int i) { exists(any(Raw::TypeStmt typedef).getMember(i)) } or
   ThisVar() or
   PipelineIteratorVar() or
   PipelineByPropertyNameIteratorVar(Raw::PipelineByPropertyNameParameter p) or

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/EnvVariable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/EnvVariable.qll
@@ -1,11 +1,15 @@
 private import AstImport
 
-class EnvVariable extends Expr, TEnvVariable {
-  final override string toString() { result = this.getName() }
+class EnvVariable extends Variable instanceof EnvVariableImpl {
+  string getLowerCaseName() { result = super.getLowerCaseNameImpl() }
 
-  string getName() { any(Synthesis s).envVariableName(this, result) }
-}
+  bindingset[name]
+  pragma[inline_late]
+  final predicate matchesName(string name) { this.getLowerCaseName() = name.toLowerCase() }
 
-class SystemDrive extends EnvVariable {
-  SystemDrive() { this.getName() = "systemdrive" }
+  bindingset[result]
+  pragma[inline_late]
+  final string getAName() { result.toLowerCase() = this.getLowerCaseName() }
+
+  override Ast getChild(ChildIndex childIndex) { none() }
 }

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/TAst.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/TAst.qll
@@ -160,7 +160,6 @@ private module Cached {
     TUsingExpr(Raw::UsingExpr u) or
     TBoolLiteral(Raw::Ast parent, ChildIndex i) { mkSynthChild(BoolLiteralKind(_), parent, i) } or
     TNullLiteral(Raw::Ast parent, ChildIndex i) { mkSynthChild(NullLiteralKind(), parent, i) } or
-    TEnvVariable(Raw::Ast parent, ChildIndex i) { mkSynthChild(EnvVariableKind(_), parent, i) } or
     TAutomaticVariable(Raw::Ast parent, ChildIndex i) {
       mkSynthChild(AutomaticVariableKind(_), parent, i)
     }
@@ -180,7 +179,7 @@ private module Cached {
 
   class TAstSynth =
     TExprStmtSynth or TFunctionSynth or TBoolLiteral or TNullLiteral or TVarAccessSynth or
-        TEnvVariable or TTypeSynth or TAutomaticVariable or TVariableSynth;
+        TTypeSynth or TAutomaticVariable or TVariableSynth;
 
   class TExpr =
     TArrayExpr or TArrayLiteral or TOperation or TConstExpr or TConvertExpr or TErrorExpr or
@@ -188,7 +187,7 @@ private module Cached {
         TPipelineChain or TStringConstExpr or TConditionalExpr or TVarAccess or
         TExpandableStringExpr or TScriptBlockExpr or TExpandableSubExpr or TTypeNameExpr or
         TUsingExpr or TAttributedExpr or TIf or TBoolLiteral or TNullLiteral or TThisExpr or
-        TEnvVariable or TAutomaticVariable or TParenExpr;
+        TAutomaticVariable or TParenExpr;
 
   class TStmt =
     TAssignStmt or TBreakStmt or TContinueStmt or TDataStmt or TDoUntilStmt or TDoWhileStmt or
@@ -308,7 +307,6 @@ private module Cached {
     result = TBoolLiteral(parent, i) or
     result = TNullLiteral(parent, i) or
     result = TVarAccessSynth(parent, i) or
-    result = TEnvVariable(parent, i) or
     result = TTypeSynth(parent, i) or
     result = TAutomaticVariable(parent, i) or
     result = TVariableSynth(parent, i)

--- a/powershell/ql/lib/semmle/code/powershell/ast/internal/Variable.qll
+++ b/powershell/ql/lib/semmle/code/powershell/ast/internal/Variable.qll
@@ -106,6 +106,10 @@ module Private {
     }
   }
 
+  class EnvVariableImpl extends VariableSynth {
+    override EnvVar i;
+  }
+
   abstract class VarAccessImpl extends Expr, TVarAccess {
     abstract VariableImpl getVariableImpl();
   }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/CfgNodes.qll
@@ -1093,20 +1093,6 @@ module ExprNodes {
     CallExprCfgNode getCall() { result.getPipelineArgument() = this }
   }
 
-  private class EnvVariableChildMapping extends ExprChildMapping, EnvVariable {
-    override predicate relevantChild(Ast child) { none() }
-  }
-
-  class EnvVariableCfgNode extends ExprCfgNode {
-    override string getAPrimaryQlClass() { result = "EnvVariableCfgNode" }
-
-    override EnvVariableChildMapping e;
-
-    override EnvVariable getExpr() { result = e }
-
-    string getName() { result = e.getName() }
-  }
-
   private class OperationChildMapping extends ExprChildMapping, Operation {
     override predicate relevantChild(Ast child) { child = this.getAnOperand() }
   }

--- a/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/powershell/ql/lib/semmle/code/powershell/controlflow/internal/ControlFlowGraphImpl.qll
@@ -736,8 +736,6 @@ module Trees {
 
   class VarTree extends LeafTree instanceof Variable { }
 
-  class EnvVariableTree extends LeafTree instanceof EnvVariable { }
-
   class AutomaticVariableTree extends LeafTree instanceof AutomaticVariable { }
 
   class BinaryExprTree extends StandardPostOrderTree instanceof BinaryExpr {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/Ssa.qll
@@ -130,6 +130,21 @@ module Ssa {
     final override Location getLocation() { result = this.getBasicBlock().getLocation() }
   }
 
+  class InitialEnvVarDefinition extends Definition, SsaImpl::WriteDefinition {
+    private EnvVariable v;
+
+    InitialEnvVarDefinition() {
+      exists(BasicBlock bb, int i |
+        this.definesAt(v, bb, i) and
+        SsaImpl::envVarWrite(bb, i, v)
+      )
+    }
+
+    final override string toString() { result = "<initial env var> " + v }
+
+    final override Location getLocation() { result = this.getBasicBlock().getLocation() }
+  }
+
   /**  phi node. */
   class PhiNode extends Definition, SsaImpl::PhiNode {
     /** Gets an input of this phi node. */

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/Local.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/flowsources/Local.qll
@@ -31,7 +31,7 @@ abstract class EnvironmentVariableSource extends LocalFlowSource {
 }
 
 private class EnvironmentVariableEnv extends EnvironmentVariableSource {
-  EnvironmentVariableEnv() { this.asExpr().getExpr() instanceof EnvVariable }
+  EnvironmentVariableEnv() { this.asExpr().getExpr() = any(EnvVariable env).getAnAccess() }
 }
 
 private class ExternalEnvironmentVariableSource extends EnvironmentVariableSource {

--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -1415,30 +1415,3 @@ ContentApprox getContentApprox(Content c) {
   c instanceof Content::UnknownKeyOrPositionContent and
   result = TUnknownContentApprox()
 }
-
-// TFieldContent(string name) {
-//   name = any(PropertyMember member).getName()
-//   or
-//   name = any(MemberExpr me).getMemberName()
-// } or
-// // A known map key
-// TKnownKeyContent(ConstantValue cv) { exists(cv.asString()) } or
-// // A known array index
-// TKnownPositionalContent(ConstantValue cv) { cv.asInt() = [0 .. 10] } or
-// // An unknown key
-// TUnknownKeyContent() or
-// // An unknown positional element
-// TUnknownPositionalContent() or
-// // A unknown position or key - and we dont even know what kind it is
-// TUnknownKeyOrPositionContent()
-/**
- * A unit class for adding additional jump steps.
- *
- * Extend this class to add additional jump steps.
- */
-class AdditionalJumpStep extends Unit {
-  /**
-   * Holds if data can flow from `pred` to `succ` in a way that discards call contexts.
-   */
-  abstract predicate step(Node pred, Node succ);
-}

--- a/powershell/ql/lib/semmle/code/powershell/security/CommandInjectionCustomizations.qll
+++ b/powershell/ql/lib/semmle/code/powershell/security/CommandInjectionCustomizations.qll
@@ -31,7 +31,12 @@ module CommandInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of user input, considered as a flow source for command injection. */
-  class FlowSourceAsSource extends Source instanceof SourceNode {
+  class FlowSourceAsSource extends Source {
+    FlowSourceAsSource() {
+      this instanceof SourceNode and
+      not this instanceof EnvironmentVariableSource
+    }
+
     override string getSourceType() { result = "user-provided value" }
   }
 

--- a/powershell/ql/test/library-tests/dataflow/global/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/global/test.expected
@@ -1,0 +1,6 @@
+models
+edges
+nodes
+subpaths
+testFailures
+#select

--- a/powershell/ql/test/library-tests/dataflow/global/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/global/test.expected
@@ -1,6 +1,15 @@
 models
 edges
+| test.ps1:2:14:2:23 | Call to source | test.ps1:5:25:7:1 | <initial env var> env:x | provenance |  |
+| test.ps1:5:25:7:1 | <initial env var> env:x | test.ps1:6:5:6:15 | env:x | provenance |  |
+| test.ps1:16:18:16:27 | Call to source | test.ps1:5:25:7:1 | <initial env var> env:x | provenance |  |
 nodes
+| test.ps1:2:14:2:23 | Call to source | semmle.label | Call to source |
+| test.ps1:5:25:7:1 | <initial env var> env:x | semmle.label | <initial env var> env:x |
+| test.ps1:6:5:6:15 | env:x | semmle.label | env:x |
+| test.ps1:16:18:16:27 | Call to source | semmle.label | Call to source |
 subpaths
 testFailures
 #select
+| test.ps1:6:5:6:15 | env:x | test.ps1:2:14:2:23 | Call to source | test.ps1:6:5:6:15 | env:x | $@ | test.ps1:2:14:2:23 | Call to source | Call to source |
+| test.ps1:6:5:6:15 | env:x | test.ps1:16:18:16:27 | Call to source | test.ps1:6:5:6:15 | env:x | $@ | test.ps1:16:18:16:27 | Call to source | Call to source |

--- a/powershell/ql/test/library-tests/dataflow/global/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/global/test.ps1
@@ -3,7 +3,7 @@ function WriteToEnvVar {
 }
 
 function ReadFromEndVar {
-    Sink $Env:x # $ MISSING: hasValueFlow=1 hasValueFlow=3
+    Sink $Env:x # $ hasValueFlow=1 hasValueFlow=3
 }
 
 function WriteAndThenOverWriteEnvVar {

--- a/powershell/ql/test/library-tests/dataflow/global/test.ps1
+++ b/powershell/ql/test/library-tests/dataflow/global/test.ps1
@@ -1,0 +1,20 @@
+function WriteToEnvVar {
+    $env:x = Source "1"
+}
+
+function ReadFromEndVar {
+    Sink $Env:x # $ MISSING: hasValueFlow=1 hasValueFlow=3
+}
+
+function WriteAndThenOverWriteEnvVar {
+    $env:x = Source "2"
+    $env:x = 0
+}
+
+function MaybeWriteToEnvVar($b) {
+    if($b -eq $true) {
+        $env:x = Source "3"
+    } else {
+        $env:x = 0
+    }
+}

--- a/powershell/ql/test/library-tests/dataflow/global/test.ql
+++ b/powershell/ql/test/library-tests/dataflow/global/test.ql
@@ -1,0 +1,13 @@
+/**
+ * @kind path-problem
+ */
+
+import powershell
+import semmle.code.powershell.dataflow.DataFlow
+private import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
+
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/powershell/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
@@ -54,6 +54,7 @@ edges
 | test.ps1:172:42:172:47 | input | test.ps1:136:11:136:20 | userinput | provenance |  |
 | test.ps1:173:42:173:47 | input | test.ps1:144:11:144:20 | userinput | provenance |  |
 | test.ps1:214:10:214:32 | Call to read-host | test.ps1:217:7:217:10 | $o | provenance | Src:MaD:0  |
+| test.ps1:225:14:225:36 | Call to read-host | test.ps1:229:7:229:10 | $y | provenance | Src:MaD:0  |
 nodes
 | test.ps1:3:11:3:20 | userinput | semmle.label | userinput |
 | test.ps1:4:23:4:52 | Get-Process -Name $UserInput | semmle.label | Get-Process -Name $UserInput |
@@ -112,6 +113,8 @@ nodes
 | test.ps1:173:42:173:47 | input | semmle.label | input |
 | test.ps1:214:10:214:32 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:217:7:217:10 | $o | semmle.label | $o |
+| test.ps1:225:14:225:36 | Call to read-host | semmle.label | Call to read-host |
+| test.ps1:229:7:229:10 | $y | semmle.label | $y |
 subpaths
 #select
 | test.ps1:4:23:4:52 | Get-Process -Name $UserInput | test.ps1:152:10:152:32 | Call to read-host | test.ps1:4:23:4:52 | Get-Process -Name $UserInput | This command depends on a $@. | test.ps1:152:10:152:32 | Call to read-host | user-provided value |
@@ -133,3 +136,4 @@ subpaths
 | test.ps1:139:50:139:59 | UserInput | test.ps1:152:10:152:32 | Call to read-host | test.ps1:139:50:139:59 | UserInput | This command depends on a $@. | test.ps1:152:10:152:32 | Call to read-host | user-provided value |
 | test.ps1:147:63:147:72 | UserInput | test.ps1:152:10:152:32 | Call to read-host | test.ps1:147:63:147:72 | UserInput | This command depends on a $@. | test.ps1:152:10:152:32 | Call to read-host | user-provided value |
 | test.ps1:217:7:217:10 | $o | test.ps1:214:10:214:32 | Call to read-host | test.ps1:217:7:217:10 | $o | This command depends on a $@. | test.ps1:214:10:214:32 | Call to read-host | user-provided value |
+| test.ps1:229:7:229:10 | $y | test.ps1:225:14:225:36 | Call to read-host | test.ps1:229:7:229:10 | $y | This command depends on a $@. | test.ps1:225:14:225:36 | Call to read-host | user-provided value |

--- a/powershell/ql/test/query-tests/security/cwe-078/CommandInjection/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-078/CommandInjection/test.ps1
@@ -216,3 +216,15 @@ function false-positive-in-call-operator($d)
 
     . "$o" # BAD
 }
+
+function flow-through-env-var() {
+    $x = $env:foo
+
+    . "$x" # GOOD # we don't consider environment vars flow sources
+
+    $input = Read-Host "enter input"
+    $env:bar = $input
+
+    $y = $env:bar
+    . "$y" # BAD # but we have flow through them
+}


### PR DESCRIPTION
This PR is an alternative to https://github.com/microsoft/codeql/pull/259. Instead of removing some of the environment variables as flow, we disable them all in the command injection query.

In addition, this PR implements global dataflow through environment variables so that we retain flow-through. This PR also adds a test that demonstrates this.

cc @chanel-y what do you think of this as an alternative to https://github.com/microsoft/codeql/pull/259?