### PR TITLE
PS: Do not alert on `inputfile` in the SQL injection query

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
+++ b/powershell/ql/lib/semmle/code/powershell/security/SqlInjectionCustomizations.qll
@@ -57,8 +57,8 @@ module SqlInjection {
       exists(DataFlow::CallNode call | call.matchesName("Invoke-Sqlcmd") |
         this = call.getNamedArgument(query())
         or
-        this = call.getNamedArgument(inputfile())
-        or
+        // If the input is not provided as a query parameter or an input file
+        // parameter then it's the first argument.
         not call.hasNamedArgument(query()) and
         not call.hasNamedArgument(inputfile()) and
         this = call.getArgument(0)

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -4,7 +4,6 @@ edges
 | test.ps1:1:1:1:10 | userinput | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:78:13:78:22 | userinput | provenance |  |
-| test.ps1:1:1:1:10 | userinput | test.ps1:114:76:114:85 | userinput | provenance |  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:1:1:1:10 | userinput | provenance | Src:MaD:0  |
 | test.ps1:4:1:4:6 | query | test.ps1:5:72:5:77 | query | provenance |  |
 | test.ps1:8:1:8:6 | query | test.ps1:9:72:9:77 | query | provenance |  |
@@ -24,7 +23,6 @@ nodes
 | test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
 | test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
 | test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |
-| test.ps1:114:76:114:85 | userinput | semmle.label | userinput |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -32,4 +30,3 @@ subpaths
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
-| test.ps1:114:76:114:85 | userinput | test.ps1:1:14:1:45 | Call to read-host | test.ps1:114:76:114:85 | userinput | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -4,6 +4,7 @@ edges
 | test.ps1:1:1:1:10 | userinput | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | provenance |  |
 | test.ps1:1:1:1:10 | userinput | test.ps1:78:13:78:22 | userinput | provenance |  |
+| test.ps1:1:1:1:10 | userinput | test.ps1:114:76:114:85 | userinput | provenance |  |
 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:1:1:1:10 | userinput | provenance | Src:MaD:0  |
 | test.ps1:4:1:4:6 | query | test.ps1:5:72:5:77 | query | provenance |  |
 | test.ps1:8:1:8:6 | query | test.ps1:9:72:9:77 | query | provenance |  |
@@ -23,6 +24,7 @@ nodes
 | test.ps1:72:15:79:1 | ${...} [element Query] | semmle.label | ${...} [element Query] |
 | test.ps1:78:13:78:22 | userinput | semmle.label | userinput |
 | test.ps1:81:15:81:25 | QueryConn2 | semmle.label | QueryConn2 |
+| test.ps1:114:76:114:85 | userinput | semmle.label | userinput |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -30,3 +32,4 @@ subpaths
 | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:17:24:17:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
+| test.ps1:114:76:114:85 | userinput | test.ps1:1:14:1:45 | Call to read-host | test.ps1:114:76:114:85 | userinput | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -110,3 +110,5 @@ TakesTypedParameters $userinput $userinput $userinput $userinput $userinput $use
 
 $query = "SELECT * FROM MyTable WHERE MyColumn = '$userinput'"
 Invoke-Sqlcmd -unknown $userinput -ServerInstance "MyServer" -Database "MyDatabase" -q "SELECT * FROM MyTable" # GOOD
+
+Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -InputFile $userinput # GOOD [FALSE POSITIVE] # this is not really what this query is about.

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -111,4 +111,4 @@ TakesTypedParameters $userinput $userinput $userinput $userinput $userinput $use
 $query = "SELECT * FROM MyTable WHERE MyColumn = '$userinput'"
 Invoke-Sqlcmd -unknown $userinput -ServerInstance "MyServer" -Database "MyDatabase" -q "SELECT * FROM MyTable" # GOOD
 
-Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -InputFile $userinput # GOOD [FALSE POSITIVE] # this is not really what this query is about.
+Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -InputFile $userinput # GOOD # this is not really what this query is about.


### PR DESCRIPTION
The results I've seen in the wild on those sinks are less convincing. And we have plenty of results even without these sinks. So let's just get rid of them for now.

What do you say, @chanel-y?