### PR TITLE
PS: Also handle `-q` and `-i` arguments in sql injection query

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
+++ b/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
@@ -48,15 +48,19 @@ module SqlInjection {
     override string getSourceType() { result = this.(SourceNode).getSourceType() }
   }
 
+  private string query() { result = ["query", "q"] }
+
+  private string inputfile() { result = ["inputfile", "i"] }
+
   class InvokeSqlCmdSink extends Sink {
     InvokeSqlCmdSink() {
       exists(DataFlow::CallNode call | call.matchesName("Invoke-Sqlcmd") |
-        this = call.getNamedArgument("query")
+        this = call.getNamedArgument(query())
         or
-        this = call.getNamedArgument("inputfile")
+        this = call.getNamedArgument(inputfile())
         or
-        not call.hasNamedArgument("query") and
-        not call.hasNamedArgument("inputfile") and
+        not call.hasNamedArgument(query()) and
+        not call.hasNamedArgument(inputfile()) and
         this = call.getArgument(0)
         or
         // TODO: Here we really should pick a splat argument, but we don't yet extract whether an

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -4,7 +4,6 @@ edges
 | test.ps1:1:1:1:10 | userinput | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:78:13:78:22 | userinput | provenance |  |
-| test.ps1:1:1:1:10 | userinput | test.ps1:112:24:112:33 | userinput | provenance |  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:1:1:1:10 | userinput | provenance | Src:MaD:0  |
 | test.ps1:4:1:4:6 | query | test.ps1:5:72:5:77 | query | provenance |  |
 | test.ps1:8:1:8:6 | query | test.ps1:9:72:9:77 | query | provenance |  |
@@ -24,7 +23,6 @@ nodes
 | test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
 | test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
 | test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |
-| test.ps1:112:24:112:33 | userinput | semmle.label | userinput |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -32,4 +30,3 @@ subpaths
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
-| test.ps1:112:24:112:33 | userinput | test.ps1:1:14:1:45 | Call to read-host | test.ps1:112:24:112:33 | userinput | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -4,6 +4,7 @@ edges
 | test.ps1:1:1:1:10 | userinput | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:78:13:78:22 | userinput | provenance |  |
+| test.ps1:1:1:1:10 | userinput | test.ps1:112:24:112:33 | userinput | provenance |  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:1:1:1:10 | userinput | provenance | Src:MaD:0  |
 | test.ps1:4:1:4:6 | query | test.ps1:5:72:5:77 | query | provenance |  |
 | test.ps1:8:1:8:6 | query | test.ps1:9:72:9:77 | query | provenance |  |
@@ -23,6 +24,7 @@ nodes
 | test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
 | test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
 | test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |
+| test.ps1:112:24:112:33 | userinput | semmle.label | userinput |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -30,3 +32,4 @@ subpaths
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
+| test.ps1:112:24:112:33 | userinput | test.ps1:1:14:1:45 | Call to read-host | test.ps1:112:24:112:33 | userinput | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -109,4 +109,4 @@ function TakesTypedParameters([int]$i, [long]$l, [float]$f, [double]$d, [decimal
 TakesTypedParameters $userinput $userinput $userinput $userinput $userinput $userinput $userinput $userinput
 
 $query = "SELECT * FROM MyTable WHERE MyColumn = '$userinput'"
-Invoke-Sqlcmd -unknown $userinput -ServerInstance "MyServer" -Database "MyDatabase" -q "SELECT * FROM MyTable" # GOOD [FALSE POSITIVE]
+Invoke-Sqlcmd -unknown $userinput -ServerInstance "MyServer" -Database "MyDatabase" -q "SELECT * FROM MyTable" # GOOD

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -107,3 +107,6 @@ function TakesTypedParameters([int]$i, [long]$l, [float]$f, [double]$d, [decimal
 }
 
 TakesTypedParameters $userinput $userinput $userinput $userinput $userinput $userinput $userinput $userinput
+
+$query = "SELECT * FROM MyTable WHERE MyColumn = '$userinput'"
+Invoke-Sqlcmd -unknown $userinput -ServerInstance "MyServer" -Database "MyDatabase" -q "SELECT * FROM MyTable" # GOOD [FALSE POSITIVE]


### PR DESCRIPTION
The query was only considering the `-query` and `-inputfile` arguments, but not the aliases `-q` and `-i`. This resulted in both FPs and FNs.

This PR fixes these and also adds an example of the FP that's now fixed.