### PR TITLE
PS: Add GUID as simple sanitizers

### DIFF
--- a/powershell/ql/lib/semmle/code/powershell/security/Sanitizers.qll
+++ b/powershell/ql/lib/semmle/code/powershell/security/Sanitizers.qll
@@ -4,11 +4,11 @@ private import semmle.code.powershell.dataflow.DataFlow
 /**
  * A dataflow node that is guarenteed to have a "simple" type.
  *
- * Simple types include integers, floats, characters, booleans, and `datetime`.
+ * Simple types include integers, floats, characters, booleans, `datetime`, and `guid`.
  */
 class SimpleTypeSanitizer extends DataFlow::Node {
   SimpleTypeSanitizer() {
     this.asParameter().getStaticType() =
-      ["int32", "int64", "single", "double", "decimal", "char", "boolean", "datetime"]
+      ["int32", "int64", "single", "double", "decimal", "char", "boolean", "datetime", "guid"]
   }
 }

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -19,12 +19,20 @@ edges
 | test.ps1:78:49:78:58 | userinput | test.ps1:78:13:78:59 | SELECT * FROM Customers WHERE id = $userinput | provenance | Config |
 | test.ps1:78:49:78:58 | userinput | test.ps1:111:51:111:60 | userinput | provenance |  |
 | test.ps1:111:51:111:60 | userinput | test.ps1:128:28:128:37 | userinput | provenance |  |
+| test.ps1:111:51:111:60 | userinput | test.ps1:150:10:150:19 | userinput | provenance |  |
 | test.ps1:121:9:121:56 | unvalidated | test.ps1:125:130:125:141 | unvalidated | provenance |  |
 | test.ps1:125:128:125:142 | $(...) | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | provenance |  |
 | test.ps1:125:128:125:142 | $(...) | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | provenance | Config |
 | test.ps1:125:130:125:141 | unvalidated | test.ps1:125:128:125:142 | $(...) | provenance |  |
 | test.ps1:125:130:125:141 | unvalidated | test.ps1:125:128:125:142 | $(...) | provenance | Config |
 | test.ps1:128:28:128:37 | userinput | test.ps1:121:9:121:56 | unvalidated | provenance |  |
+| test.ps1:144:11:144:50 | r | test.ps1:146:55:146:56 | r | provenance |  |
+| test.ps1:146:5:146:10 | query | test.ps1:147:72:147:77 | query | provenance |  |
+| test.ps1:146:5:146:10 | query | test.ps1:147:72:147:77 | query | provenance |  |
+| test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | test.ps1:146:5:146:10 | query | provenance |  |
+| test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | test.ps1:146:5:146:10 | query | provenance |  |
+| test.ps1:146:55:146:56 | r | test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | provenance | Config |
+| test.ps1:150:10:150:19 | userinput | test.ps1:144:11:144:50 | r | provenance |  |
 nodes
 | test.ps1:1:1:1:10 | userinput | semmle.label | userinput |
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
@@ -52,6 +60,13 @@ nodes
 | test.ps1:125:128:125:142 | $(...) | semmle.label | $(...) |
 | test.ps1:125:130:125:141 | unvalidated | semmle.label | unvalidated |
 | test.ps1:128:28:128:37 | userinput | semmle.label | userinput |
+| test.ps1:144:11:144:50 | r | semmle.label | r |
+| test.ps1:146:5:146:10 | query | semmle.label | query |
+| test.ps1:146:5:146:10 | query | semmle.label | query |
+| test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$r' |
+| test.ps1:146:55:146:56 | r | semmle.label | r |
+| test.ps1:147:72:147:77 | query | semmle.label | query |
+| test.ps1:150:10:150:19 | userinput | semmle.label | userinput |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -60,3 +75,4 @@ subpaths
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | test.ps1:1:14:1:45 | Call to read-host | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
+| test.ps1:147:72:147:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:147:72:147:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |

--- a/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/powershell/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -19,20 +19,12 @@ edges
 | test.ps1:78:49:78:58 | userinput | test.ps1:78:13:78:59 | SELECT * FROM Customers WHERE id = $userinput | provenance | Config |
 | test.ps1:78:49:78:58 | userinput | test.ps1:111:51:111:60 | userinput | provenance |  |
 | test.ps1:111:51:111:60 | userinput | test.ps1:128:28:128:37 | userinput | provenance |  |
