### PR TITLE
PS: Remove environment variables from `powershell/microsoft/public/sql-injection`

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
+++ b/powershell/ql/lib/semmle/code/powershell/dataflow/internal/DataFlowPrivate.qll
@@ -428,7 +428,11 @@ predicate nodeIsHidden(Node n) { n.(NodeImpl).nodeIsHidden() }
  * Holds if `n` should never be skipped over in the `PathGraph` and in path
  * explanations.
  */
-predicate neverSkipInPathGraph(Node n) { isReturned(n.(AstNode).getCfgNode()) }
+predicate neverSkipInPathGraph(Node n) {
+  isReturned(n.(AstNode).getCfgNode())
+  or
+  n = any(SsaDefinitionNodeImpl def | not def.nodeIsHidden())
+}
 
 /** An SSA node. */
 class SsaNode extends NodeImpl, TSsaNode {
@@ -438,9 +442,6 @@ class SsaNode extends NodeImpl, TSsaNode {
 
   /** Gets the underlying variable. */
   Variable getVariable() { result = node.getSourceVariable() }
-
-  /** Holds if this node should be hidden from path explanations. */
-  predicate isHidden() { any() }
 
   override CfgScope getCfgScope() { result = node.getBasicBlock().getScope() }
 
@@ -454,7 +455,7 @@ class SsaDefinitionNodeImpl extends SsaNode {
 
   Ssa::Definition getDefinition() { result = node.getDefinition() }
 
-  override predicate isHidden() {
+  override predicate nodeIsHidden() {
     exists(SsaImpl::Definition def | def = this.getDefinition() |
       not def instanceof Ssa::WriteDefinition
       or

--- a/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
+++ b/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
@@ -38,8 +38,13 @@ module SqlInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of user input, considered as a flow source for command injection. */
-  class FlowSourceAsSource extends Source instanceof SourceNode {
-    override string getSourceType() { result = SourceNode.super.getSourceType() }
+  class FlowSourceAsSource extends Source {
+    FlowSourceAsSource() {
+      this instanceof SourceNode and
+      not this instanceof EnvironmentVariableSource
+    }
+
+    override string getSourceType() { result = this.(SourceNode).getSourceType() }
   }
 
   class InvokeSqlCmdSink extends Sink {

--- a/powershell/ql/test/library-tests/dataflow/fields/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/fields/test.expected
@@ -33,15 +33,19 @@ edges
 | test.ps1:32:6:32:13 | ...[...] [unknown] | test.ps1:32:6:32:16 | ...[...] | provenance |  |
 | test.ps1:33:6:33:10 | arr7 [unknown, unknown] | test.ps1:33:6:33:21 | ...[...] [unknown] | provenance |  |
 | test.ps1:33:6:33:21 | ...[...] [unknown] | test.ps1:33:6:33:32 | ...[...] | provenance |  |
-| test.ps1:35:6:35:16 | Call to source | test.ps1:37:15:37:16 | x | provenance |  |
-| test.ps1:37:9:37:16 | ...,... [element 2] | test.ps1:40:6:40:10 | arr8 [element 2] | provenance |  |
-| test.ps1:37:9:37:16 | ...,... [element 2] | test.ps1:41:6:41:10 | arr8 [element 2] | provenance |  |
+| test.ps1:35:1:35:2 | x | test.ps1:37:15:37:16 | x | provenance |  |
+| test.ps1:35:6:35:16 | Call to source | test.ps1:35:1:35:2 | x | provenance |  |
+| test.ps1:37:1:37:5 | arr8 [element 2] | test.ps1:40:6:40:10 | arr8 [element 2] | provenance |  |
+| test.ps1:37:1:37:5 | arr8 [element 2] | test.ps1:41:6:41:10 | arr8 [element 2] | provenance |  |
+| test.ps1:37:9:37:16 | ...,... [element 2] | test.ps1:37:1:37:5 | arr8 [element 2] | provenance |  |
 | test.ps1:37:15:37:16 | x | test.ps1:37:9:37:16 | ...,... [element 2] | provenance |  |
 | test.ps1:40:6:40:10 | arr8 [element 2] | test.ps1:40:6:40:13 | ...[...] | provenance |  |
 | test.ps1:41:6:41:10 | arr8 [element 2] | test.ps1:41:6:41:20 | ...[...] | provenance |  |
-| test.ps1:43:6:43:16 | Call to source | test.ps1:45:17:45:18 | y | provenance |  |
-| test.ps1:45:9:45:19 | @(...) [element 2] | test.ps1:48:6:48:10 | arr9 [element 2] | provenance |  |
-| test.ps1:45:9:45:19 | @(...) [element 2] | test.ps1:49:6:49:10 | arr9 [element 2] | provenance |  |
+| test.ps1:43:1:43:2 | y | test.ps1:45:17:45:18 | y | provenance |  |
+| test.ps1:43:6:43:16 | Call to source | test.ps1:43:1:43:2 | y | provenance |  |
+| test.ps1:45:1:45:5 | arr9 [element 2] | test.ps1:48:6:48:10 | arr9 [element 2] | provenance |  |
+| test.ps1:45:1:45:5 | arr9 [element 2] | test.ps1:49:6:49:10 | arr9 [element 2] | provenance |  |
+| test.ps1:45:9:45:19 | @(...) [element 2] | test.ps1:45:1:45:5 | arr9 [element 2] | provenance |  |
 | test.ps1:45:17:45:18 | y | test.ps1:45:9:45:19 | @(...) [element 2] | provenance |  |
 | test.ps1:48:6:48:10 | arr9 [element 2] | test.ps1:48:6:48:13 | ...[...] | provenance |  |
 | test.ps1:49:6:49:10 | arr9 [element 2] | test.ps1:49:6:49:20 | ...[...] | provenance |  |
@@ -50,20 +54,29 @@ edges
 | test.ps1:61:1:61:8 | [post] myClass [field] | test.ps1:63:1:63:8 | myClass [field] | provenance |  |
 | test.ps1:61:18:61:28 | Call to source | test.ps1:61:1:61:8 | [post] myClass [field] | provenance |  |
 | test.ps1:63:1:63:8 | myClass [field] | test.ps1:54:5:56:5 | this [field] | provenance |  |
-| test.ps1:66:10:66:20 | Call to source | test.ps1:69:5:69:6 | x | provenance |  |
-| test.ps1:67:10:67:20 | Call to source | test.ps1:70:5:70:6 | y | provenance |  |
-| test.ps1:68:10:68:20 | Call to source | test.ps1:70:9:70:10 | z | provenance |  |
+| test.ps1:66:5:66:6 | x | test.ps1:69:5:69:6 | x | provenance |  |
+| test.ps1:66:5:66:6 | x | test.ps1:69:5:69:6 | x | provenance |  |
+| test.ps1:66:10:66:20 | Call to source | test.ps1:66:5:66:6 | x | provenance |  |
+| test.ps1:66:10:66:20 | Call to source | test.ps1:66:5:66:6 | x | provenance |  |
+| test.ps1:67:5:67:6 | y | test.ps1:70:5:70:6 | y | provenance |  |
+| test.ps1:67:5:67:6 | y | test.ps1:70:5:70:6 | y | provenance |  |
+| test.ps1:67:10:67:20 | Call to source | test.ps1:67:5:67:6 | y | provenance |  |
+| test.ps1:67:10:67:20 | Call to source | test.ps1:67:5:67:6 | y | provenance |  |
+| test.ps1:68:5:68:6 | z | test.ps1:70:9:70:10 | z | provenance |  |
+| test.ps1:68:10:68:20 | Call to source | test.ps1:68:5:68:6 | z | provenance |  |
 | test.ps1:69:5:69:6 | x | test.ps1:73:6:73:12 | Call to produce [unknown index] | provenance |  |
 | test.ps1:70:5:70:6 | y | test.ps1:73:6:73:12 | Call to produce [unknown index] | provenance |  |
 | test.ps1:70:9:70:10 | z | test.ps1:73:6:73:12 | Call to produce [unknown index] | provenance |  |
-| test.ps1:73:6:73:12 | Call to produce [unknown index] | test.ps1:74:6:74:7 | x [unknown index] | provenance |  |
-| test.ps1:73:6:73:12 | Call to produce [unknown index] | test.ps1:75:6:75:7 | x [unknown index] | provenance |  |
-| test.ps1:73:6:73:12 | Call to produce [unknown index] | test.ps1:76:6:76:7 | x [unknown index] | provenance |  |
+| test.ps1:73:1:73:2 | x [unknown index] | test.ps1:74:6:74:7 | x [unknown index] | provenance |  |
+| test.ps1:73:1:73:2 | x [unknown index] | test.ps1:75:6:75:7 | x [unknown index] | provenance |  |
+| test.ps1:73:1:73:2 | x [unknown index] | test.ps1:76:6:76:7 | x [unknown index] | provenance |  |
+| test.ps1:73:6:73:12 | Call to produce [unknown index] | test.ps1:73:1:73:2 | x [unknown index] | provenance |  |
 | test.ps1:74:6:74:7 | x [unknown index] | test.ps1:74:6:74:10 | ...[...] | provenance |  |
 | test.ps1:75:6:75:7 | x [unknown index] | test.ps1:75:6:75:10 | ...[...] | provenance |  |
 | test.ps1:76:6:76:7 | x [unknown index] | test.ps1:76:6:76:10 | ...[...] | provenance |  |
-| test.ps1:78:9:81:1 | ${...} [element a] | test.ps1:83:6:83:10 | hash [element a] | provenance |  |
-| test.ps1:78:9:81:1 | ${...} [element a] | test.ps1:87:6:87:10 | hash [element a] | provenance |  |
+| test.ps1:78:1:78:5 | hash [element a] | test.ps1:83:6:83:10 | hash [element a] | provenance |  |
+| test.ps1:78:1:78:5 | hash [element a] | test.ps1:87:6:87:10 | hash [element a] | provenance |  |
+| test.ps1:78:9:81:1 | ${...} [element a] | test.ps1:78:1:78:5 | hash [element a] | provenance |  |
 | test.ps1:79:7:79:17 | Call to source | test.ps1:78:9:81:1 | ${...} [element a] | provenance |  |
 | test.ps1:83:6:83:10 | hash [element a] | test.ps1:83:6:83:15 | ...[...] | provenance |  |
 | test.ps1:87:6:87:10 | hash [element a] | test.ps1:87:6:87:15 | ...[...] | provenance |  |
@@ -112,14 +125,18 @@ nodes
 | test.ps1:33:6:33:10 | arr7 [unknown, unknown] | semmle.label | arr7 [unknown, unknown] |
 | test.ps1:33:6:33:21 | ...[...] [unknown] | semmle.label | ...[...] [unknown] |
 | test.ps1:33:6:33:32 | ...[...] | semmle.label | ...[...] |
+| test.ps1:35:1:35:2 | x | semmle.label | x |
 | test.ps1:35:6:35:16 | Call to source | semmle.label | Call to source |
+| test.ps1:37:1:37:5 | arr8 [element 2] | semmle.label | arr8 [element 2] |
 | test.ps1:37:9:37:16 | ...,... [element 2] | semmle.label | ...,... [element 2] |
 | test.ps1:37:15:37:16 | x | semmle.label | x |
 | test.ps1:40:6:40:10 | arr8 [element 2] | semmle.label | arr8 [element 2] |
 | test.ps1:40:6:40:13 | ...[...] | semmle.label | ...[...] |
 | test.ps1:41:6:41:10 | arr8 [element 2] | semmle.label | arr8 [element 2] |
 | test.ps1:41:6:41:20 | ...[...] | semmle.label | ...[...] |
+| test.ps1:43:1:43:2 | y | semmle.label | y |
 | test.ps1:43:6:43:16 | Call to source | semmle.label | Call to source |
+| test.ps1:45:1:45:5 | arr9 [element 2] | semmle.label | arr9 [element 2] |
 | test.ps1:45:9:45:19 | @(...) [element 2] | semmle.label | @(...) [element 2] |
 | test.ps1:45:17:45:18 | y | semmle.label | y |
 | test.ps1:48:6:48:10 | arr9 [element 2] | semmle.label | arr9 [element 2] |
@@ -132,12 +149,18 @@ nodes
 | test.ps1:61:1:61:8 | [post] myClass [field] | semmle.label | [post] myClass [field] |
 | test.ps1:61:18:61:28 | Call to source | semmle.label | Call to source |
 | test.ps1:63:1:63:8 | myClass [field] | semmle.label | myClass [field] |
+| test.ps1:66:5:66:6 | x | semmle.label | x |
+| test.ps1:66:5:66:6 | x | semmle.label | x |
 | test.ps1:66:10:66:20 | Call to source | semmle.label | Call to source |
+| test.ps1:67:5:67:6 | y | semmle.label | y |
+| test.ps1:67:5:67:6 | y | semmle.label | y |
 | test.ps1:67:10:67:20 | Call to source | semmle.label | Call to source |
+| test.ps1:68:5:68:6 | z | semmle.label | z |
 | test.ps1:68:10:68:20 | Call to source | semmle.label | Call to source |
 | test.ps1:69:5:69:6 | x | semmle.label | x |
 | test.ps1:70:5:70:6 | y | semmle.label | y |
 | test.ps1:70:9:70:10 | z | semmle.label | z |
+| test.ps1:73:1:73:2 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:73:6:73:12 | Call to produce [unknown index] | semmle.label | Call to produce [unknown index] |
 | test.ps1:74:6:74:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:74:6:74:10 | ...[...] | semmle.label | ...[...] |
@@ -145,6 +168,7 @@ nodes
 | test.ps1:75:6:75:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:76:6:76:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:76:6:76:10 | ...[...] | semmle.label | ...[...] |
+| test.ps1:78:1:78:5 | hash [element a] | semmle.label | hash [element a] |
 | test.ps1:78:9:81:1 | ${...} [element a] | semmle.label | ${...} [element a] |
 | test.ps1:79:7:79:17 | Call to source | semmle.label | Call to source |
 | test.ps1:83:6:83:10 | hash [element a] | semmle.label | hash [element a] |

--- a/powershell/ql/test/library-tests/dataflow/global/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/global/test.expected
@@ -1,12 +1,14 @@
 models
 edges
-| test.ps1:2:14:2:23 | Call to source | test.ps1:5:25:7:1 | <initial env var> env:x | provenance |  |
-| test.ps1:5:25:7:1 | <initial env var> env:x | test.ps1:6:5:6:15 | env:x | provenance |  |
-| test.ps1:16:18:16:27 | Call to source | test.ps1:5:25:7:1 | <initial env var> env:x | provenance |  |
+| test.ps1:2:5:2:23 | env:x | test.ps1:6:5:6:15 | env:x | provenance |  |
+| test.ps1:2:14:2:23 | Call to source | test.ps1:2:5:2:23 | env:x | provenance |  |
+| test.ps1:16:9:16:27 | env:x | test.ps1:6:5:6:15 | env:x | provenance |  |
+| test.ps1:16:18:16:27 | Call to source | test.ps1:16:9:16:27 | env:x | provenance |  |
 nodes
+| test.ps1:2:5:2:23 | env:x | semmle.label | env:x |
 | test.ps1:2:14:2:23 | Call to source | semmle.label | Call to source |
-| test.ps1:5:25:7:1 | <initial env var> env:x | semmle.label | <initial env var> env:x |
 | test.ps1:6:5:6:15 | env:x | semmle.label | env:x |
+| test.ps1:16:9:16:27 | env:x | semmle.label | env:x |
 | test.ps1:16:18:16:27 | Call to source | semmle.label | Call to source |
 subpaths
 testFailures

--- a/powershell/ql/test/library-tests/dataflow/mad/flow.expected
+++ b/powershell/ql/test/library-tests/dataflow/mad/flow.expected
@@ -5,19 +5,24 @@ edges
 | file://:0:0:0:0 | [summary param] pos(0, {}) in system.management.automation.language.codegeneration!;Method[escapesinglequotedstringcontent] | file://:0:0:0:0 | [summary] to write: ReturnValue in system.management.automation.language.codegeneration!;Method[escapesinglequotedstringcontent] | provenance |  |
 | file://:0:0:0:0 | [summary] read: Argument[pipeline].Element[?] in microsoft.powershell.utility!;Method[join-string] | file://:0:0:0:0 | [summary] to write: ReturnValue in microsoft.powershell.utility!;Method[join-string] | provenance |  |
 | file://:0:0:0:0 | [summary] read: Argument[pipeline].Element[?] in microsoft.powershell.utility!;Method[join-string] | file://:0:0:0:0 | [summary] to write: ReturnValue in microsoft.powershell.utility!;Method[join-string] | provenance |  |
-| test.ps1:1:6:1:15 | Call to source | test.ps1:2:94:2:95 | x | provenance |  |
-| test.ps1:2:6:2:96 | Call to escapesinglequotedstringcontent | test.ps1:3:6:3:7 | y | provenance |  |
+| test.ps1:1:1:1:2 | x | test.ps1:2:94:2:95 | x | provenance |  |
+| test.ps1:1:6:1:15 | Call to source | test.ps1:1:1:1:2 | x | provenance |  |
+| test.ps1:2:1:2:2 | y | test.ps1:3:6:3:7 | y | provenance |  |
+| test.ps1:2:6:2:96 | Call to escapesinglequotedstringcontent | test.ps1:2:1:2:2 | y | provenance |  |
 | test.ps1:2:94:2:95 | x | file://:0:0:0:0 | [summary param] pos(0, {}) in system.management.automation.language.codegeneration!;Method[escapesinglequotedstringcontent] | provenance |  |
 | test.ps1:2:94:2:95 | x | test.ps1:2:6:2:96 | Call to escapesinglequotedstringcontent | provenance |  |
-| test.ps1:5:6:5:15 | Call to source | test.ps1:7:6:7:7 | x | provenance |  |
-| test.ps1:6:6:6:15 | Call to source | test.ps1:7:10:7:11 | y | provenance |  |
+| test.ps1:5:1:5:2 | x | test.ps1:7:6:7:7 | x | provenance |  |
+| test.ps1:5:6:5:15 | Call to source | test.ps1:5:1:5:2 | x | provenance |  |
+| test.ps1:6:1:6:2 | y | test.ps1:7:10:7:11 | y | provenance |  |
+| test.ps1:6:6:6:15 | Call to source | test.ps1:6:1:6:2 | y | provenance |  |
+| test.ps1:7:1:7:2 | z | test.ps1:8:6:8:7 | z | provenance |  |
 | test.ps1:7:6:7:7 | x | test.ps1:7:6:7:11 | ...,... [element 0] | provenance |  |
 | test.ps1:7:6:7:11 | ...,... [element 0] | file://:0:0:0:0 | [summary param] pipeline in microsoft.powershell.utility!;Method[join-string] [element 0] | provenance |  |
 | test.ps1:7:6:7:11 | ...,... [element 0] | test.ps1:7:15:7:25 | Call to join-string | provenance |  |
 | test.ps1:7:6:7:11 | ...,... [element 1] | file://:0:0:0:0 | [summary param] pipeline in microsoft.powershell.utility!;Method[join-string] [element 1] | provenance |  |
 | test.ps1:7:6:7:11 | ...,... [element 1] | test.ps1:7:15:7:25 | Call to join-string | provenance |  |
 | test.ps1:7:10:7:11 | y | test.ps1:7:6:7:11 | ...,... [element 1] | provenance |  |
-| test.ps1:7:15:7:25 | Call to join-string | test.ps1:8:6:8:7 | z | provenance |  |
+| test.ps1:7:15:7:25 | Call to join-string | test.ps1:7:1:7:2 | z | provenance |  |
 nodes
 | file://:0:0:0:0 | [summary param] pipeline in microsoft.powershell.utility!;Method[join-string] [element 0] | semmle.label | [summary param] pipeline in microsoft.powershell.utility!;Method[join-string] [element 0] |
 | file://:0:0:0:0 | [summary param] pipeline in microsoft.powershell.utility!;Method[join-string] [element 1] | semmle.label | [summary param] pipeline in microsoft.powershell.utility!;Method[join-string] [element 1] |
@@ -27,12 +32,17 @@ nodes
 | file://:0:0:0:0 | [summary] to write: ReturnValue in microsoft.powershell.utility!;Method[join-string] | semmle.label | [summary] to write: ReturnValue in microsoft.powershell.utility!;Method[join-string] |
 | file://:0:0:0:0 | [summary] to write: ReturnValue in microsoft.powershell.utility!;Method[join-string] | semmle.label | [summary] to write: ReturnValue in microsoft.powershell.utility!;Method[join-string] |
 | file://:0:0:0:0 | [summary] to write: ReturnValue in system.management.automation.language.codegeneration!;Method[escapesinglequotedstringcontent] | semmle.label | [summary] to write: ReturnValue in system.management.automation.language.codegeneration!;Method[escapesinglequotedstringcontent] |
+| test.ps1:1:1:1:2 | x | semmle.label | x |
 | test.ps1:1:6:1:15 | Call to source | semmle.label | Call to source |
+| test.ps1:2:1:2:2 | y | semmle.label | y |
 | test.ps1:2:6:2:96 | Call to escapesinglequotedstringcontent | semmle.label | Call to escapesinglequotedstringcontent |
 | test.ps1:2:94:2:95 | x | semmle.label | x |
 | test.ps1:3:6:3:7 | y | semmle.label | y |
+| test.ps1:5:1:5:2 | x | semmle.label | x |
 | test.ps1:5:6:5:15 | Call to source | semmle.label | Call to source |
+| test.ps1:6:1:6:2 | y | semmle.label | y |
 | test.ps1:6:6:6:15 | Call to source | semmle.label | Call to source |
+| test.ps1:7:1:7:2 | z | semmle.label | z |
 | test.ps1:7:6:7:7 | x | semmle.label | x |
 | test.ps1:7:6:7:11 | ...,... [element 0] | semmle.label | ...,... [element 0] |
 | test.ps1:7:6:7:11 | ...,... [element 1] | semmle.label | ...,... [element 1] |

--- a/powershell/ql/test/library-tests/dataflow/params/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/params/test.expected
@@ -1,77 +1,81 @@
 models
 edges
 | test.ps1:1:14:1:15 | a | test.ps1:2:10:2:11 | a | provenance |  |
-| test.ps1:5:6:5:15 | Call to source | test.ps1:6:5:6:6 | x | provenance |  |
+| test.ps1:5:1:5:2 | x | test.ps1:6:5:6:6 | x | provenance |  |
+| test.ps1:5:6:5:15 | Call to source | test.ps1:5:1:5:2 | x | provenance |  |
 | test.ps1:6:5:6:6 | x | test.ps1:1:14:1:15 | a | provenance |  |
 | test.ps1:8:20:8:21 | x | test.ps1:9:10:9:11 | x | provenance |  |
 | test.ps1:8:24:8:25 | y | test.ps1:10:10:10:11 | y | provenance |  |
 | test.ps1:8:28:8:29 | z | test.ps1:11:10:11:11 | z | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:18:11:18:16 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:19:22:19:27 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:20:14:20:19 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:21:11:21:16 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:22:22:22:27 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:23:22:23:27 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:24:14:24:19 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:25:11:25:16 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:26:22:26:27 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:27:22:27:27 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:28:14:28:19 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:29:11:29:16 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:30:32:30:37 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:31:32:31:37 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:32:14:32:19 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:33:11:33:16 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:34:32:34:37 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:35:32:35:37 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:36:32:36:37 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:37:24:37:29 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:38:21:38:26 | first | provenance |  |
-| test.ps1:14:10:14:19 | Call to source | test.ps1:39:32:39:37 | first | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:18:18:18:24 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:19:11:19:17 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:20:21:20:27 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:21:21:21:27 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:22:14:22:20 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:23:11:23:17 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:24:21:24:27 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:25:21:25:27 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:26:14:26:20 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:27:11:27:17 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:28:31:28:37 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:29:21:29:27 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:30:14:30:20 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:31:11:31:17 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:32:31:32:37 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:33:31:33:37 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:34:14:34:20 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:35:24:35:30 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:36:21:36:27 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:37:31:37:37 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:38:31:38:37 | second | provenance |  |
-| test.ps1:15:11:15:20 | Call to source | test.ps1:39:24:39:30 | second | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:18:26:18:31 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:19:29:19:34 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:20:29:20:34 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:21:29:21:34 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:22:29:22:34 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:23:32:23:37 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:24:32:24:37 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:25:32:25:37 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:26:32:26:37 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:27:32:27:37 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:28:24:28:29 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:29:32:29:37 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:30:25:30:30 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:31:22:31:27 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:32:24:32:29 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:33:21:33:26 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:34:25:34:30 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:35:14:35:19 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:36:14:36:19 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:37:14:37:19 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:38:14:38:19 | third | provenance |  |
-| test.ps1:16:10:16:19 | Call to source | test.ps1:39:14:39:19 | third | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:18:11:18:16 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:19:22:19:27 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:20:14:20:19 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:21:11:21:16 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:22:22:22:27 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:23:22:23:27 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:24:14:24:19 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:25:11:25:16 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:26:22:26:27 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:27:22:27:27 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:28:14:28:19 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:29:11:29:16 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:30:32:30:37 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:31:32:31:37 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:32:14:32:19 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:33:11:33:16 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:34:32:34:37 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:35:32:35:37 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:36:32:36:37 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:37:24:37:29 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:38:21:38:26 | first | provenance |  |
+| test.ps1:14:1:14:6 | first | test.ps1:39:32:39:37 | first | provenance |  |
+| test.ps1:14:10:14:19 | Call to source | test.ps1:14:1:14:6 | first | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:18:18:18:24 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:19:11:19:17 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:20:21:20:27 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:21:21:21:27 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:22:14:22:20 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:23:11:23:17 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:24:21:24:27 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:25:21:25:27 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:26:14:26:20 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:27:11:27:17 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:28:31:28:37 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:29:21:29:27 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:30:14:30:20 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:31:11:31:17 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:32:31:32:37 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:33:31:33:37 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:34:14:34:20 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:35:24:35:30 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:36:21:36:27 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:37:31:37:37 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:38:31:38:37 | second | provenance |  |
+| test.ps1:15:1:15:7 | second | test.ps1:39:24:39:30 | second | provenance |  |
+| test.ps1:15:11:15:20 | Call to source | test.ps1:15:1:15:7 | second | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:18:26:18:31 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:19:29:19:34 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:20:29:20:34 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:21:29:21:34 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:22:29:22:34 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:23:32:23:37 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:24:32:24:37 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:25:32:25:37 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:26:32:26:37 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:27:32:27:37 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:28:24:28:29 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:29:32:29:37 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:30:25:30:30 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:31:22:31:27 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:32:24:32:29 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:33:21:33:26 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:34:25:34:30 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:35:14:35:19 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:36:14:36:19 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:37:14:37:19 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:38:14:38:19 | third | provenance |  |
+| test.ps1:16:1:16:6 | third | test.ps1:39:14:39:19 | third | provenance |  |
+| test.ps1:16:10:16:19 | Call to source | test.ps1:16:1:16:6 | third | provenance |  |
 | test.ps1:18:11:18:16 | first | test.ps1:8:20:8:21 | x | provenance |  |
 | test.ps1:18:18:18:24 | second | test.ps1:8:24:8:25 | y | provenance |  |
 | test.ps1:18:26:18:31 | third | test.ps1:8:28:8:29 | z | provenance |  |
@@ -139,11 +143,13 @@ edges
 | test.ps1:39:24:39:30 | second | test.ps1:8:24:8:25 | y | provenance |  |
 | test.ps1:39:32:39:37 | first | test.ps1:8:20:8:21 | x | provenance |  |
 | test.ps1:43:11:43:20 | userinput | test.ps1:44:10:44:19 | UserInput | provenance |  |
-| test.ps1:47:10:47:19 | Call to source | test.ps1:48:46:48:51 | input | provenance |  |
+| test.ps1:47:1:47:6 | input | test.ps1:48:46:48:51 | input | provenance |  |
+| test.ps1:47:10:47:19 | Call to source | test.ps1:47:1:47:6 | input | provenance |  |
 | test.ps1:48:46:48:51 | input | test.ps1:43:11:43:20 | userinput | provenance |  |
 nodes
 | test.ps1:1:14:1:15 | a | semmle.label | a |
 | test.ps1:2:10:2:11 | a | semmle.label | a |
+| test.ps1:5:1:5:2 | x | semmle.label | x |
 | test.ps1:5:6:5:15 | Call to source | semmle.label | Call to source |
 | test.ps1:6:5:6:6 | x | semmle.label | x |
 | test.ps1:8:20:8:21 | x | semmle.label | x |
@@ -152,8 +158,11 @@ nodes
 | test.ps1:9:10:9:11 | x | semmle.label | x |
 | test.ps1:10:10:10:11 | y | semmle.label | y |
 | test.ps1:11:10:11:11 | z | semmle.label | z |
+| test.ps1:14:1:14:6 | first | semmle.label | first |
 | test.ps1:14:10:14:19 | Call to source | semmle.label | Call to source |
+| test.ps1:15:1:15:7 | second | semmle.label | second |
 | test.ps1:15:11:15:20 | Call to source | semmle.label | Call to source |
+| test.ps1:16:1:16:6 | third | semmle.label | third |
 | test.ps1:16:10:16:19 | Call to source | semmle.label | Call to source |
 | test.ps1:18:11:18:16 | first | semmle.label | first |
 | test.ps1:18:18:18:24 | second | semmle.label | second |
@@ -223,6 +232,7 @@ nodes
 | test.ps1:39:32:39:37 | first | semmle.label | first |
 | test.ps1:43:11:43:20 | userinput | semmle.label | userinput |
 | test.ps1:44:10:44:19 | UserInput | semmle.label | UserInput |
+| test.ps1:47:1:47:6 | input | semmle.label | input |
 | test.ps1:47:10:47:19 | Call to source | semmle.label | Call to source |
 | test.ps1:48:46:48:51 | input | semmle.label | input |
 subpaths

--- a/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/pipeline/test.expected
@@ -1,8 +1,11 @@
 models
 edges
-| test.ps1:2:10:2:19 | Call to source | test.ps1:5:5:5:6 | x | provenance |  |
-| test.ps1:3:10:3:19 | Call to source | test.ps1:6:5:6:6 | y | provenance |  |
-| test.ps1:4:10:4:19 | Call to source | test.ps1:6:9:6:10 | z | provenance |  |
+| test.ps1:2:5:2:6 | x | test.ps1:5:5:5:6 | x | provenance |  |
+| test.ps1:2:10:2:19 | Call to source | test.ps1:2:5:2:6 | x | provenance |  |
+| test.ps1:3:5:3:6 | y | test.ps1:6:5:6:6 | y | provenance |  |
+| test.ps1:3:10:3:19 | Call to source | test.ps1:3:5:3:6 | y | provenance |  |
+| test.ps1:4:5:4:6 | z | test.ps1:6:9:6:10 | z | provenance |  |
+| test.ps1:4:10:4:19 | Call to source | test.ps1:4:5:4:6 | z | provenance |  |
 | test.ps1:5:5:5:6 | x | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
 | test.ps1:6:5:6:6 | y | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
 | test.ps1:6:9:6:10 | z | test.ps1:17:1:17:7 | Call to produce [unknown index] | provenance |  |
@@ -13,8 +16,10 @@ edges
 | test.ps1:12:5:14:5 | x [element 1] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
 | test.ps1:12:5:14:5 | x [unknown index] | test.ps1:13:9:13:15 | __pipeline_iterator | provenance |  |
 | test.ps1:17:1:17:7 | Call to produce [unknown index] | test.ps1:10:11:10:43 | x [unknown index] | provenance |  |
-| test.ps1:19:6:19:15 | Call to source | test.ps1:21:1:21:2 | x | provenance |  |
-| test.ps1:20:6:20:15 | Call to source | test.ps1:21:5:21:6 | y | provenance |  |
+| test.ps1:19:1:19:2 | x | test.ps1:21:1:21:2 | x | provenance |  |
+| test.ps1:19:6:19:15 | Call to source | test.ps1:19:1:19:2 | x | provenance |  |
+| test.ps1:20:1:20:2 | y | test.ps1:21:5:21:6 | y | provenance |  |
+| test.ps1:20:6:20:15 | Call to source | test.ps1:20:1:20:2 | y | provenance |  |
 | test.ps1:21:1:21:2 | x | test.ps1:21:1:21:6 | ...,... [element 0] | provenance |  |
 | test.ps1:21:1:21:6 | ...,... [element 0] | test.ps1:10:11:10:43 | x [element 0] | provenance |  |
 | test.ps1:21:1:21:6 | ...,... [element 1] | test.ps1:10:11:10:43 | x [element 1] | provenance |  |
@@ -23,8 +28,10 @@ edges
 | test.ps1:23:38:27:1 | [synth] pipeline [element 1] | test.ps1:24:5:26:5 | [synth] pipeline [element 1] | provenance |  |
 | test.ps1:24:5:26:5 | [synth] pipeline [element 0] | test.ps1:25:9:25:15 | __pipeline_iterator | provenance |  |
 | test.ps1:24:5:26:5 | [synth] pipeline [element 1] | test.ps1:25:9:25:15 | __pipeline_iterator | provenance |  |
-| test.ps1:29:6:29:15 | Call to source | test.ps1:31:1:31:2 | x | provenance |  |
-| test.ps1:30:6:30:15 | Call to source | test.ps1:31:5:31:6 | y | provenance |  |
+| test.ps1:29:1:29:2 | x | test.ps1:31:1:31:2 | x | provenance |  |
+| test.ps1:29:6:29:15 | Call to source | test.ps1:29:1:29:2 | x | provenance |  |
+| test.ps1:30:1:30:2 | y | test.ps1:31:5:31:6 | y | provenance |  |
+| test.ps1:30:6:30:15 | Call to source | test.ps1:30:1:30:2 | y | provenance |  |
 | test.ps1:31:1:31:2 | x | test.ps1:31:1:31:6 | ...,... [element 0] | provenance |  |
 | test.ps1:31:1:31:6 | ...,... [element 0] | test.ps1:23:38:27:1 | [synth] pipeline [element 0] | provenance |  |
 | test.ps1:31:1:31:6 | ...,... [element 1] | test.ps1:23:38:27:1 | [synth] pipeline [element 1] | provenance |  |
@@ -48,8 +55,11 @@ edges
 | test.ps1:50:88:50:105 | ${...} [element x] | test.ps1:50:72:50:105 | [...]... [element x] | provenance |  |
 | test.ps1:50:94:50:104 | Call to source | test.ps1:50:88:50:105 | ${...} [element x] | provenance |  |
 nodes
+| test.ps1:2:5:2:6 | x | semmle.label | x |
 | test.ps1:2:10:2:19 | Call to source | semmle.label | Call to source |
+| test.ps1:3:5:3:6 | y | semmle.label | y |
 | test.ps1:3:10:3:19 | Call to source | semmle.label | Call to source |
+| test.ps1:4:5:4:6 | z | semmle.label | z |
 | test.ps1:4:10:4:19 | Call to source | semmle.label | Call to source |
 | test.ps1:5:5:5:6 | x | semmle.label | x |
 | test.ps1:6:5:6:6 | y | semmle.label | y |
@@ -62,7 +72,9 @@ nodes
 | test.ps1:12:5:14:5 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:13:9:13:15 | __pipeline_iterator | semmle.label | __pipeline_iterator |
 | test.ps1:17:1:17:7 | Call to produce [unknown index] | semmle.label | Call to produce [unknown index] |
+| test.ps1:19:1:19:2 | x | semmle.label | x |
 | test.ps1:19:6:19:15 | Call to source | semmle.label | Call to source |
+| test.ps1:20:1:20:2 | y | semmle.label | y |
 | test.ps1:20:6:20:15 | Call to source | semmle.label | Call to source |
 | test.ps1:21:1:21:2 | x | semmle.label | x |
 | test.ps1:21:1:21:6 | ...,... [element 0] | semmle.label | ...,... [element 0] |
@@ -73,7 +85,9 @@ nodes
 | test.ps1:24:5:26:5 | [synth] pipeline [element 0] | semmle.label | [synth] pipeline [element 0] |
 | test.ps1:24:5:26:5 | [synth] pipeline [element 1] | semmle.label | [synth] pipeline [element 1] |
 | test.ps1:25:9:25:15 | __pipeline_iterator | semmle.label | __pipeline_iterator |
+| test.ps1:29:1:29:2 | x | semmle.label | x |
 | test.ps1:29:6:29:15 | Call to source | semmle.label | Call to source |
+| test.ps1:30:1:30:2 | y | semmle.label | y |
 | test.ps1:30:6:30:15 | Call to source | semmle.label | Call to source |
 | test.ps1:31:1:31:2 | x | semmle.label | x |
 | test.ps1:31:1:31:6 | ...,... [element 0] | semmle.label | ...,... [element 0] |

--- a/powershell/ql/test/library-tests/dataflow/returns/test.expected
+++ b/powershell/ql/test/library-tests/dataflow/returns/test.expected
@@ -1,52 +1,69 @@
 models
 edges
 | test.ps1:2:5:2:14 | Call to source | test.ps1:5:6:5:19 | Call to callsourceonce | provenance |  |
-| test.ps1:5:6:5:19 | Call to callsourceonce | test.ps1:6:6:6:7 | x | provenance |  |
+| test.ps1:5:1:5:2 | x | test.ps1:6:6:6:7 | x | provenance |  |
+| test.ps1:5:6:5:19 | Call to callsourceonce | test.ps1:5:1:5:2 | x | provenance |  |
 | test.ps1:9:5:9:14 | Call to source | test.ps1:13:6:13:20 | Call to callsourcetwice [unknown index] | provenance |  |
 | test.ps1:10:5:10:14 | Call to source | test.ps1:13:6:13:20 | Call to callsourcetwice [unknown index] | provenance |  |
-| test.ps1:13:6:13:20 | Call to callsourcetwice [unknown index] | test.ps1:15:6:15:7 | x [unknown index] | provenance |  |
-| test.ps1:13:6:13:20 | Call to callsourcetwice [unknown index] | test.ps1:16:6:16:7 | x [unknown index] | provenance |  |
+| test.ps1:13:1:13:2 | x [unknown index] | test.ps1:15:6:15:7 | x [unknown index] | provenance |  |
+| test.ps1:13:1:13:2 | x [unknown index] | test.ps1:16:6:16:7 | x [unknown index] | provenance |  |
+| test.ps1:13:6:13:20 | Call to callsourcetwice [unknown index] | test.ps1:13:1:13:2 | x [unknown index] | provenance |  |
 | test.ps1:15:6:15:7 | x [unknown index] | test.ps1:15:6:15:10 | ...[...] | provenance |  |
 | test.ps1:16:6:16:7 | x [unknown index] | test.ps1:16:6:16:10 | ...[...] | provenance |  |
 | test.ps1:19:12:19:21 | Call to source | test.ps1:22:6:22:18 | Call to returnsource1 | provenance |  |
-| test.ps1:22:6:22:18 | Call to returnsource1 | test.ps1:23:6:23:7 | x | provenance |  |
-| test.ps1:26:10:26:19 | Call to source | test.ps1:27:5:27:6 | x | provenance |  |
+| test.ps1:22:1:22:2 | x | test.ps1:23:6:23:7 | x | provenance |  |
+| test.ps1:22:6:22:18 | Call to returnsource1 | test.ps1:22:1:22:2 | x | provenance |  |
+| test.ps1:26:5:26:6 | x | test.ps1:27:5:27:6 | x | provenance |  |
+| test.ps1:26:5:26:6 | x | test.ps1:27:5:27:6 | x | provenance |  |
+| test.ps1:26:10:26:19 | Call to source | test.ps1:26:5:26:6 | x | provenance |  |
+| test.ps1:26:10:26:19 | Call to source | test.ps1:26:5:26:6 | x | provenance |  |
 | test.ps1:27:5:27:6 | x | test.ps1:32:6:32:18 | Call to returnsource2 [unknown index] | provenance |  |
-| test.ps1:28:10:28:19 | Call to source | test.ps1:29:12:29:13 | y | provenance |  |
+| test.ps1:28:5:28:6 | y | test.ps1:29:12:29:13 | y | provenance |  |
+| test.ps1:28:10:28:19 | Call to source | test.ps1:28:5:28:6 | y | provenance |  |
 | test.ps1:29:12:29:13 | y | test.ps1:32:6:32:18 | Call to returnsource2 [unknown index] | provenance |  |
-| test.ps1:32:6:32:18 | Call to returnsource2 [unknown index] | test.ps1:33:6:33:7 | x [unknown index] | provenance |  |
-| test.ps1:32:6:32:18 | Call to returnsource2 [unknown index] | test.ps1:34:6:34:7 | x [unknown index] | provenance |  |
+| test.ps1:32:1:32:2 | x [unknown index] | test.ps1:33:6:33:7 | x [unknown index] | provenance |  |
+| test.ps1:32:1:32:2 | x [unknown index] | test.ps1:34:6:34:7 | x [unknown index] | provenance |  |
+| test.ps1:32:6:32:18 | Call to returnsource2 [unknown index] | test.ps1:32:1:32:2 | x [unknown index] | provenance |  |
 | test.ps1:33:6:33:7 | x [unknown index] | test.ps1:33:6:33:10 | ...[...] | provenance |  |
 | test.ps1:34:6:34:7 | x [unknown index] | test.ps1:34:6:34:10 | ...[...] | provenance |  |
 | test.ps1:38:9:38:18 | Call to source | test.ps1:42:6:42:21 | Call to callsourceinloop [unknown index] | provenance |  |
-| test.ps1:42:6:42:21 | Call to callsourceinloop [unknown index] | test.ps1:43:6:43:7 | x [unknown index] | provenance |  |
-| test.ps1:42:6:42:21 | Call to callsourceinloop [unknown index] | test.ps1:44:6:44:7 | x [unknown index] | provenance |  |
+| test.ps1:42:1:42:2 | x [unknown index] | test.ps1:43:6:43:7 | x [unknown index] | provenance |  |
+| test.ps1:42:1:42:2 | x [unknown index] | test.ps1:44:6:44:7 | x [unknown index] | provenance |  |
+| test.ps1:42:6:42:21 | Call to callsourceinloop [unknown index] | test.ps1:42:1:42:2 | x [unknown index] | provenance |  |
 | test.ps1:43:6:43:7 | x [unknown index] | test.ps1:43:6:43:10 | ...[...] | provenance |  |
 | test.ps1:44:6:44:7 | x [unknown index] | test.ps1:44:6:44:10 | ...[...] | provenance |  |
 nodes
 | test.ps1:2:5:2:14 | Call to source | semmle.label | Call to source |
+| test.ps1:5:1:5:2 | x | semmle.label | x |
 | test.ps1:5:6:5:19 | Call to callsourceonce | semmle.label | Call to callsourceonce |
 | test.ps1:6:6:6:7 | x | semmle.label | x |
 | test.ps1:9:5:9:14 | Call to source | semmle.label | Call to source |
 | test.ps1:10:5:10:14 | Call to source | semmle.label | Call to source |
+| test.ps1:13:1:13:2 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:13:6:13:20 | Call to callsourcetwice [unknown index] | semmle.label | Call to callsourcetwice [unknown index] |
 | test.ps1:15:6:15:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:15:6:15:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:16:6:16:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:16:6:16:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:19:12:19:21 | Call to source | semmle.label | Call to source |
+| test.ps1:22:1:22:2 | x | semmle.label | x |
 | test.ps1:22:6:22:18 | Call to returnsource1 | semmle.label | Call to returnsource1 |
 | test.ps1:23:6:23:7 | x | semmle.label | x |
+| test.ps1:26:5:26:6 | x | semmle.label | x |
+| test.ps1:26:5:26:6 | x | semmle.label | x |
 | test.ps1:26:10:26:19 | Call to source | semmle.label | Call to source |
 | test.ps1:27:5:27:6 | x | semmle.label | x |
+| test.ps1:28:5:28:6 | y | semmle.label | y |
 | test.ps1:28:10:28:19 | Call to source | semmle.label | Call to source |
 | test.ps1:29:12:29:13 | y | semmle.label | y |
+| test.ps1:32:1:32:2 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:32:6:32:18 | Call to returnsource2 [unknown index] | semmle.label | Call to returnsource2 [unknown index] |
 | test.ps1:33:6:33:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:33:6:33:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:34:6:34:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:34:6:34:10 | ...[...] | semmle.label | ...[...] |
 | test.ps1:38:9:38:18 | Call to source | semmle.label | Call to source |
+| test.ps1:42:1:42:2 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:42:6:42:21 | Call to callsourceinloop [unknown index] | semmle.label | Call to callsourceinloop [unknown index] |
 | test.ps1:43:6:43:7 | x [unknown index] | semmle.label | x [unknown index] |
 | test.ps1:43:6:43:10 | ...[...] | semmle.label | ...[...] |

--- a/powershell/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
@@ -6,7 +6,8 @@ edges
 | test.ps1:27:11:27:20 | userinput | test.ps1:28:38:28:67 | Get-Process -Name $UserInput | provenance |  |
 | test.ps1:33:11:33:20 | userinput | test.ps1:34:14:34:46 | public class Foo { $UserInput } | provenance |  |
 | test.ps1:39:11:39:20 | userinput | test.ps1:40:30:40:62 | public class Foo { $UserInput } | provenance |  |
-| test.ps1:45:11:45:20 | userinput | test.ps1:48:30:48:34 | code | provenance |  |
+| test.ps1:45:11:45:20 | userinput | test.ps1:47:5:47:9 | code | provenance |  |
+| test.ps1:47:5:47:9 | code | test.ps1:48:30:48:34 | code | provenance |  |
 | test.ps1:73:11:73:20 | userinput | test.ps1:75:25:75:54 | Get-Process -Name $UserInput | provenance |  |
 | test.ps1:80:11:80:20 | userinput | test.ps1:82:16:82:45 | Get-Process -Name $UserInput | provenance |  |
 | test.ps1:87:11:87:20 | userinput | test.ps1:89:12:89:28 | ping $UserInput | provenance |  |
@@ -17,24 +18,25 @@ edges
 | test.ps1:129:11:129:20 | userinput | test.ps1:131:28:131:37 | UserInput | provenance |  |
 | test.ps1:136:11:136:20 | userinput | test.ps1:139:50:139:59 | UserInput | provenance |  |
 | test.ps1:144:11:144:20 | userinput | test.ps1:147:63:147:72 | UserInput | provenance |  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:154:46:154:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:155:46:155:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:156:46:156:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:157:46:157:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:158:46:158:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:159:46:159:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:160:46:160:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:161:46:161:51 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:163:48:163:53 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:164:48:164:53 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:165:48:165:53 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:166:41:166:46 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:167:41:167:46 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:168:36:168:41 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:169:36:169:41 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:170:36:170:41 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:172:42:172:47 | input | provenance | Src:MaD:0  |
-| test.ps1:152:10:152:32 | Call to read-host | test.ps1:173:42:173:47 | input | provenance | Src:MaD:0  |
+| test.ps1:152:1:152:6 | input | test.ps1:154:46:154:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:155:46:155:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:156:46:156:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:157:46:157:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:158:46:158:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:159:46:159:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:160:46:160:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:161:46:161:51 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:163:48:163:53 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:164:48:164:53 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:165:48:165:53 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:166:41:166:46 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:167:41:167:46 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:168:36:168:41 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:169:36:169:41 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:170:36:170:41 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:172:42:172:47 | input | provenance |  |
+| test.ps1:152:1:152:6 | input | test.ps1:173:42:173:47 | input | provenance |  |
+| test.ps1:152:10:152:32 | Call to read-host | test.ps1:152:1:152:6 | input | provenance | Src:MaD:0  |
 | test.ps1:154:46:154:51 | input | test.ps1:3:11:3:20 | userinput | provenance |  |
 | test.ps1:155:46:155:51 | input | test.ps1:9:11:9:20 | userinput | provenance |  |
 | test.ps1:156:46:156:51 | input | test.ps1:15:11:15:20 | userinput | provenance |  |
@@ -53,8 +55,14 @@ edges
 | test.ps1:170:36:170:41 | input | test.ps1:129:11:129:20 | userinput | provenance |  |
 | test.ps1:172:42:172:47 | input | test.ps1:136:11:136:20 | userinput | provenance |  |
 | test.ps1:173:42:173:47 | input | test.ps1:144:11:144:20 | userinput | provenance |  |
-| test.ps1:214:10:214:32 | Call to read-host | test.ps1:217:7:217:10 | $o | provenance | Src:MaD:0  |
-| test.ps1:225:14:225:36 | Call to read-host | test.ps1:229:7:229:10 | $y | provenance | Src:MaD:0  |
+| test.ps1:214:5:214:6 | o | test.ps1:217:7:217:10 | $o | provenance |  |
+| test.ps1:214:10:214:32 | Call to read-host | test.ps1:214:5:214:6 | o | provenance | Src:MaD:0  |
+| test.ps1:225:5:225:10 | input | test.ps1:226:5:226:21 | env:bar | provenance |  |
+| test.ps1:225:5:225:10 | input | test.ps1:226:5:226:21 | env:bar | provenance |  |
+| test.ps1:225:14:225:36 | Call to read-host | test.ps1:225:5:225:10 | input | provenance | Src:MaD:0  |
+| test.ps1:225:14:225:36 | Call to read-host | test.ps1:225:5:225:10 | input | provenance | Src:MaD:0  |
+| test.ps1:226:5:226:21 | env:bar | test.ps1:228:5:228:6 | y | provenance |  |
+| test.ps1:228:5:228:6 | y | test.ps1:229:7:229:10 | $y | provenance |  |
 nodes
 | test.ps1:3:11:3:20 | userinput | semmle.label | userinput |
 | test.ps1:4:23:4:52 | Get-Process -Name $UserInput | semmle.label | Get-Process -Name $UserInput |
@@ -71,6 +79,7 @@ nodes
 | test.ps1:39:11:39:20 | userinput | semmle.label | userinput |
 | test.ps1:40:30:40:62 | public class Foo { $UserInput } | semmle.label | public class Foo { $UserInput } |
 | test.ps1:45:11:45:20 | userinput | semmle.label | userinput |
+| test.ps1:47:5:47:9 | code | semmle.label | code |
 | test.ps1:48:30:48:34 | code | semmle.label | code |
 | test.ps1:73:11:73:20 | userinput | semmle.label | userinput |
 | test.ps1:75:25:75:54 | Get-Process -Name $UserInput | semmle.label | Get-Process -Name $UserInput |
@@ -92,6 +101,7 @@ nodes
 | test.ps1:139:50:139:59 | UserInput | semmle.label | UserInput |
 | test.ps1:144:11:144:20 | userinput | semmle.label | userinput |
 | test.ps1:147:63:147:72 | UserInput | semmle.label | UserInput |
+| test.ps1:152:1:152:6 | input | semmle.label | input |
 | test.ps1:152:10:152:32 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:154:46:154:51 | input | semmle.label | input |
 | test.ps1:155:46:155:51 | input | semmle.label | input |
@@ -111,9 +121,14 @@ nodes
 | test.ps1:170:36:170:41 | input | semmle.label | input |
 | test.ps1:172:42:172:47 | input | semmle.label | input |
 | test.ps1:173:42:173:47 | input | semmle.label | input |
+| test.ps1:214:5:214:6 | o | semmle.label | o |
 | test.ps1:214:10:214:32 | Call to read-host | semmle.label | Call to read-host |
 | test.ps1:217:7:217:10 | $o | semmle.label | $o |
+| test.ps1:225:5:225:10 | input | semmle.label | input |
+| test.ps1:225:5:225:10 | input | semmle.label | input |
 | test.ps1:225:14:225:36 | Call to read-host | semmle.label | Call to read-host |
+| test.ps1:226:5:226:21 | env:bar | semmle.label | env:bar |
+| test.ps1:228:5:228:6 | y | semmle.label | y |
 | test.ps1:229:7:229:10 | $y | semmle.label | $y |
 subpaths
 #select

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -1,17 +1,25 @@
 edges
-| test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | provenance | Src:MaD:0  |
-| test.ps1:1:14:1:45 | Call to read-host | test.ps1:9:72:9:77 | query | provenance | Src:MaD:0  |
-| test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
-| test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance | Src:MaD:0  |
-| test.ps1:1:14:1:45 | Call to read-host | test.ps1:78:13:78:22 | userinput | provenance | Src:MaD:0  |
-| test.ps1:72:15:79:1 | ${...} [element Query] | test.ps1:81:15:81:25 | QueryConn2 | provenance |  |
+| test.ps1:1:1:1:10 | userinput | test.ps1:4:1:4:6 | query | provenance |  |
+| test.ps1:1:1:1:10 | userinput | test.ps1:8:1:8:6 | query | provenance |  |
+| test.ps1:1:1:1:10 | userinput | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
+| test.ps1:1:1:1:10 | userinput | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
+| test.ps1:1:1:1:10 | userinput | test.ps1:78:13:78:22 | userinput | provenance |  |
+| test.ps1:1:14:1:45 | Call to read-host | test.ps1:1:1:1:10 | userinput | provenance | Src:MaD:0  |
+| test.ps1:4:1:4:6 | query | test.ps1:5:72:5:77 | query | provenance |  |
+| test.ps1:8:1:8:6 | query | test.ps1:9:72:9:77 | query | provenance |  |
+| test.ps1:72:1:72:11 | QueryConn2 [element Query] | test.ps1:81:15:81:25 | QueryConn2 | provenance |  |
+| test.ps1:72:15:79:1 | ${...} [element Query] | test.ps1:72:1:72:11 | QueryConn2 [element Query] | provenance |  |
 | test.ps1:78:13:78:22 | userinput | test.ps1:72:15:79:1 | ${...} [element Query] | provenance |  |
 nodes
+| test.ps1:1:1:1:10 | userinput | semmle.label | userinput |
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
+| test.ps1:4:1:4:6 | query | semmle.label | query |
 | test.ps1:5:72:5:77 | query | semmle.label | query |
+| test.ps1:8:1:8:6 | query | semmle.label | query |
 | test.ps1:9:72:9:77 | query | semmle.label | query |
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$userinput' |
+| test.ps1:72:1:72:11 | QueryConn2 [element Query] | semmle.label | QueryConn2 [element Query] |
 | test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
 | test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
 | test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |

--- a/powershell/ql/test/query-tests/security/cwe-502/UnsafeDeserialization.expected
+++ b/powershell/ql/test/query-tests/security/cwe-502/UnsafeDeserialization.expected
@@ -1,10 +1,14 @@
 edges
-| test.ps1:1:20:1:47 | Call to read-host | test.ps1:3:69:3:84 | untrustedBase64 | provenance | Src:MaD:0  |
-| test.ps1:3:11:3:86 | Call to new | test.ps1:4:31:4:37 | stream | provenance |  |
+| test.ps1:1:1:1:16 | untrustedBase64 | test.ps1:3:69:3:84 | untrustedBase64 | provenance |  |
+| test.ps1:1:20:1:47 | Call to read-host | test.ps1:1:1:1:16 | untrustedBase64 | provenance | Src:MaD:0  |
+| test.ps1:3:1:3:7 | stream | test.ps1:4:31:4:37 | stream | provenance |  |
+| test.ps1:3:11:3:86 | Call to new | test.ps1:3:1:3:7 | stream | provenance |  |
 | test.ps1:3:41:3:85 | Call to frombase64string | test.ps1:3:11:3:86 | Call to new | provenance | Config |
 | test.ps1:3:69:3:84 | untrustedBase64 | test.ps1:3:41:3:85 | Call to frombase64string | provenance | Config |
 nodes
+| test.ps1:1:1:1:16 | untrustedBase64 | semmle.label | untrustedBase64 |
 | test.ps1:1:20:1:47 | Call to read-host | semmle.label | Call to read-host |
+| test.ps1:3:1:3:7 | stream | semmle.label | stream |
 | test.ps1:3:11:3:86 | Call to new | semmle.label | Call to new |
 | test.ps1:3:41:3:85 | Call to frombase64string | semmle.label | Call to frombase64string |
 | test.ps1:3:69:3:84 | untrustedBase64 | semmle.label | untrustedBase64 |


### PR DESCRIPTION
... and also make the paths outputted in dataflow queries more readable.

This PR does two things (each in their own commit):
1. It removes environment variables as sources in the PowerShell SQL injection query. This matches the change we did in https://github.com/microsoft/codeql/pull/261/commits/b72af27e81e25fecaa79886e0444f40335326d9c for the command-line injection query.
2. It fixes a bug related to how we hide/unhide certain nodes in dataflow paths. The dataflow library has two "hooks" that decides which nodes to never show in a path (the `nodeIsHidden` predicate) and which nodes to always show in a path (the `neverSkipInPathGraph`). We had a bug in `nodeIsHidden` which always hid uses of local variables. This meant that paths were way too compressed to be readable. Furthermore, I chose to [follow C#](https://github.com/github/codeql/blob/97cf15affcd72931b35be5bc9de5af6d31516f9e/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplSpecific.qll#L30) and always show definitions in the path.

The combination of these two fixes in (2) mean that paths are much more readable 🎉 