### PR TITLE
Rename ConditionKind to BinaryConditionKind to resolve name conflict with ConditionKind definition which was added in upstream base QL.

### DIFF
--- a/binary/ql/lib/semmle/code/binary/ast/ir/IR.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/IR.qll
@@ -348,7 +348,7 @@ private module FinalInstruction {
   class FunEntryInstruction extends Instruction instanceof Instruction::FunEntryInstruction { }
 
   class CJumpInstruction extends Instruction instanceof Instruction::CJumpInstruction {
-    ConditionKind getKind() { result = super.getKind() }
+    BinaryConditionKind getKind() { result = super.getKind() }
 
     ConditionOperand getConditionOperand() { result = super.getConditionOperand() }
 

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction0/Instruction.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction0/Instruction.qll
@@ -112,9 +112,9 @@ class ConstInstruction extends Instruction {
 class CJumpInstruction extends Instruction {
   override Opcode::CJump opcode;
 
-  Opcode::ConditionKind getKind() { te.hasJumpCondition(tag, result) }
+  Opcode::BinaryConditionKind getKind() { te.hasJumpCondition(tag, result) }
 
-  override string getImmediateValue() { result = Opcode::stringOfConditionKind(this.getKind()) }
+  override string getImmediateValue() { result = Opcode::stringOfBinaryConditionKind(this.getKind()) }
 
   ConditionOperand getConditionOperand() { result = this.getAnOperand() }
 

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction0/TranslatedElement.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction0/TranslatedElement.qll
@@ -218,7 +218,7 @@ abstract class TranslatedElement extends TTranslatedElement {
    * Holds if this translated element generates a `CJump` instruction when given the tag `tag`, and
    * the condition kind of the jump is `kind`.
    */
-  predicate hasJumpCondition(InstructionTag tag, Opcode::ConditionKind kind) { none() }
+  predicate hasJumpCondition(InstructionTag tag, Opcode::BinaryConditionKind kind) { none() }
 
   /**
    * Holds if this translated element generates a local variable with the given tag.

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction0/TranslatedInstruction.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction0/TranslatedInstruction.qll
@@ -783,7 +783,7 @@ class TranslatedX86ConditionalJump extends TranslatedX86Instruction, TTranslated
     v.isNone() // A jump has no result
   }
 
-  override predicate hasJumpCondition(InstructionTag tag, Opcode::ConditionKind kind) {
+  override predicate hasJumpCondition(InstructionTag tag, Opcode::BinaryConditionKind kind) {
     tag = SingleTag() and
     (
       instr instanceof Raw::X86Jb and kind = Opcode::LT()
@@ -1844,7 +1844,7 @@ abstract class TranslatedRelationalInstruction extends TranslatedCilInstruction,
 {
   override Raw::CilRelationalInstruction instr;
 
-  abstract Opcode::ConditionKind getConditionKind();
+  abstract Opcode::BinaryConditionKind getConditionKind();
 
   TranslatedRelationalInstruction() { this = TTranslatedCilRelationalInstruction(instr) }
 
@@ -1872,7 +1872,7 @@ abstract class TranslatedRelationalInstruction extends TranslatedCilInstruction,
     tag = CilRelVarTag()
   }
 
-  final override predicate hasJumpCondition(InstructionTag tag, Opcode::ConditionKind kind) {
+  final override predicate hasJumpCondition(InstructionTag tag, Opcode::BinaryConditionKind kind) {
     tag = CilRelCJumpTag() and
     kind = this.getConditionKind()
   }
@@ -1940,19 +1940,19 @@ abstract class TranslatedRelationalInstruction extends TranslatedCilInstruction,
 class TranslatedCilClt extends TranslatedRelationalInstruction {
   override Raw::CilClt instr;
 
-  override Opcode::ConditionKind getConditionKind() { result = Opcode::LT() }
+  override Opcode::BinaryConditionKind getConditionKind() { result = Opcode::LT() }
 }
 
 class TranslatedCilCgt extends TranslatedRelationalInstruction {
   override Raw::CilCgt instr;
 
-  override Opcode::ConditionKind getConditionKind() { result = Opcode::GT() }
+  override Opcode::BinaryConditionKind getConditionKind() { result = Opcode::GT() }
 }
 
 class TranslatedCilCeq extends TranslatedRelationalInstruction {
   override Raw::CilCeq instr;
 
-  override Opcode::ConditionKind getConditionKind() { result = Opcode::EQ() }
+  override Opcode::BinaryConditionKind getConditionKind() { result = Opcode::EQ() }
 }
 
 /**
@@ -2004,7 +2004,7 @@ abstract class TranslatedCilBooleanBranchInstruction extends TranslatedCilInstru
     tag = CilBoolBranchSubVarTag()
   }
 
-  override predicate hasJumpCondition(InstructionTag tag, Opcode::ConditionKind kind) {
+  override predicate hasJumpCondition(InstructionTag tag, Opcode::BinaryConditionKind kind) {
     tag = CilBoolBranchCJumpTag() and
     kind = Opcode::EQ()
   }

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction1/Instruction1.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction1/Instruction1.qll
@@ -369,7 +369,7 @@ module InstructionInput implements Transform<Instruction0>::TransformInputSig {
 
     abstract Instruction0::Function getEnclosingFunction();
 
-    predicate hasJumpCondition(InstructionTag tag, ConditionKind kind) { none() }
+    predicate hasJumpCondition(InstructionTag tag, BinaryConditionKind kind) { none() }
 
     predicate hasTempVariable(TempVariableTag tag) { none() }
 

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction2/Instruction2.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/Instruction2/Instruction2.qll
@@ -208,7 +208,7 @@ private module InstructionInput implements Transform<Instruction1>::TransformInp
 
   private newtype TInstructionTag =
     ZeroTag() or
-    CmpDefTag(ConditionKind k) or
+    CmpDefTag(BinaryConditionKind k) or
     InitializeParameterTag(Instruction1::Variable v) { isReadBeforeInitialization(v, _) }
 
   class LocalVariableTag extends Void {
@@ -228,9 +228,9 @@ private module InstructionInput implements Transform<Instruction1>::TransformInp
       this = ZeroTag() and
       result = "ZeroTag"
       or
-      exists(ConditionKind k |
+      exists(BinaryConditionKind k |
         this = CmpDefTag(k) and
-        result = "CmpDefTag(" + stringOfConditionKind(k) + ")"
+        result = "CmpDefTag(" + stringOfBinaryConditionKind(k) + ")"
       )
       or
       exists(Instruction1::Variable v |
@@ -367,7 +367,7 @@ private module InstructionInput implements Transform<Instruction1>::TransformInp
    * There is only a result if the condition part of `cmp` may be undefined.
    */
   private predicate controlFlowsToCmp(
-    Instruction1::Instruction i, Instruction1::CJumpInstruction cjump, ConditionKind kind
+    Instruction1::Instruction i, Instruction1::CJumpInstruction cjump, BinaryConditionKind kind
   ) {
     // There is control-flow from i to cjump without a write to the
     // variable that is used as a condition to cjump
@@ -512,7 +512,7 @@ private module InstructionInput implements Transform<Instruction1>::TransformInp
 
   private newtype TTranslatedElement =
     TTranslatedComparisonInstruction(
-      Instruction1::Instruction i, Instruction1::CJumpInstruction cjump, ConditionKind kind
+      Instruction1::Instruction i, Instruction1::CJumpInstruction cjump, BinaryConditionKind kind
     ) {
       controlFlowsToCmp(i, cjump, kind)
     } or
@@ -539,7 +539,7 @@ private module InstructionInput implements Transform<Instruction1>::TransformInp
 
     int getConstantValue(InstructionTag tag) { none() }
 
-    predicate hasJumpCondition(InstructionTag tag, ConditionKind kind) { none() }
+    predicate hasJumpCondition(InstructionTag tag, BinaryConditionKind kind) { none() }
 
     predicate hasTempVariable(TempVariableTag tag) { none() }
 
@@ -571,7 +571,7 @@ private module InstructionInput implements Transform<Instruction1>::TransformInp
   }
 
   private class TranslatedComparisonInstruction extends TranslatedInstruction {
-    ConditionKind kind;
+    BinaryConditionKind kind;
     Instruction1::CJumpInstruction cjump;
 
     TranslatedComparisonInstruction() {
@@ -639,7 +639,7 @@ private module InstructionInput implements Transform<Instruction1>::TransformInp
       result = 0
     }
 
-    override predicate hasJumpCondition(InstructionTag tag, ConditionKind k) {
+    override predicate hasJumpCondition(InstructionTag tag, BinaryConditionKind k) {
       kind = k and
       tag = CmpDefTag(kind)
     }

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/InstructionSig.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/InstructionSig.qll
@@ -225,7 +225,7 @@ signature module InstructionSig {
   class FunEntryInstruction extends Instruction;
 
   class CJumpInstruction extends Instruction {
-    ConditionKind getKind();
+    BinaryConditionKind getKind();
 
     ConditionOperand getConditionOperand();
 

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/Opcode.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/Opcode.qll
@@ -149,7 +149,7 @@ class FieldAddress extends Opcode, TFieldAddress {
   override string toString() { result = "FieldAddress" }
 }
 
-newtype ConditionKind =
+newtype BinaryConditionKind =
   EQ() or
   NE() or
   LT() or
@@ -157,7 +157,7 @@ newtype ConditionKind =
   GT() or
   GE()
 
-string stringOfConditionKind(ConditionKind cond) {
+string stringOfBinaryConditionKind(BinaryConditionKind cond) {
   cond = EQ() and
   result = "EQ"
   or

--- a/binary/ql/lib/semmle/code/binary/ast/ir/internal/TransformInstruction/TransformInstruction.qll
+++ b/binary/ql/lib/semmle/code/binary/ast/ir/internal/TransformInstruction/TransformInstruction.qll
@@ -98,7 +98,7 @@ module Transform<InstructionSig Input> {
 
       Input::Function getStaticTarget(InstructionTag tag);
 
-      predicate hasJumpCondition(InstructionTag tag, Opcode::ConditionKind kind);
+      predicate hasJumpCondition(InstructionTag tag, Opcode::BinaryConditionKind kind);
 
       string toString();
 
@@ -583,7 +583,7 @@ module Transform<InstructionSig Input> {
     class CJumpInstruction extends Instruction {
       CJumpInstruction() { this.getOpcode() instanceof Opcode::CJump }
 
-      Opcode::ConditionKind getKind() {
+      Opcode::BinaryConditionKind getKind() {
         exists(Input::CJumpInstruction cjump |
           this = TOldInstruction(cjump) and
           result = cjump.getKind()
@@ -595,7 +595,7 @@ module Transform<InstructionSig Input> {
         )
       }
 
-      override string getImmediateValue() { result = Opcode::stringOfConditionKind(this.getKind()) }
+      override string getImmediateValue() { result = Opcode::stringOfBinaryConditionKind(this.getKind()) }
 
       ConditionOperand getConditionOperand() { result = this.getAnOperand() }
 


### PR DESCRIPTION
Changes introduced in this (https://github.com/microsoft/codeql/commit/723a896b992291808daffa355f2a2cab75ab00a5) commit cause a name collision with the ConditionKind on the binary pack. This just renames the types defined in binary pack to prepend `Binary` for disambiguation.