-| test.ps1:111:51:111:60 | userinput | test.ps1:150:10:150:19 | userinput | provenance |  |
 | test.ps1:121:9:121:56 | unvalidated | test.ps1:125:130:125:141 | unvalidated | provenance |  |
 | test.ps1:125:128:125:142 | $(...) | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | provenance |  |
 | test.ps1:125:128:125:142 | $(...) | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | provenance | Config |
 | test.ps1:125:130:125:141 | unvalidated | test.ps1:125:128:125:142 | $(...) | provenance |  |
 | test.ps1:125:130:125:141 | unvalidated | test.ps1:125:128:125:142 | $(...) | provenance | Config |
 | test.ps1:128:28:128:37 | userinput | test.ps1:121:9:121:56 | unvalidated | provenance |  |
-| test.ps1:144:11:144:50 | r | test.ps1:146:55:146:56 | r | provenance |  |
-| test.ps1:146:5:146:10 | query | test.ps1:147:72:147:77 | query | provenance |  |
-| test.ps1:146:5:146:10 | query | test.ps1:147:72:147:77 | query | provenance |  |
-| test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | test.ps1:146:5:146:10 | query | provenance |  |
-| test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | test.ps1:146:5:146:10 | query | provenance |  |
-| test.ps1:146:55:146:56 | r | test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | provenance | Config |
-| test.ps1:150:10:150:19 | userinput | test.ps1:144:11:144:50 | r | provenance |  |
 nodes
 | test.ps1:1:1:1:10 | userinput | semmle.label | userinput |
 | test.ps1:1:14:1:45 | Call to read-host | semmle.label | Call to read-host |
@@ -60,13 +52,6 @@ nodes
 | test.ps1:125:128:125:142 | $(...) | semmle.label | $(...) |
 | test.ps1:125:130:125:141 | unvalidated | semmle.label | unvalidated |
 | test.ps1:128:28:128:37 | userinput | semmle.label | userinput |
-| test.ps1:144:11:144:50 | r | semmle.label | r |
-| test.ps1:146:5:146:10 | query | semmle.label | query |
-| test.ps1:146:5:146:10 | query | semmle.label | query |
-| test.ps1:146:14:146:58 | SELECT * FROM MyTable WHERE MyColumn = '$r' | semmle.label | SELECT * FROM MyTable WHERE MyColumn = '$r' |
-| test.ps1:146:55:146:56 | r | semmle.label | r |
-| test.ps1:147:72:147:77 | query | semmle.label | query |
-| test.ps1:150:10:150:19 | userinput | semmle.label | userinput |
 subpaths
 #select
 | test.ps1:5:72:5:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:5:72:5:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
@@ -75,4 +60,3 @@ subpaths
 | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | test.ps1:1:14:1:45 | Call to read-host | test.ps1:28:24:28:76 | SELECT * FROM MyTable WHERE MyColumn = '$userinput' | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:81:15:81:25 | QueryConn2 | test.ps1:1:14:1:45 | Call to read-host | test.ps1:81:15:81:25 | QueryConn2 | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
 | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | test.ps1:1:14:1:45 | Call to read-host | test.ps1:125:92:125:143 | SELECT * FROM Customers where id = $($unvalidated) | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |
-| test.ps1:147:72:147:77 | query | test.ps1:1:14:1:45 | Call to read-host | test.ps1:147:72:147:77 | query | This SQL query depends on a $@. | test.ps1:1:14:1:45 | Call to read-host | read from stdin |

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -139,3 +139,12 @@ $QueryConn3 = @{
 Invoke-Sqlcmd @QueryConn3 # GOOD
 
 &sqlcmd -e -S $userinput -U "Login" -P "MyPassword" -d "MyDBName" -i "input_file.sql" # GOOD
+
+function WithGuid {
+    PARAM([Parameter(Mandatory = $true)] [guid] $r)
+
+    $query = "SELECT * FROM MyTable WHERE MyColumn = '$r'"
+    Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -q $query # GOOD [FALSE POSITIVE]
+}
+
+WithGuid $userinput

--- a/powershell/ql/test/query-tests/security/cwe-089/test.ps1
+++ b/powershell/ql/test/query-tests/security/cwe-089/test.ps1
@@ -144,7 +144,7 @@ function WithGuid {
     PARAM([Parameter(Mandatory = $true)] [guid] $r)
 
     $query = "SELECT * FROM MyTable WHERE MyColumn = '$r'"
-    Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -q $query # GOOD [FALSE POSITIVE]
+    Invoke-Sqlcmd -ServerInstance "MyServer" -Database "MyDatabase" -q $query # GOOD
 }
 
 WithGuid $userinput


### PR DESCRIPTION
This PR adds the [GUID](https://learn.microsoft.com/en-us/dotnet/api/system.guid?view=net-10.0) type to the list of "simple types" so that they are automatically added as barriers when one uses the `SimpleTypeSanitizer`.

The motivation for this was a FP reported internally at Micosoft on the SQL injection query for PowerShell, and luckily this query already makes use of this sanitizer